### PR TITLE
Fix lxc-to-lxd

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,6 +136,9 @@ jobs:
           sudo ip link delete docker0
           sudo nft flush ruleset
 
+          sudo systemctl mask lxc.service
+          sudo systemctl mask lxc-net.service
+
           sudo apt-get install --no-install-recommends -y \
             curl \
             dnsutils \
@@ -160,6 +163,7 @@ jobs:
             dnsmasq-base \
             gettext \
             jq \
+            lxc-utils \
             lvm2 \
             nftables \
             quota \

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1578,8 +1578,8 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 
 	// And attach stdin and stdout to it
 	go func() {
-		ws.MirrorRead(context.Background(), conn, args.Terminal)
-		<-ws.MirrorWrite(context.Background(), conn, args.Terminal)
+		_, writeDone := ws.Mirror(context.Background(), conn, args.Terminal)
+		<-writeDone
 		_ = conn.Close()
 	}()
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -2326,8 +2326,8 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 
 	// And attach stdin and stdout to it
 	go func() {
-		ws.MirrorRead(context.Background(), conn, args.Terminal)
-		<-ws.MirrorWrite(context.Background(), conn, args.Terminal)
+		_, writeDone := ws.Mirror(context.Background(), conn, args.Terminal)
+		<-writeDone
 		_ = conn.Close()
 	}()
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -2413,8 +2413,7 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 		}
 
 		// Attach reader/writer.
-		readDone, writeDone := ws.Mirror(context.Background(), conn, rwc)
-		<-readDone
+		_, writeDone := ws.Mirror(context.Background(), conn, rwc)
 		<-writeDone
 		_ = conn.Close()
 

--- a/lxc-to-lxd/transfer.go
+++ b/lxc-to-lxd/transfer.go
@@ -30,6 +30,8 @@ func rsyncSend(conn *websocket.Conn, path string, rsyncArgs string) error {
 	}
 
 	readDone, writeDone := ws.Mirror(context.Background(), conn, dataSocket)
