### PR TITLE
Enforce every code path returning a response

### DIFF
--- a/lxd/finger.go
+++ b/lxd/finger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/lxc/lxd"
 )
 
-func fingerGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
+func fingerGet(d *Daemon, r *http.Request) Response {
 	remoteAddr := r.RemoteAddr
 	if remoteAddr == "@" {
 		remoteAddr = "unix socket"
@@ -22,7 +22,7 @@ func fingerGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 		resp["auth"] = "untrusted"
 	}
 
-	SyncResponse(true, resp, w)
+	return SyncResponse(true, resp)
 }
 
 var fingerCmd = Command{"finger", true, false, fingerGet, nil, nil, nil}

--- a/lxd/list.go
+++ b/lxd/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lxc/lxd"
 )
 
-func listGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
+func listGet(d *Daemon, r *http.Request) Response {
 	lxd.Debugf("responding to list")
 
 	result := make([]string, 0)
@@ -18,7 +18,7 @@ func listGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 		result = append(result, containers[i].Name())
 	}
 
-	SyncResponse(true, result, w)
+	return SyncResponse(true, result)
 }
 
 var listCmd = Command{"list", false, false, listGet, nil, nil, nil}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -17,11 +17,10 @@ const (
 	SYS_CLASS_NET = "/sys/class/net"
 )
 
-func networksGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
+func networksGet(d *Daemon, r *http.Request) Response {
 	ifs, err := net.Interfaces()
 	if err != nil {
-		InternalError(w, err)
-		return
+		return InternalError(err)
 	}
 
 	result := make([]string, 0)
@@ -29,7 +28,7 @@ func networksGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 		result = append(result, fmt.Sprintf("/%s/networks/%s", lxd.APIVersion, iface.Name))
 	}
 
-	SyncResponse(true, result, w)
+	return SyncResponse(true, result)
 }
 
 var networksCmd = Command{"networks", false, false, networksGet, nil, nil, nil}
@@ -84,13 +83,12 @@ func isOnBridge(c *lxc.Container, bridge string) bool {
 	return false
 }
 
-func networkGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
+func networkGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
-		InternalError(w, err)
-		return
+		return InternalError(err)
 	}
 
 	n := network{}
@@ -104,8 +102,7 @@ func networkGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 		for _, ct := range lxc.ActiveContainerNames(d.lxcpath) {
 			c, err := lxc.NewContainer(ct, d.lxcpath)
 			if err != nil {
-				InternalError(w, err)
-				return
+				return InternalError(err)
 			}
 
 			if isOnBridge(c, n.Name) {
@@ -116,7 +113,7 @@ func networkGet(d *Daemon, w http.ResponseWriter, r *http.Request) {
 		n.Type = "unknown"
 	}
 
-	SyncResponse(true, &n, w)
+	return SyncResponse(true, &n)
 }
 
 var networkCmd = Command{"networks/{name}", false, false, networkGet, nil, nil, nil}


### PR DESCRIPTION
LXD had several code paths which would not return a response (or would return
some bogus response). In addition, the code was often more verbose than it
needed to be, having to pass around the ResponseWriter everywhere that needed
it.

This commit resolves that by introducing our own signature for http handler
types, the Response type. You can still do arbitrary stuff to the
ResponseWriter if you want (see the container file handler code), but this uses
the compiler to enforce that every code path actually returns a response. It is
also significatly less ugly, with no bare returns and not having to pass the
ResponseWriter everywhere.

Closes #101

Signed-off-by: Tycho Andersen tycho.andersen@canonical.com
