### PR TITLE
lxd/apparmor/rsync: Fix transferring instances including snaps

### DIFF
--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -20,12 +20,13 @@ var rsyncProfileTpl = template.Must(template.New("rsyncProfile").Parse(`#include
 profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
+  capability chown,
   capability dac_override,
   capability dac_read_search,
-  capability mknod,
-  capability chown,
-  capability fsetid,
   capability fowner,
+  capability fsetid,
+  capability mknod,
+  capability setfcap,
 
   unix (connect, send, receive) type=stream,
 


### PR DESCRIPTION
This was identified through PRs failing on lxd-cloud.