### PR TITLE
Storage: Don't delete the target root volume when migrating between ZFS pools

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -885,11 +885,6 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		// refresh.
 		if len(snapshots) == 0 {
 			volTargetArgs.Refresh = false
-
-			err = d.DeleteVolume(vol, op)
-			if err != nil {
-				return fmt.Errorf("Failed deleting volume: %w", err)
-			}
 		}
 
 		var respSnapshots []ZFSDataset


### PR DESCRIPTION
When copying/migrating an instance without snapshots between two ZFS pools, an already existing root volume cannot be deleted on the target before doing the actual migration. This is currently happening if an instance doesn't have any snapshots which doesn't allow for optimized incremental copy.

When the migration fails (due to network outages or other errors on the source), there won't be any volume left on the target side. This is critical if `lxc copy` is used with the `--refresh` flag.

By keeping the volume on the target, `zfs receive` will update/overwrite it anyway.

If another storage backend is chosen at the source end, `rsync` will be used instead and this isn't applicable then.

Fixes https://github.com/canonical/lxd/issues/11822