### PR TITLE
Makefile: Set GO111MODULE=on for update-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ update-schema:
 .PHONY: update-api
 update-api:
 ifeq "$(LXD_OFFLINE)" ""
-	(cd / ; go get -v -x github.com/go-swagger/go-swagger/cmd/swagger)
+	(cd / ; GO111MODULE=on go get -v -x github.com/go-swagger/go-swagger/cmd/swagger)
 endif
 	swagger generate spec -o doc/rest-api.yaml -w ./lxd -m
 


### PR DESCRIPTION
Forces go mod enabled for compatibility with Go 1.13 when no GOPATH set.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>