### PR TITLE
Correct `sysinfo` system call header level

### DIFF
--- a/doc/syscall-interception.md
+++ b/doc/syscall-interception.md
@@ -118,7 +118,7 @@ previously allowed by the kernel.
 
 This can be enabled by setting `security.syscalls.intercept.setxattr` to `true`.
 
-## `sysinfo`
+### `sysinfo`
 
 The `sysinfo` system call is used by some distributions instead of `/proc/` entries to report on resource usage.
 


### PR DESCRIPTION
It should be level 3 so correct it as it is.