### PR TITLE
Networks: Fixes getStoragePool to support NULL description fields (stable-4.0)

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -473,7 +473,7 @@ func (c *Cluster) getPartialNetworkByName(networkName string, stateFilter Networ
 
 	var q strings.Builder
 
-	q.WriteString(`SELECT n.id, n.name, n.description, n.state
+	q.WriteString(`SELECT n.id, n.name, IFNULL(n.description, "") as description, n.state
 		FROM networks AS n
 		WHERE n.name=?
 	`)


### PR DESCRIPTION
There are historically created networks that still have NULL description fields.

Regression introduced in #9370

Fixes #9385

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>