### PR TITLE
doc: add a Discourse link about simple streams

### DIFF
--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -1,3 +1,7 @@
+---
+discourse: 9310
+---
+
 # Image handling
 ## Introduction
 LXD uses an image based workflow. It comes with a built-in image store


### PR DESCRIPTION
Add a link to a Discourse post that explains how to upload
images to a simple streams server.

Related to https://github.com/lxc/linuxcontainers.org/issues/592

Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>