### PR TITLE
Add get-default to remote's help message

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -21,6 +21,7 @@ lxc remote list                    List all remotes.
 lxc remote rename <old> <new>      Rename remote <old> to <new>.
 lxc remote set-url <name> <url>    Update <name>'s url to <url>.
 lxc remote set-default <name>      Set the default remote.
+lxc remote get-default             Print the default remote.
 `
 
 func (c *remoteCmd) usage() string {


### PR DESCRIPTION
Just a quick thing I noticed while on a call today.

Signed-off-by: Tycho Andersen tycho.andersen@canonical.com
