### PR TITLE
Networks: Fixes getStoragePool to support NULL description fields

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -545,7 +545,7 @@ func (c *Cluster) getPartialNetworkByProjectAndName(projectName string, networkN
 
 	var q strings.Builder
 
-	q.WriteString(`SELECT n.id, n.name, n.description, n.state, n.type
+	q.WriteString(`SELECT n.id, n.name, IFNULL(n.description, "") as description, n.state, n.type
 		FROM networks AS n
 		WHERE n.project_id = (SELECT id FROM projects WHERE name = ? LIMIT 1)
 		AND n.name=?


### PR DESCRIPTION
There are historically created networks that still have NULL description fields.

Fixes #9385

Regression introduced by https://github.com/lxc/lxd/pull/9370 as newly created networks have an empty string for the default `description`.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>