### PR TITLE
Network: Rework isInUseByDevice to remove unnecessary DB lookups via NICType

### DIFF
--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -145,7 +145,7 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 	}
 
 	for _, profile := range profiles {
-		inUse, err := isInUseByProfile(s, profile, networkProjectName, networkName)
+		inUse, err := usedByProfileDevices(s, profile, networkProjectName, networkName)
 		if err != nil {
 			return nil, err
 		}
@@ -181,9 +181,9 @@ func UsedBy(s *state.State, networkProjectName string, networkName string, first
 	return usedBy, nil
 }
 
-// isInUseByProfile indicates if network is referenced by a profile's NIC devices.
+// usedByProfileDevices indicates if network is referenced by a profile's NIC devices.
 // Checks if the device's parent or network properties match the network name.
-func isInUseByProfile(s *state.State, profile db.Profile, networkProjectName string, networkName string) (bool, error) {
+func usedByProfileDevices(s *state.State, profile db.Profile, networkProjectName string, networkName string) (bool, error) {
 	// Get the translated network project name from the profiles's project.
 	profileNetworkProjectName, _, err := project.NetworkProject(s.Cluster, profile.Project)
 	if err != nil {


### PR DESCRIPTION
There's no need to convert the `network` property of `nic` device to a NIC type for validating whether a NIC uses the specified network.

If it has a non-empty `network` property that matches the `networkName` then it uses the network irrespective of NIC type.
It should be up to the NIC validation itself to prevent a NIC ever becoming associated with a network that it is incompatible with.

Use of the `isInUseByDevice` requires that the network in question has already been checked as possible to be used by the instance based on its project settings.