+	<-writeDone
+	_ = dataSocket.Close()
 
 	output, err := io.ReadAll(stderr)
 	if err != nil {
@@ -40,7 +42,6 @@ func rsyncSend(conn *websocket.Conn, path string, rsyncArgs string) error {
 
 	err = cmd.Wait()
 	<-readDone
-	<-writeDone
 
 	if err != nil {
 		return fmt.Errorf("Failed to rsync: %v\n%s", err, output)

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -280,16 +280,18 @@ func (s *consoleWs) doConsole(op *operations.Operation) error {
 	// Mirror the console and websocket.
 	mirrorDoneCh := make(chan struct{})
 	go func() {
-		defer logger.Debug("Finished mirroring websocket to console")
 		s.connsLock.Lock()
 		conn := s.conns[0]
 		s.connsLock.Unlock()
 
-		logger.Debug("Started mirroring websocket")
+		l := logger.AddContext(logger.Ctx{"address": conn.RemoteAddr().String()})
+		defer l.Debug("Finished mirroring websocket to console")
+
+		l.Debug("Started mirroring websocket")
 		readDone, writeDone := ws.Mirror(context.Background(), conn, console)
 
 		<-readDone
-		logger.Debug("Finished mirroring console to websocket")
+		l.Debug("Finished mirroring console to websocket")
 		<-writeDone
 		close(mirrorDoneCh)
 	}()

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -165,13 +165,15 @@ func (s *consoleWs) connectVGA(op *operations.Operation, r *http.Request, w http
 
 		// Mirror the console and websocket.
 		go func() {
-			defer logger.Debug("Finished mirroring websocket to console")
+			l := logger.AddContext(logger.Ctx{"address": conn.RemoteAddr().String()})
 
-			logger.Debug("Started mirroring websocket")
+			defer l.Debug("Finished mirroring websocket to console")
+
+			l.Debug("Started mirroring websocket")
 			readDone, writeDone := ws.Mirror(context.Background(), conn, console)
 
 			<-readDone
-			logger.Debugf("Finished mirroring console to websocket")
+			l.Debug("Finished mirroring console to websocket")
 			<-writeDone
 		}()
 

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -385,9 +385,9 @@ func (d *ceph) MigrationTypes(contentType ContentType, refresh bool, copySnapsho
 	// Do not pass compression argument to rsync if the associated
 	// config key, that is rsync.compression, is set to false.
 	if shared.IsFalse(d.Config()["rsync.compression"]) {
-		rsyncFeatures = []string{"delete", "bidirectional"}
+		rsyncFeatures = []string{"xattrs", "delete", "bidirectional"}
 	} else {
-		rsyncFeatures = []string{"delete", "compress", "bidirectional"}
+		rsyncFeatures = []string{"xattrs", "delete", "compress", "bidirectional"}
 	}
 
 	if refresh {

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -306,7 +306,7 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			wrapper = migration.ProgressTracker(op, "fs_progress", volName)
 		}
 
-		d.Logger().Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path})
+		d.Logger().Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path, "features": volTargetArgs.MigrationType.Features})
 		defer d.Logger().Debug("Receiving filesystem volume stopped", logger.Ctx{"volName": volName, "path": path})
 
 		return rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)

--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -12,65 +12,8 @@ import (
 // Mirror takes a websocket and replicates all read/write to a ReadWriteCloser.
 // Returns channels indicating when reads and writes are finished (respectively).
 func Mirror(ctx context.Context, conn *websocket.Conn, rwc io.ReadWriteCloser) (chan struct{}, chan struct{}) {
-	return MirrorWithHooks(ctx, conn, rwc, nil, nil)
-}
-
-// MirrorWithHooks is identical to Mirror but allows for code to be run at the end of the read or write operations.
-// Returns channels indicating when reads and writes are finished (respectively).
-func MirrorWithHooks(ctx context.Context, conn *websocket.Conn, rwc io.ReadWriteCloser, hookRead func(conn *websocket.Conn), hookWrite func(conn *websocket.Conn)) (chan struct{}, chan struct{}) {
-	logger.Debug("Websocket: Started mirror", logger.Ctx{"address": conn.RemoteAddr().String()})
-
-	chRead := make(chan struct{}, 1)
-	chWrite := make(chan struct{}, 1)
-	chDone := make(chan struct{}, 1)
-
-	connRWC := NewWrapper(conn)
-
-	go func() {
-		_, _ = io.Copy(rwc, connRWC)
-		defer close(chWrite)
-
-		// Call the hook.
-		if hookRead != nil {
-			hookRead(conn)
-		}
-	}()
-
-	go func() {
-		_, _ = io.Copy(connRWC, rwc)
-		defer close(chRead)
-
-		// Call the hook.
-		if hookWrite != nil {
-			hookWrite(conn)
-		}
-
-		// Send write barrier.
-		connRWC.Close()
-	}()
-
-	go func() {
-		<-chRead
-		<-chWrite
-		close(chDone)
-
-		// Send close message.
-		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
-		_ = conn.WriteMessage(websocket.CloseMessage, closeMsg)
-
-		logger.Debug("Websocket: Stopped mirror", logger.Ctx{"address": conn.RemoteAddr().String()})
-	}()
-
-	go func() {
-		// Handle cancelation.
-		select {
-		case <-ctx.Done():
-		case <-chDone:
-		}
-
-		// Close the ReadWriteCloser on termination.
-		rwc.Close()
-	}()
+	chRead := MirrorRead(ctx, conn, rwc)
+	chWrite := MirrorWrite(ctx, conn, rwc)
 
 	return chRead, chWrite
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -309,6 +309,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_devlxd "/dev/lxd"
     run_test test_fuidshift "fuidshift"
     run_test test_migration "migration"
+    run_test test_lxc_to_lxd "LXC to LXD"
     run_test test_fdleak "fd leak"
     run_test test_storage "storage"
     run_test test_storage_volume_snapshots "storage volume snapshots"

--- a/test/suites/lxc-to-lxd.sh
+++ b/test/suites/lxc-to-lxd.sh
@@ -5,8 +5,14 @@ test_lxc_to_lxd() {
 
   mkdir -p "${LXC_DIR}"
 
+  lxc network create lxcbr0
+
   # Create LXC containers
   lxc-create -P "${LXC_DIR}" -n c1 -B dir -t busybox
+  lxc-start -P "${LXC_DIR}" -n c1
+  lxc-attach -P "${LXC_DIR}" -n c1 -- touch /root/foo
+  lxc-stop -P "${LXC_DIR}" -n c1 --kill
+
   lxc-create -P "${LXC_DIR}" -n c2 -B dir -t busybox
   lxc-create -P "${LXC_DIR}" -n c3 -B dir -t busybox
 
@@ -34,6 +40,7 @@ test_lxc_to_lxd() {
 
   # Ensure the converted container is startable
   lxc start c1
+  lxc exec c1 -- stat /root/foo
   lxc delete -f c1
 
   # Convert some LXC containers
@@ -57,4 +64,7 @@ test_lxc_to_lxd() {
   lxc info c1
   lxc info c2
   lxc info c3
+
+  lxc delete -f c1 c2 c3
+  lxc network delete lxcbr0
 }

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -461,7 +461,7 @@ migration() {
   lxc_remote copy l2:c1 l1:
   lxc_remote start l1:c1
   lxc_remote delete l1:c1 -f
-  lxc_remote delete l2:c1
+  lxc_remote delete l2:c1 -f
 
   lxc_remote project switch l1:default
   lxc_remote project delete l1:proj

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -432,6 +432,7 @@ migration() {
   lxc_remote storage volume copy l1:"$remote_pool1"/foo l2:"$remote_pool2"/bar
   lxc_remote storage volume delete l1:"$remote_pool1" foo
   lxc_remote storage volume delete l2:"$remote_pool2" bar
+  lxc_remote storage unset l1:"$remote_pool1" rsync.compression
 
   # Test some migration between projects
   lxc_remote project create l1:proj -c features.images=false -c features.profiles=false


### PR DESCRIPTION
Fix hang in lxc-to-lxd and re-enable the tests.

This currently doesn't support the storage pool having rsync compression disabled, which is why the tests were passing when run individually but failed if run after the migration test.

To solve this issue I've ensure the migration tests return the rsync compression state to default (enabled) so that the lxc_to_lxd tests pass. I will also look into whether we can support rsync compression disabled in lxc-to-lxd.

Related to #11910