### PR TITLE
idmap: don't always print out all idmap entries

### DIFF
--- a/lxd/idmap.go
+++ b/lxd/idmap.go
@@ -40,7 +40,6 @@ func checkmap(fname string, username string) (uint, uint, error) {
 	idrange = 0
 	for scanner.Scan() {
 		s := strings.Split(scanner.Text(), ":")
-		fmt.Println(s)
 		if len(s) < 3 {
 			return 0, 0, fmt.Errorf("unexpected values in %q: %q", fname, s)
 		}


### PR DESCRIPTION
It was a debug line which should be removed.

Signed-off-by: Serge Hallyn serge.hallyn@ubuntu.com
