### PR TITLE
VM: Fix AppArmor instance_qemu profile

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -74,8 +74,10 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /snap/lxd/*/share/qemu/**                 kr,
 
   # Snap-specific paths
-  /var/snap/lxd/common/ceph/**              r,
-  {{ .rootPath }}/etc/ceph/**               r,
+  /var/snap/lxd/common/ceph/**                         r,
+  {{ .rootPath }}/etc/ceph/**                          r,
+  {{ .rootPath }}/run/systemd/resolve/stub-resolv.conf r,
+  {{ .rootPath }}/run/systemd/resolve/resolv.conf      r,
 
   # Snap-specific libraries
   /snap/lxd/*/lib/**.so*            mr,


### PR DESCRIPTION
lxd uses /var/lib/snapd/hostfs/run/systemd/resolve/stub-resolv.conf for launching qemu instances, so this path is added to AppArmor profile to prevent denials

fix #11149

Signed-off-by: Viktor Iakovchuk <viktor@yakovchuk.net>