### PR TITLE
Replace links

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -24,8 +24,7 @@ After building your dependencies, you can now add your GitHub fork as a remote:
 
 Then switch to it:
 
-<!-- wokeignore:rule=master -->
-    git checkout myfork/master
+    git checkout myfork/main
 
 ### Building LXD
 

--- a/doc/metadata.yaml
+++ b/doc/metadata.yaml
@@ -1,5 +1,5 @@
 site_title: LXD
-site_logo_url: https://linuxcontainers.org/static/img/containers.png
+site_logo_url: https://documentation.ubuntu.com/lxd/en/latest/_static/tag.png
 navigation:
     - title: Getting started
       location: index.md

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -1,6 +1,6 @@
 ---
 discourse: 12281,11735
-relatedlinks: https://grafana.com/grafana/dashboards/15726
+relatedlinks: https://grafana.com/grafana/dashboards/19131-lxd/
 ---
 
 (metrics)=
@@ -234,7 +234,7 @@ After editing the configuration, restart Prometheus (for example, `snap restart 
 ## Set up a Grafana dashboard
 
 To visualize the metrics data, set up [Grafana](https://grafana.com/).
-LXD provides a [Grafana dashboard](https://grafana.com/grafana/dashboards/15726-lxd/) that is configured to display the LXD metrics scraped by Prometheus.
+LXD provides a [Grafana dashboard](https://grafana.com/grafana/dashboards/19131-lxd/) that is configured to display the LXD metrics scraped by Prometheus.
 
 ```{note}
 The dashboard requires Grafana 8.4 or later.
@@ -245,7 +245,7 @@ See the Grafana documentation for instructions on installing and signing in:
 - [Install Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/)
 - [Sign in to Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/sign-in-to-grafana/)
 
-Complete the following steps to import the [LXD dashboard](https://grafana.com/grafana/dashboards/15726-lxd/):
+Complete the following steps to import the [LXD dashboard](https://grafana.com/grafana/dashboards/19131-lxd/):
 
 1. Configure Prometheus as the data source:
 
@@ -271,7 +271,7 @@ Complete the following steps to import the [LXD dashboard](https://grafana.com/g
 
       ![Import a dashboard in Grafana](images/grafana_dashboard_import.png)
 
-   1. In the {guilabel}`Import via grafana.com` field, enter the dashboard ID `15726`.
+   1. In the {guilabel}`Import via grafana.com` field, enter the dashboard ID `19131`.
 
       ![Enter the LXD dashboard ID](images/grafana_dashboard_id.png)
 

--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -64,7 +64,7 @@
   "description": "Overview of LXD instances",
   "editable": false,
   "fiscalYearStartMonth": 0,
-  "gnetId": 15726,
+  "gnetId": 19131,
   "graphTooltip": 0,
   "id": null,
   "links": [
@@ -74,7 +74,7 @@
       "targetBlank": true,
       "title": "Documentation",
       "type": "link",
-      "url": "https://linuxcontainers.org/lxd/docs/latest/"
+      "url": "https://documentation.ubuntu.com/lxd/en/latest/"
     }
   ],
   "liveNow": false,

--- a/lxd/main_cluster.go
+++ b/lxd/main_cluster.go
@@ -425,7 +425,7 @@ database, so you can possibly inspect it for further recovery.
 You'll be able to permanently delete from the database all information about
 former cluster members by running "lxc cluster remove <member-name> --force".
 
-See https://linuxcontainers.org/lxd/docs/master/clustering#recover-from-quorum-loss for more
+See https://documentation.ubuntu.com/lxd/en/latest/howto/cluster_recover/#recover-from-quorum-loss for more
 info.
 
 Do you want to proceed? (yes/no): `)

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -1,6 +1,6 @@
 // Package migration provides the primitives for migration in LXD.
 //
-// See https://github.com/canonical/lxd/blob/master/specs/migration.md for a complete
+// See https://github.com/canonical/lxd/blob/main/doc/migration.md for a complete
 // description.
 
 package main

--- a/lxd/resources/utils.go
+++ b/lxd/resources/utils.go
@@ -109,7 +109,7 @@ func hasBitField(n []uint32, bit uint) bool {
 }
 
 func udevDecode(s string) (string, error) {
-	// Inverse of https://github.com/systemd/systemd/blob/master/src/basic/device-nodes.c#L22
+	// Inverse of https://github.com/systemd/systemd/blob/main/src/shared/device-nodes.c#L19
 	ret := ""
 	for i := 0; i < len(s); i++ {
 		// udev converts non-devnode supported chars to four byte encode hex strings.

--- a/lxd/util/http_test.go
+++ b/lxd/util/http_test.go
@@ -7,17 +7,17 @@ import (
 func ExampleListenAddresses() {
 	listenAddressConfigs := []string{
 		"",
-		"127.0.0.1:8000",           // Valid IPv4 address with port.
-		"127.0.0.1",                // Valid IPv4 address without port.
-		"[127.0.0.1]",              // Valid wrapped IPv4 address without port.
-		"[::1]:8000",               // Valid IPv6 address with port.
-		"::1:8000",                 // Valid IPv6 address without port (that might look like a port).
-		"::1",                      // Valid IPv6 address without port.
-		"[::1]",                    // Valid wrapped IPv6 address without port.
-		"linuxcontainers.org",      // Valid hostname without port.
-		"linuxcontainers.org:8000", // Valid hostname with port.
-		"foo:8000:9000",            // Invalid host and port combination.
-		":::8000",                  // Invalid host and port combination.
+		"127.0.0.1:8000",   // Valid IPv4 address with port.
+		"127.0.0.1",        // Valid IPv4 address without port.
+		"[127.0.0.1]",      // Valid wrapped IPv4 address without port.
+		"[::1]:8000",       // Valid IPv6 address with port.
+		"::1:8000",         // Valid IPv6 address without port (that might look like a port).
+		"::1",              // Valid IPv6 address without port.
+		"[::1]",            // Valid wrapped IPv6 address without port.
+		"example.com",      // Valid hostname without port.
+		"example.com:8000", // Valid hostname with port.
+		"foo:8000:9000",    // Invalid host and port combination.
+		":::8000",          // Invalid host and port combination.
 	}
 
 	for _, listlistenAddressConfig := range listenAddressConfigs {
@@ -33,8 +33,8 @@ func ExampleListenAddresses() {
 	// "::1:8000": [[::1:8000]:8443] <nil>
 	// "::1": [[::1]:8443] <nil>
 	// "[::1]": [[::1]:8443] <nil>
-	// "linuxcontainers.org": [linuxcontainers.org:8443] <nil>
-	// "linuxcontainers.org:8000": [linuxcontainers.org:8000] <nil>
+	// "example.com": [example.com:8443] <nil>
+	// "example.com:8000": [example.com:8000] <nil>
 	// "foo:8000:9000": [] address foo:8000:9000: too many colons in address
 	// ":::8000": [] address :::8000: too many colons in address
 }

--- a/shared/api/url_test.go
+++ b/shared/api/url_test.go
@@ -11,7 +11,7 @@ func ExampleURL() {
 	fmt.Println(u.Project("project-with-%-in-it"))
 	fmt.Println(u.Target(""))
 	fmt.Println(u.Target("member-with-%-in-it"))
-	fmt.Println(u.Host("linuxcontainers.org"))
+	fmt.Println(u.Host("example.com"))
 	fmt.Println(u.Scheme("https"))
 
 	// Output: /1.0/networks/name-with-%252F-in-it
@@ -19,6 +19,6 @@ func ExampleURL() {
 	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
 	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
 	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
-	// //linuxcontainers.org/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
-	// https://linuxcontainers.org/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// //example.com/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// https://example.com/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
 }

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -341,7 +341,7 @@ func GenerateMemCert(client bool, addHosts bool) ([]byte, []byte, error) {
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			Organization: []string{"linuxcontainers.org"},
+			Organization: []string{"LXD"},
 			CommonName:   fmt.Sprintf("%s@%s", username, hostname),
 		},
 		NotBefore: validFrom,


### PR DESCRIPTION
There still are some occurrences for `git grep linuxcontainers.org  | grep -vF images.linuxcontainers.org` but those will need more work. We might need to extract content from the discourse instance.