### PR TITLE
Cluster: Remove obsolete group delete/create for PUT endpoint

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4005,23 +4005,6 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		groupID, err := dbCluster.GetClusterGroupID(ctx, tx.Tx(), obj.Name)
-		if err != nil {
-			return err
-		}
-
-		err = dbCluster.DeleteNodeClusterGroup(ctx, tx.Tx(), int(groupID))
-		if err != nil {
-			return err
-		}
-
-		for _, node := range obj.Nodes {
-			_, err = dbCluster.CreateNodeClusterGroup(ctx, tx.Tx(), dbCluster.NodeClusterGroup{GroupID: int(groupID), Node: node})
-			if err != nil {
-				return err
-			}
-		}
-
 		members, err := tx.GetClusterGroupNodes(ctx, name)
 		if err != nil {
 			return err

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3390,6 +3390,16 @@ test_clustering_groups() {
   lxc cluster group create cluster:foobar
   [ "$(lxc query cluster:/1.0/cluster/groups/foobar | jq '.members | length')" -eq 0 ]
 
+  # Copy both description and members from default group
+  lxc cluster group show cluster:default | lxc cluster group edit cluster:foobar
+  [ "$(lxc query cluster:/1.0/cluster/groups/foobar | jq '.description == "Default cluster group"')" = "true" ]
+  [ "$(lxc query cluster:/1.0/cluster/groups/foobar | jq '.members | length')" -eq 3 ]
+
+  # Delete all members from new group
+  lxc cluster group remove cluster:node1 foobar
+  lxc cluster group remove cluster:node2 foobar
+  lxc cluster group remove cluster:node3 foobar
+
   # Add second node to new group. Node2 will now belong to both groups.
   lxc cluster group assign cluster:node2 default,foobar
   [ "$(lxc query cluster:/1.0/cluster/members/node2 | jq 'any(.groups[] == "default"; .)')" = "true" ]


### PR DESCRIPTION
The `nodes_cluster_groups` table doesn't have a row with the given group_id if the group itself doesn't have any members. This leads to the error message `NodeClusterGroup not found` when trying to delete all rows affecting the cluster group.

Since the list of active and required members already gets compared and created/removed by another loop, this deletion/creation is effectively not required.

Fixes https://github.com/canonical/lxd/issues/11943