### PR TITLE
VM: Skip every other vsock syscall error except ENODEV

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7460,11 +7460,14 @@ func (d *qemu) freeVsockID(vsockID uint32) bool {
 			return false
 		}
 
-		if unixErrno == unix.ENODEV {
-			// The syscall to the vsock device returned "no such device".
-			// This means the address (Context ID) is free.
-			return true
+		if unixErrno != unix.ENODEV {
+			// Skip the vsockID if another syscall error was encountered.
+			return false
 		}
+
+		// The syscall to the vsock device returned "no such device".
+		// This means the address (Context ID) is free.
+		return true
 	}
 
 	// Address is already in use.


### PR DESCRIPTION
Handles a panic condition if the connection attempt to the vsock returns syscall errors other than ENODEV. In such situations the socket was never opened up and therefore cannot be closed with `c.Close()`.

This can be observed for exported/imported VMs and does not happen for individually created VMs. 

Since other errors might occur, fixing this should be a good idea in general. Investigation why this is happening especially for imported VMs is part of https://github.com/canonical/lxd/issues/11907:

```
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfe7919]
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: goroutine 38684 [running]:
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/mdlayher/vsock.(*Conn).Close(0x0)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/go/pkg/mod/github.com/mdlayher/vsock@v1.2.1/vsock.go:205 +0x19
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/canonical/lxd/lxd/instance/drivers.(*qemu).freeVsockID(0xc00118e030?, 0x24?)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance/drivers/driver_qemu.go:7475 +0x87
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/canonical/lxd/lxd/instance/drivers.(*qemu).nextVsockID(0xc00087e180)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance/drivers/driver_qemu.go:7514 +0x2cf
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/canonical/lxd/lxd/instance/drivers.(*qemu).start(0xc00087e180, 0x0, 0x0)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance/drivers/driver_qemu.go:1149 +0x7a5
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/canonical/lxd/lxd/instance/drivers.(*qemu).Start(0xc00087e180, 0x10?)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance/drivers/driver_qemu.go:1066 +0x68
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: main.doInstanceStatePut({0x2143820?, 0xc00087e180?}, {{0xc000d83560?, 0xc000e425c0?}, 0xc0019e26f8?, 0x58?, 0x27?})
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance_state.go:244 +0xe3
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: main.instanceStatePut.func1(0xc000445da0?)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/instance_state.go:200 +0x6a
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: github.com/canonical/lxd/lxd/operations.(*Operation).Start.func1(0xc000877c20)
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/operations/operations.go:284 +0x2c
Jul 10 10:31:14 thinkpad lxd.daemon[3689]: created by github.com/canonical/lxd/lxd/operations.(*Operation).Start
Jul 10 10:31:14 thinkpad lxd.daemon[3689]:         /home/julian/dev/lxd/lxd/operations/operations.go:283 +0xf7
Jul 10 10:31:14 thinkpad lxd.daemon[3225]: => LXD failed with return code 2
```