### PR TITLE
lxd/instance/qemu: Fix host-nodes on multi-node

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -259,7 +259,7 @@ qom-type = "memory-backend-memfd"
 size = "{{$memory}}M"
 policy = "bind"
 {{- if eq $.qemuMemObjectFormat "indexed"}}
-host-nodes.{{$index}} = "{{$element}}"
+host-nodes.0 = "{{$element}}"
 {{- else}}
 host-nodes = "{{$element}}"
 {{- end}}


### PR DESCRIPTION
Each of the NUMA nodes only maps to a single node on the host, so the
array should always use the 0 index.

This fixes failure to start on instances spanning two NUMA domains.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>