### PR TITLE
Only add timeout to db query context if deadline is not already set

### DIFF
--- a/lxd/db/query/transaction.go
+++ b/lxd/db/query/transaction.go
@@ -12,8 +12,12 @@ import (
 
 // Transaction executes the given function within a database transaction with a 10s context timeout.
 func Transaction(ctx context.Context, db *sql.DB, f func(context.Context, *sql.Tx) error) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel()
+	_, ok := ctx.Deadline()
+	if !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Second*10)
+		defer cancel()
+	}
 
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
I have changed `query.Transaction` to only set a deadline on the context when one is not already set. 