### PR TITLE
VM: Adds workaround for QEMU 6.x regression in handling memory object host-nodes setting

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -257,8 +257,12 @@ discard-data = "on"
 qom-type = "memory-backend-memfd"
 {{- end }}
 size = "{{$memory}}M"
-host-nodes = "{{$element}}"
 policy = "bind"
+{{- if eq $.qemuMemObjectFormat "indexed"}}
+host-nodes.{{$index}} = "{{$element}}"
+{{- else}}
+host-nodes = "{{$element}}"
+{{- end}}
 
 [numa]
 type = "node"


### PR DESCRIPTION
Fixes #9374

Tested on:

- Ubuntu Focal without snap on QEMU 4.2.1.
- Ubuntu Hirsute without snap on QEMU 5.2.0.
- Ubuntu Focal with snap on QEMU 6.1.0.

Using:

```
lxc launch images:ubuntu/20.04/cloud v1 -c limits.cpu=0-1 --vm
```

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

With thanks to @bonzini for the suggested short term workaround before we migrate this section to QMP.