### PR TITLE
Add instance type to instances of offline cluster members

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -147,6 +147,7 @@ type Instance struct {
 	Name     string
 	Project  string
 	Location string
+	Type     instancetype.Type
 }
 
 // GetInstancesByMemberAddress returns the instances associated to each cluster member address.
@@ -157,7 +158,7 @@ func (c *ClusterTx) GetInstancesByMemberAddress(ctx context.Context, offlineThre
 	var q strings.Builder
 
 	q.WriteString(`SELECT
-		instances.id, instances.name,
+		instances.id, instances.name, instances.type,
 		nodes.id, nodes.name, nodes.address, nodes.heartbeat,
 		projects.name
 	FROM instances
@@ -193,7 +194,7 @@ func (c *ClusterTx) GetInstancesByMemberAddress(ctx context.Context, offlineThre
 		var memberAddress string
 		var memberID int64
 		var memberHeartbeat time.Time
-		err := rows.Scan(&inst.ID, &inst.Name, &memberID, &inst.Location, &memberAddress, &memberHeartbeat, &inst.Project)
+		err := rows.Scan(&inst.ID, &inst.Name, &inst.Type, &memberID, &inst.Location, &memberAddress, &memberHeartbeat, &inst.Project)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -318,6 +318,7 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 				StatusCode: api.Error,
 				Location:   inst.Location,
 				Project:    inst.Project,
+				Type:       inst.Type.String(),
 			},
 		}
 


### PR DESCRIPTION
This fixes #11947 where the instance type of instances of offline cluster members would always be shown as "CONTAINER".
For these instances, the instance type field was an empty string which then was interpreted as "CONTAINER" by the CLI.
