### PR TITLE
Actually return a 404 for a missing container

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -123,6 +123,11 @@ func containerGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	c, err := lxc.NewContainer(name, d.lxcpath)
 	if err != nil {
+		InternalError(w, err)
+		return
+	}
+
+	if !c.Defined() {
 		NotFound(w)
 		return
 	}
@@ -134,6 +139,11 @@ func containerDelete(d *Daemon, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	c, err := lxc.NewContainer(name, d.lxcpath)
 	if err != nil {
+		InternalError(w, err)
+		return
+	}
+
+	if !c.Defined() {
 		NotFound(w)
 		return
 	}
@@ -147,6 +157,11 @@ func containerStateGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	c, err := lxc.NewContainer(name, d.lxcpath)
 	if err != nil {
+		InternalError(w, err)
+		return
+	}
+
+	if !c.Defined() {
 		NotFound(w)
 		return
 	}
@@ -181,6 +196,11 @@ func containerStatePut(d *Daemon, w http.ResponseWriter, r *http.Request) {
 
 	c, err := lxc.NewContainer(name, d.lxcpath)
 	if err != nil {
+		InternalError(w, err)
+		return
+	}
+
+	if !c.Defined() {
 		NotFound(w)
 		return
 	}


### PR DESCRIPTION
NewContainer always returns a new container (unless some internal LXC error has
happend), even if it is not defined yet. In some cases, we only want to allow
operations on containers that exist, so we should check and be sure the
container is defined before we try to perform operations on it.

Signed-off-by: Tycho Andersen tycho.andersen@canonical.com
