### PR TITLE
lxd/network/driver/ovn: Fix comment on getLoadBalancerName

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -728,7 +728,7 @@ func (n *ovn) getIntSwitchInstancePortPrefix() string {
 	return fmt.Sprintf("%s-instance", n.getNetworkPrefix())
 }
 
-// openvswitch returns OVN load balancer name to use for a listen address.
+// getLoadBalancerName returns OVN load balancer name to use for a listen address.
 func (n *ovn) getLoadBalancerName(listenAddress string) openvswitch.OVNLoadBalancer {
 	return openvswitch.OVNLoadBalancer(fmt.Sprintf("%s-lb-%s", n.getNetworkPrefix(), listenAddress))
 }


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>