### PR TITLE
rest-api: Update background operations

### DIFF
--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -45,7 +45,7 @@ For an async operation, the following dict is returned:
         'type': "async",
         'operation': "/1.0/containers/<id>",                    # URL to the background operation
         'resources': {
-            'containers': [["/1.0/containers/my-container"]     # List of affected resources
+            'containers': ["/1.0/containers/my-container"]      # List of affected resources
         },
         'metadata': {}                                          # Metadata relevant to the operation
     }
@@ -487,10 +487,8 @@ Return:
     {
         'created_at': 1415639996,                   # Creation timestamp
         'updated_at': 1415639996,                   # Last update timestamp
-        'status': "running",                        # Status string ("pending", "running", "done", "cancelling", "cancelled")
-        'status_code': 2,                           # Status code
-        'result': "",                               # Result string ("success", "failure")
-        'result_code': 0,                           # Result code
+        'status': "running",                        # Status string ("pending", "running", "succeeded", "failed", "cancelling", "cancelled")
+        'status_code': 1,                           # Status code
         'resources': {
             'containers': ['/1.0/containers/1']     # List of affected resources
         },
@@ -524,7 +522,8 @@ Input (wait for any event):
 Input (wait for the operation to succeed):
 
     {
-        'result_code': 1
+        'status_code': 2,       # Wait for status to be "succeeded"
+        'timeout': 30           # Timeout after 30s if status wasn't reached
     }
 
 ## /1.0/profiles


### PR DESCRIPTION
Return the metadata dict on creation and allow storing multiple related
resources.

Signed-off-by: Stéphane Graber stgraber@ubuntu.com
