### PR TITLE
lxd/main: Add setfattr to dependencies

### DIFF
--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -51,7 +51,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("This must be run as root")
 	}
 
-	neededPrograms := []string{"ip", "rsync", "tar", "unsquashfs", "xz"}
+	neededPrograms := []string{"ip", "rsync", "setfattr", "tar", "unsquashfs", "xz"}
 	for _, p := range neededPrograms {
 		_, err := exec.LookPath(p)
 		if err != nil {


### PR DESCRIPTION
https://discuss.linuxcontainers.org/t/missing-attr-package-when-using-cephfs/11998

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>