### PR TITLE
Use ~/.config/lxc as the config directory everywhere

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,12 +148,8 @@ func ParseError(r *Response) error {
 }
 
 func readMyCert() (string, string, error) {
-	homedir := os.Getenv("HOME")
-	if homedir == "" {
-		return "", "", fmt.Errorf("Failed to find homedir")
-	}
-	certf := fmt.Sprintf("%s/.config/lxd/%s", homedir, "cert.pem")
-	keyf := fmt.Sprintf("%s/.config/lxd/%s", homedir, "key.pem")
+	certf := configPath("cert.pem")
+	keyf := configPath("key.pem")
 
 	err := FindOrGenCert(certf, keyf)
 

--- a/config.go
+++ b/config.go
@@ -36,9 +36,13 @@ type RemoteConfig struct {
 	Addr string `yaml:"addr"`
 }
 
+func configPath(file string) string {
+	return os.ExpandEnv(fmt.Sprintf("$HOME/.config/lxc/%s", file))
+}
+
 func renderConfigPath(path string) string {
 	if path == "" {
-		path = "$HOME/.lxd/config.yaml"
+		path = configPath("config.yml")
 	}
 
 	return os.ExpandEnv(path)


### PR DESCRIPTION
Closes #74

Signed-off-by: Tycho Andersen tycho.andersen@canonical.com
