### PR TITLE
lxd: implement volume import/export for CephFS

### DIFF
--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -63,7 +63,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
 func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
-	return nil, nil, ErrNotImplemented
+	return genericVFSBackupUnpack(d, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
@@ -468,7 +468,7 @@ func (d *cephfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *
 
 // BackupVolume creates an exported version of a volume.
 func (d *cephfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return ErrNotImplemented
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
 // CreateVolumeSnapshot creates a new snapshot.


### PR DESCRIPTION
Following this discussion: https://discuss.linuxcontainers.org/t/lxd-cephfs-volume-export-results-in-error-not-implemented/11906
I have added genericVFSBackupVolume to the `CreateVolumeFromBackup` and `BackupVolume` methods in the CephFS driver.
Tested at home, not sure if I am missing something here but it does seem to work!

Let me know if I need to change or help out with anything.

Signed-off-by: Massim Knaapen <massim@gohike.nl>