### PR TITLE
seccomp: verify retrieved fds when

### DIFF
--- a/lxd/include/process_utils.h
+++ b/lxd/include/process_utils.h
@@ -28,6 +28,11 @@ static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
 	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
 }
 
+static inline bool process_still_alive(int pidfd)
+{
+	return pidfd_send_signal(pidfd, 0, NULL, 0) == 0;
+}
+
 static inline int wait_for_pid(pid_t pid)
 {
 	int status, ret;

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -208,4 +208,39 @@
 	#endif
 #endif
 
+#ifndef __NR_kcmp
+	#if defined __i386__
+		#define __NR_kcmp 349
+	#elif defined __x86_64__
+		#define __NR_kcmp 312
+	#elif defined __arm__
+		#define __NR_kcmp 378
+	#elif defined __aarch64__
+		#define __NR_kcmp 378
+	#elif defined __s390__
+		#define __NR_kcmp 343
+	#elif defined __powerpc__
+		#define __NR_kcmp 354
+	#elif defined __riscv
+		#define __NR_kcmp 272
+	#elif defined __sparc__
+		#define __NR_kcmp 341
+	#elif defined __ia64__
+		#define __NR_kcmp (321 + 1024)
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_kcmp (347 + 4000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_kcmp (311 + 6000)
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_kcmp (306 + 5000)
+		#endif
+	#else
+		#define -1
+		#warning "__NR_kcmp not defined for your architecture"
+	#endif
+#endif
+
 #endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_wrappers.h
+++ b/lxd/include/syscall_wrappers.h
@@ -6,6 +6,7 @@
 #endif
 #include <asm/unistd.h>
 #include <errno.h>
+#include <linux/kcmp.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -143,6 +144,17 @@ static inline int core_scheduling_cookie_share_to(pid_t pid)
 {
 	return prctl(PR_SCHED_CORE, PR_SCHED_CORE_SHARE_TO, pid,
 		     PR_SCHED_CORE_SCOPE_THREAD, 0);
+}
+
+static int kcmp(pid_t pid1, pid_t pid2, int type, unsigned long idx1,
+		unsigned long idx2)
+{
+	return syscall(__NR_kcmp, pid1, pid2, type, idx1, idx2);
+}
+
+static inline bool filetable_shared(pid_t pid1, pid_t pid2)
+{
+	return kcmp(pid1, pid2, KCMP_FILES, -EBADF, -EBADF) == 0;
 }
 
 #endif /* __LXD_SYSCALL_WRAPPER_H */


### PR DESCRIPTION
Pidfds currently can only be used with thread-group leaders.  When we
get a request from a non-threadgroup leader to perform a bpf syscall we
parse out the threadgroup leader's pid and allocate a pidfd based on the
threadgroup leader's pid. We then proceed to retrieve file descriptors
based on the threadgroup leader's pidfd. This assumes that the
threadgroup leader and the target thread share the same file descriptor
table but that assumption isn't safe because the target thread could
have called unshare(CLONE_FILES) at some point, closed the bpf fds and
opened new ones. So we need to make sure that the retrieved fds that we
now hold refer to the same open file as the target thread. To achieve
this we use kcmp(). If kcmp() tells us that the file descriptor table is
still shared after we retrieved the fds we're good. After this we also
need to make sure that the process the pidfd refers to is still alive to
make sure we're talking about the fds of the same threadgroup.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>