### PR TITLE
DB: Adds 10s timeout to Transaction

### DIFF
--- a/lxd/db/query/transaction.go
+++ b/lxd/db/query/transaction.go
@@ -3,14 +3,19 @@ package query
 import (
 	"database/sql"
 	"strings"
+	"time"
 
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // Transaction executes the given function within a database transaction.
 func Transaction(db *sql.DB, f func(*sql.Tx) error) error {
-	tx, err := db.Begin()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		// If there is a leftover transaction let's try to rollback,
 		// we'll then retry again.


### PR DESCRIPTION
This ensures that queries don't block forever when using a stale connection to a remote dqlite DB.

Fixes #9400

The issue that @masnax reported in #9400 was caused by a stale TLS connection to the leader which was caused when the leader was abruptly terminated on a "real" remote network (i.e not local).

This cause the query: https://github.com/lxc/lxd/blob/e86e1f8f7837ada83402bcc891ace8f5f8cfcd18/lxd/cluster/events.go#L55 to block until the default `net.ipv4.tcp_retries2` had expired (setting it lower also solved the problem but required per-system modification).

This appears to have caused a lock to be held open on the database preventing cluster fail over.

By adding a 10s max query time, this allowed the query to timeout and allow cluster operation to resume.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>