### PR TITLE
Update to current standard DCO 1.1

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -20,7 +20,7 @@ Developer Certificate of Origin:
 --------------------------------
 
 To improve tracking of contributions to this project we will use a
-process modeled on the modified DCO 1.1 and use a "sign-off" procedure
+process modeled on the DCO 1.1 and use a "sign-off" procedure
 on patches that are being emailed around or contributed in any other
 way.
 
@@ -29,31 +29,41 @@ patch, which certifies that you wrote it or otherwise have the right
 to pass it on as an open-source patch.  The rules are pretty simple:
 if you can certify the below:
 
-By making a contribution to this project, I certify that:
+  Developer Certificate of Origin
+  Version 1.1
 
-(a) The contribution was created in whole or in part by me and I have
-    the right to submit it under the open source license indicated in
-    the file; or
+  Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+  660 York Street, Suite 102,
+  San Francisco, CA 94110 USA
 
-(b) The contribution is based upon previous work that, to the best of
-    my knowledge, is covered under an appropriate open source License
-    and I have the right under that license to submit that work with
-    modifications, whether created in whole or in part by me, under
-    the same open source license (unless I am permitted to submit
-    under a different license), as indicated in the file; or
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
 
-(c) The contribution was provided directly to me by some other person
-    who certified (a), (b) or (c) and I have not modified it.
+  Developer's Certificate of Origin 1.1
 
-(d) The contribution is made free of any other party's intellectual
-    property claims or rights.
+  By making a contribution to this project, I certify that:
 
-(e) I understand and agree that this project and the contribution are
-    public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
+  (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
 
+  (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+  (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+  (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
 
 then you just add a line saying
 


### PR DESCRIPTION
The previous version was an IBM-modified one from LXC. Instead let's use
the standard DCO 1.1 as it currently is on developercertificate.org.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
