### PR TITLE
Updated documentation of /cluster/members/<name> to have correct keys

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -2978,10 +2978,11 @@ Return:
 Return:
 
     {
-        "name": "lxd1",
+        "server_name": "lxd1",
         "url": "https://10.1.1.101:8443",
         "database": true,
-        "state": "Online"
+        "status": "Online",
+        "message":"fully operational"
     }
 
 #### POST


### PR DESCRIPTION
The documentation did no longer reflect the actual structure of the api

Signed-off-by: Felix Engelmann <felix-lxd@nlogn.org>