### PR TITLE
lxc/profile: add --refresh flag to lxc profile copy

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -115,7 +115,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -588,7 +588,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -607,17 +607,17 @@ msgstr "- Partition %d"
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -656,17 +656,17 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 #, fuzzy
 msgid "<alias>"
 msgstr "Aliasse:\n"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 #, fuzzy
 msgid "<alias> <target>"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
@@ -821,12 +821,12 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -856,12 +856,12 @@ msgstr "Administrator Passwort für %s: "
 msgid "Admin secret key: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -917,12 +917,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1037,7 +1037,7 @@ msgstr "Ungültige Abbild Eigenschaft: %s\n"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1256,22 +1256,22 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -1281,12 +1281,12 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
@@ -1373,12 +1373,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, fuzzy, c-format
@@ -1448,7 +1448,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1467,7 +1467,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1681,12 +1681,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1810,17 +1810,17 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1876,10 +1876,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2081,7 +2081,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2148,7 +2148,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network zone record configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2543,13 +2543,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2670,7 +2670,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2847,7 +2847,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3094,7 +3094,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3126,7 +3126,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliasse:\n"
@@ -3141,7 +3141,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3359,7 +3359,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3538,7 +3538,7 @@ msgstr "Veröffentliche Abbild"
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3547,12 +3547,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 #, fuzzy
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -3665,7 +3665,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -3736,12 +3736,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3807,14 +3807,14 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3822,8 +3822,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3920,8 +3920,8 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3931,7 +3931,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4046,15 +4046,15 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4406,7 +4406,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 #, fuzzy
 msgid "Pause instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4446,12 +4446,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4489,32 +4489,32 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4534,7 +4534,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4804,7 +4804,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4818,7 +4818,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
@@ -4851,7 +4851,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4865,7 +4865,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove ports from a load balancer"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4874,7 +4874,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4888,7 +4888,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4896,7 +4896,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4914,7 +4914,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4960,12 +4960,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5027,7 +5027,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5264,11 +5264,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Profil %s erstellt\n"
@@ -5459,7 +5459,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network zone record configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5566,7 +5566,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5575,7 +5575,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 #, fuzzy
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5604,7 +5604,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 #, fuzzy
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5683,7 +5683,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5719,7 +5719,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5872,7 +5872,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
@@ -5954,7 +5954,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6002,7 +6002,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -6135,7 +6135,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network zone record configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6176,6 +6176,10 @@ msgstr "Akzeptiere Zertifikat"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6340,10 +6344,10 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
@@ -6537,8 +6541,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6546,7 +6550,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6670,7 +6674,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6679,7 +6683,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6716,7 +6720,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -6824,7 +6828,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -6858,7 +6862,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -7281,8 +7285,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -7314,7 +7318,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -7322,7 +7326,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7338,7 +7342,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7346,7 +7350,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7524,7 +7528,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
@@ -7533,19 +7537,19 @@ msgstr "Fehler: %v\n"
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -7557,7 +7561,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7726,7 +7730,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7749,7 +7753,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -559,11 +559,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "  Χρήση δικτύου:"
@@ -592,12 +592,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -650,11 +650,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -966,22 +966,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -991,12 +991,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1080,12 +1080,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1367,12 +1367,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1465,7 +1465,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1490,17 +1490,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1556,10 +1556,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1750,7 +1750,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1810,7 +1810,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit network zone record configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2185,13 +2185,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2308,7 +2308,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2442,7 +2442,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2480,7 +2480,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2759,7 +2759,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3079,7 +3079,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3125,7 +3125,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3133,12 +3133,12 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3239,7 +3239,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3303,12 +3303,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3375,22 +3375,22 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3480,8 +3480,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3490,7 +3490,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3598,14 +3598,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3953,7 +3953,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3991,12 +3991,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4034,32 +4034,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4076,7 +4076,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4337,7 +4337,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4380,7 +4380,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4393,7 +4393,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4401,7 +4401,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "  Χρήση δικτύου:"
@@ -4414,7 +4414,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4422,7 +4422,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4439,7 +4439,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4481,11 +4481,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4542,7 +4542,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4774,11 +4774,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4868,7 +4868,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "  Χρήση δικτύου:"
@@ -4959,7 +4959,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show network zone record configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5070,7 +5070,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5097,7 +5097,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5171,7 +5171,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5206,7 +5206,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5430,7 +5430,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5477,7 +5477,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5605,7 +5605,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset network zone record configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5643,6 +5643,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5785,10 +5789,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5882,12 +5886,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5948,11 +5952,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5969,7 +5973,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6020,7 +6024,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6036,7 +6040,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6255,8 +6259,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6272,11 +6276,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6284,11 +6288,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6385,7 +6389,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6394,19 +6398,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6418,7 +6422,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6583,7 +6587,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6606,7 +6610,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -120,7 +120,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -475,7 +475,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -578,7 +578,7 @@ msgstr "%s no es un directorio"
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -597,16 +597,16 @@ msgstr "- Partición %d"
 msgid "- Port %d (%s)"
 msgstr "- Puerto %d (%s)"
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -642,16 +642,16 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 #, fuzzy
 msgid "<alias>"
 msgstr "Aliases:"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliases:"
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -831,12 +831,12 @@ msgstr "Contraseña admin para %s: "
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -890,12 +890,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr "Propiedad mala: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
@@ -1212,22 +1212,22 @@ msgstr "Certificado del cliente almacenado en el servidor: "
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -1237,12 +1237,12 @@ msgstr "Perfil %s renombrado a %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
@@ -1328,12 +1328,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1491,7 +1491,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1621,12 +1621,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1656,7 +1656,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr "Perfil %s creado"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1745,17 +1745,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1811,10 +1811,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2005,7 +2005,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgstr "Perfil %s creado"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creando el contenedor"
@@ -2446,13 +2446,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2569,7 +2569,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2706,7 +2706,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3016,7 +3016,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliases:"
@@ -3031,7 +3031,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
@@ -3233,7 +3233,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3357,7 +3357,7 @@ msgstr "Cacheado: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3403,7 +3403,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3411,12 +3411,12 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3517,7 +3517,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3582,12 +3582,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Perfil %s creado"
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3653,14 +3653,14 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -3668,8 +3668,8 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
@@ -3764,8 +3764,8 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3775,7 +3775,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3886,14 +3886,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4239,7 +4239,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4277,12 +4277,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4320,32 +4320,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -4365,7 +4365,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4629,7 +4629,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
@@ -4643,7 +4643,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Perfil %s creado"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4673,7 +4673,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -4707,7 +4707,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4715,7 +4715,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4775,12 +4775,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "Aliases:"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4840,7 +4840,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5072,11 +5072,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5166,7 +5166,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Perfil %s creado"
@@ -5257,7 +5257,7 @@ msgstr "Perfil %s creado"
 msgid "Show network zone record configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
@@ -5368,7 +5368,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5396,7 +5396,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5470,7 +5470,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5505,7 +5505,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5652,7 +5652,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5732,7 +5732,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5781,7 +5781,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5909,7 +5909,7 @@ msgstr "Perfil %s creado"
 msgid "Unset network zone record configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5948,6 +5948,10 @@ msgstr "Acepta certificado"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6092,10 +6096,10 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
@@ -6212,13 +6216,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6294,12 +6298,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6320,7 +6324,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6382,7 +6386,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6402,7 +6406,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6670,8 +6674,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6691,12 +6695,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6706,12 +6710,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6827,7 +6831,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6836,19 +6840,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6860,7 +6864,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7025,7 +7029,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7048,7 +7052,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -113,7 +113,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -586,7 +586,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -605,16 +605,16 @@ msgstr "- Partition %d"
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 "--console ne peut être pas utilisée tant que l'arrêt de l'instance est forcé"
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr "--console ne peut être utilisé avec --all"
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
@@ -647,17 +647,17 @@ msgstr "--refresh ne peut être utilisé qu'avec des instances"
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 #, fuzzy
 msgid "<alias>"
 msgstr "Alias :"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 #, fuzzy
 msgid "<alias> <target>"
 msgstr "Cible invalide %s"
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "<target>"
 msgstr "<cible>"
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Création du conteneur"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Alias :"
@@ -827,12 +827,12 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Création du conteneur"
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -862,12 +862,12 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Admin secret key: %s"
 msgstr "Créé : %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -922,12 +922,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Création du conteneur"
@@ -1041,7 +1041,7 @@ msgstr "Mauvaise propriété : %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1251,22 +1251,22 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, fuzzy, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, fuzzy, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -1276,12 +1276,12 @@ msgstr "Profil %s ajouté à %s"
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
@@ -1376,12 +1376,12 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1543,7 +1543,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1657,7 +1657,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
@@ -1701,12 +1701,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1737,7 +1737,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1807,7 +1807,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1835,17 +1835,17 @@ msgstr "Copie de l'image : %s"
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1901,10 +1901,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2101,7 +2101,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2168,7 +2168,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2538,7 +2538,7 @@ msgstr "Forcer l'allocation d'un pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2576,13 +2576,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2703,7 +2703,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2847,7 +2847,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -2888,7 +2888,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -3134,7 +3134,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias :"
@@ -3181,7 +3181,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3444,7 +3444,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr "Créé : %s"
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3618,7 +3618,7 @@ msgstr "Rendre l'image publique"
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Copie de l'image : %s"
@@ -3627,12 +3627,12 @@ msgstr "Copie de l'image : %s"
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Copie de l'image : %s"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3745,7 +3745,7 @@ msgstr "Nom du réseau"
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3815,12 +3815,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Profils : %s"
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, fuzzy, c-format
 msgid "Member %q already has role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, fuzzy, c-format
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
@@ -3888,14 +3888,14 @@ msgstr "Résumé manquant."
 msgid "Missing certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3903,8 +3903,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4002,8 +4002,8 @@ msgstr "Résumé manquant."
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -4013,7 +4013,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -4131,15 +4131,15 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4504,7 +4504,7 @@ msgstr "Options :"
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 #, fuzzy
 msgid "Pause instances"
 msgstr "Création du conteneur"
@@ -4544,12 +4544,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4588,32 +4588,32 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -4633,7 +4633,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -4905,7 +4905,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4919,7 +4919,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Clé de configuration invalide"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
@@ -4952,7 +4952,7 @@ msgstr "Création du conteneur"
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4966,7 +4966,7 @@ msgstr "Création du conteneur"
 msgid "Remove ports from a load balancer"
 msgstr "Création du conteneur"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
@@ -4975,7 +4975,7 @@ msgstr "Création du conteneur"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4990,7 +4990,7 @@ msgstr "Création du conteneur"
 msgid "Remove trusted client"
 msgstr "Ajouter de nouveaux clients de confiance"
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4998,7 +4998,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -5016,7 +5016,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -5061,12 +5061,12 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "Création du conteneur"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 #, fuzzy
 msgid ""
 "Restart instances\n"
@@ -5145,7 +5145,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5386,12 +5386,12 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5484,7 +5484,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Afficher la configuration étendue"
@@ -5585,7 +5585,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network zone record configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
@@ -5695,7 +5695,7 @@ msgstr "Instantanés :"
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5704,7 +5704,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 #, fuzzy
 msgid "Start instances"
 msgstr "Création du conteneur"
@@ -5734,7 +5734,7 @@ msgstr "à suivi d'état"
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 #, fuzzy
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5813,7 +5813,7 @@ msgstr "Image copiée avec succès !"
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -5851,7 +5851,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -6006,7 +6006,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
@@ -6090,7 +6090,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -6139,7 +6139,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -6273,7 +6273,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network zone record configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6316,6 +6316,10 @@ msgstr "Accepter le certificat"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6477,10 +6481,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
@@ -6692,8 +6696,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6701,7 +6705,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6834,7 +6838,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6846,7 +6850,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6895,7 +6899,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -7027,7 +7031,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -7067,7 +7071,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -7514,8 +7518,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -7547,7 +7551,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -7555,7 +7559,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7571,7 +7575,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7579,7 +7583,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7773,7 +7777,7 @@ msgstr ""
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
@@ -7782,19 +7786,19 @@ msgstr "erreur : %v"
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -7806,7 +7810,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7993,7 +7997,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -8016,7 +8020,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -444,7 +444,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -559,11 +559,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -591,12 +591,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -964,22 +964,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -989,12 +989,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1362,12 +1362,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1481,17 +1481,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1547,10 +1547,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1737,7 +1737,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2167,13 +2167,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2690,7 +2690,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3106,11 +3106,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3266,12 +3266,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3335,21 +3335,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3437,8 +3437,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3554,14 +3554,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3944,12 +3944,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3987,32 +3987,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4290,7 +4290,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4330,7 +4330,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4370,7 +4370,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4429,11 +4429,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4715,11 +4715,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4808,7 +4808,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5000,7 +5000,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5360,7 +5360,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5407,7 +5407,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5563,6 +5563,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5705,10 +5709,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5802,12 +5806,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5868,11 +5872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5889,7 +5893,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5940,7 +5944,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5956,7 +5960,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6175,8 +6179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6192,11 +6196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6204,11 +6208,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6305,7 +6309,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6314,19 +6318,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6338,7 +6342,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6503,7 +6507,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6526,7 +6530,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -124,7 +124,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -477,7 +477,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -580,7 +580,7 @@ msgstr "%s non è una directory"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -599,15 +599,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -641,16 +641,16 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 #, fuzzy
 msgid "<alias>"
 msgstr "Alias:"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -680,7 +680,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
@@ -797,11 +797,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Il nome del container è: %s"
@@ -830,12 +830,12 @@ msgstr "Password amministratore per %s: "
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -889,12 +889,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1207,22 +1207,22 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1232,12 +1232,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1395,7 +1395,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1482,7 +1482,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1615,12 +1615,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1739,17 +1739,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1805,10 +1805,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2001,7 +2001,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2404,7 +2404,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creazione del container in corso"
@@ -2441,13 +2441,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2563,7 +2563,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2698,7 +2698,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
@@ -2737,7 +2737,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2977,7 +2977,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias:"
@@ -3024,7 +3024,7 @@ msgstr "Il nome del container è: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3352,7 +3352,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3398,7 +3398,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3406,12 +3406,12 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Il nome del container è: %s"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3516,7 +3516,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3581,12 +3581,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3651,14 +3651,14 @@ msgstr "Il nome del container è: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
@@ -3666,8 +3666,8 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
@@ -3762,8 +3762,8 @@ msgstr "Il nome del container è: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3773,7 +3773,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3883,14 +3883,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4237,7 +4237,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 #, fuzzy
 msgid "Pause instances"
 msgstr "Creazione del container in corso"
@@ -4276,12 +4276,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4319,32 +4319,32 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4363,7 +4363,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4627,7 +4627,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Il nome del container è: %s"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4672,7 +4672,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Il nome del container è: %s"
@@ -4706,7 +4706,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4714,7 +4714,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4732,7 +4732,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4774,12 +4774,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4839,7 +4839,7 @@ msgstr "Il nome del container è: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5069,11 +5069,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5163,7 +5163,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Il nome del container è: %s"
@@ -5254,7 +5254,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show network zone record configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -5365,7 +5365,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 #, fuzzy
 msgid "Start instances"
 msgstr "Creazione del container in corso"
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5468,7 +5468,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
@@ -5504,7 +5504,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5731,7 +5731,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5779,7 +5779,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5945,6 +5945,10 @@ msgstr "Accetta certificato"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6093,10 +6097,10 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
@@ -6213,13 +6217,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
@@ -6295,12 +6299,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "Creazione del container in corso"
@@ -6321,7 +6325,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "Creazione del container in corso"
@@ -6383,7 +6387,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
@@ -6403,7 +6407,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
@@ -6671,8 +6675,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -6692,12 +6696,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "Creazione del container in corso"
@@ -6707,12 +6711,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
@@ -6828,7 +6832,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6837,19 +6841,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6861,7 +6865,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7026,7 +7030,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7049,7 +7053,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -107,7 +107,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -467,7 +467,7 @@ msgstr ""
 "###\n"
 "### Note that only the configuration can be changed."
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -573,7 +573,7 @@ msgstr "%s はディレクトリではありません"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(none)"
 
@@ -592,15 +592,15 @@ msgstr "- パーティション %d"
 msgid "- Port %d (%s)"
 msgstr "- ポート %d (%s)"
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "インスタンスの強制シャットダウンの際は --console は使えません"
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
@@ -633,15 +633,15 @@ msgstr "--refresh はインスタンスの場合のみ使えます"
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr "<alias>"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr "<alias> <target>"
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
@@ -671,7 +671,7 @@ msgstr ""
 msgid "<target>"
 msgstr "<target>"
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -737,7 +737,7 @@ msgstr "ネットワークゾーンレコードにエントリを追加します
 msgid "Add instance devices"
 msgstr "インスタンスにデバイスを追加します"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
@@ -804,11 +804,11 @@ msgstr "フォワードにポートを追加します"
 msgid "Add ports to a load balancer"
 msgstr "ロードバランサーにポートを追加します"
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr "インスタンスにプロファイルを追加します"
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr "クラスターメンバーにロールを追加します"
 
@@ -836,12 +836,12 @@ msgstr "%s の管理者パスワード（もしくはトークン）:"
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
@@ -895,11 +895,11 @@ msgstr "どちらもみつかりませんでした。raw SPICE ソケットは�
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr "クラスターメンバーにグループの組を割り当てます"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr "インスタンスにプロファイルを割り当てます"
 
@@ -1013,7 +1013,7 @@ msgstr "不正なイメージプロパティ形式: %s"
 msgid "Bond:"
 msgstr "ボンディング:"
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
@@ -1223,22 +1223,22 @@ msgstr "クライアント証明書がサーバに信頼されました:"
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr "クラスターグループ %s が削除されました"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr "クラスターグループ %s は現在 %s に適用されていません"
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
@@ -1248,12 +1248,12 @@ msgstr "クラスタグループ名 %s を %s に変更しました"
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr "クラスターメンバー %s がクラスターグループ %s に追加されました"
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
@@ -1341,12 +1341,12 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -1446,7 +1446,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
@@ -1517,7 +1517,7 @@ msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr "クラスターグループを作成します"
 
@@ -1605,7 +1605,7 @@ msgstr "新たにネットワークゾーンを作成します"
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
@@ -1644,12 +1644,12 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1679,7 +1679,7 @@ msgstr "圧縮アルゴリズムを指定します: backup or none"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
@@ -1739,7 +1739,7 @@ msgstr "ネットワークゾーンを削除します"
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
@@ -1763,17 +1763,17 @@ msgstr "ストレージボリュームを削除します"
 msgid "Delete warning"
 msgstr "警告を削除します"
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1829,10 +1829,10 @@ msgstr "警告を削除します"
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2027,7 +2027,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
@@ -2083,7 +2083,7 @@ msgstr "ネットワークゾーン設定をYAMLで編集します"
 msgid "Edit network zone record configurations as YAML"
 msgstr "ネットワークゾーンレコードをYAMLで編集します"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
@@ -2447,7 +2447,7 @@ msgstr "強制的に擬似端末を割り当てます"
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr "インスタンスを強制停止します"
 
@@ -2498,13 +2498,13 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2615,7 +2615,7 @@ msgstr "ネットワークゾーンの設定値を取得します"
 msgid "Get values for network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定値を取得します"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
@@ -2753,7 +2753,7 @@ msgstr "設定されている自動でのストレージボリュームの有効
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
@@ -2791,7 +2791,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
@@ -3043,7 +3043,7 @@ msgstr ""
 "を使います。"
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3075,7 +3075,7 @@ msgstr "リンクスピード: %dMbit/s (%s duplex)"
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
@@ -3087,7 +3087,7 @@ msgstr "有効な証明書追加トークンをすべて一覧表示します"
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
@@ -3542,7 +3542,7 @@ msgstr "MAD: %s (%s)"
 msgid "MANAGED"
 msgstr "MANAGED"
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr "MEMBERS"
 
@@ -3588,7 +3588,7 @@ msgstr "イメージを public にする"
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr "クラスタグループを管理します"
 
@@ -3596,11 +3596,11 @@ msgstr "クラスタグループを管理します"
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr "クラスタロールを管理します"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
@@ -3708,7 +3708,7 @@ msgstr "ネットワークゾーンレコードを管理します"
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
@@ -3773,12 +3773,12 @@ msgstr "VF の最大数: %d"
 msgid "Mdev profiles:"
 msgstr "Mdevプロファイル:"
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr "メンバー %q はすでにロール %q を持っています"
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
@@ -3842,21 +3842,21 @@ msgstr "バケット名を指定する必要があります"
 msgid "Missing certificate fingerprint"
 msgstr "証明書のフィンガープリントがありません"
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -3944,8 +3944,8 @@ msgstr "ピア名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
@@ -3954,7 +3954,7 @@ msgstr "プロファイル名を指定する必要があります"
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -4079,14 +4079,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4435,7 +4435,7 @@ msgstr "パーティション:"
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr "インスタンスを一時停止します"
 
@@ -4472,12 +4472,12 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4517,32 +4517,32 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -4559,7 +4559,7 @@ msgstr "新しいインスタンスに適用するプロファイル"
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -4825,7 +4825,7 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
@@ -4837,7 +4837,7 @@ msgstr "クラスタからメンバを削除します"
 msgid "Remove a network zone record entry"
 msgstr "ネットワークゾーンレコードエントリを削除します"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
@@ -4865,7 +4865,7 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
@@ -4877,7 +4877,7 @@ msgstr "フォワードからポートを削除します"
 msgid "Remove ports from a load balancer"
 msgstr "ロードバランサーからポートを削除します"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
@@ -4885,7 +4885,7 @@ msgstr "インスタンスからプロファイルを削除します"
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr "クラスタメンバからロールを削除します"
 
@@ -4897,7 +4897,7 @@ msgstr "ACL からルールを削除します"
 msgid "Remove trusted client"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
@@ -4905,7 +4905,7 @@ msgstr "クラスタグループの名前を変更します"
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
@@ -4922,7 +4922,7 @@ msgstr "ネットワーク ACL 名を変更します"
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
@@ -4965,11 +4965,11 @@ msgstr "ユーザの確認を要求する"
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr "インスタンスを再起動します"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5031,7 +5031,7 @@ msgstr "クラスターメンバーに join するためのトークンを失効
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
@@ -5294,11 +5294,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を行います"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5409,7 +5409,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr "クラスタグループの設定を表示します"
 
@@ -5493,7 +5493,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show network zone record configurations"
 msgstr "ネットワークゾーンレコードの設定を表示します"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
@@ -5592,7 +5592,7 @@ msgstr "スナップショット:"
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
@@ -5601,7 +5601,7 @@ msgstr "一部のインスタンスで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
@@ -5628,7 +5628,7 @@ msgstr "ステートフル"
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
@@ -5702,7 +5702,7 @@ msgstr "ストレージボリュームのコピーが成功しました!"
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
@@ -5737,7 +5737,7 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr "TARGET"
 
@@ -5897,7 +5897,7 @@ msgstr ""
 msgid "Threads:"
 msgstr "スレッド:"
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
@@ -5985,7 +5985,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -6034,7 +6034,7 @@ msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr "USED BY"
@@ -6153,7 +6153,7 @@ msgstr "ネットワークゾーンの設定を削除します"
 msgid "Unset network zone record configuration keys"
 msgstr "ネットワークゾーンレコードの設定を削除します"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
@@ -6192,6 +6192,11 @@ msgid ""
 "files."
 msgstr ""
 "入力ファイルから読み込んだ PEM 証明書と鍵でクラスター証明書を更新します。"
+
+#: lxc/profile.go:253
+#, fuzzy
+msgid "Update the target profile from the source if it already exists"
+msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
 #: lxc/image.go:955
 #, c-format
@@ -6342,10 +6347,10 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -6439,12 +6444,12 @@ msgstr "[<remote>:]<cluster member>"
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
@@ -6506,11 +6511,11 @@ msgstr "[<remote>:]<instance> <device> [key=value...]"
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr "[<remote>:]<instance> <profile>"
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr "[<remote>:]<instance> <profiles>"
 
@@ -6527,7 +6532,7 @@ msgstr "[<remote>:]<instance> <template>"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
@@ -6581,7 +6586,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
@@ -6597,7 +6602,7 @@ msgstr "[<remote>:]<member> <key>=<value>..."
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
@@ -6831,8 +6836,8 @@ msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
@@ -6848,11 +6853,11 @@ msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr "[<remote>:]<profile> <device> <type> [key=value...]"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr "[<remote>:]<profile> <key>"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
@@ -6860,11 +6865,11 @@ msgstr "[<remote>:]<profile> <key><value>..."
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr "[<remote>:]<profile> <new-name>"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
@@ -6962,7 +6967,7 @@ msgstr "ドライバ"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
@@ -6971,7 +6976,7 @@ msgstr "エラー: %v"
 msgid "info"
 msgstr "ストレージ情報"
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
@@ -6979,7 +6984,7 @@ msgstr ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    \"list\" コマンドを \"list -c ns46S\" で上書きします。"
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
@@ -6987,7 +6992,7 @@ msgstr ""
 "lxc alias remove my-list\n"
 "     \"my-list\" というエイリアスを削除します。"
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -7003,7 +7008,7 @@ msgstr ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    member.yaml の内容でクラスターメンバーを更新します"
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7257,7 +7262,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7297,7 +7302,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンスの /opt にマウントしま"
 "す。"
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -9308,9 +9313,6 @@ msgstr "yes"
 
 #~ msgid "got bad version"
 #~ msgstr "不正なバージョンを得ました"
-
-#~ msgid "not all the profiles from the source exist on the target"
-#~ msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
 #~ msgid "unreachable return reached"
 #~ msgstr "到達しないはずのreturnに到達しました"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-07-06 03:25-0400\n"
+        "POT-Creation-Date: 2023-07-13 18:08+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,7 +64,7 @@ msgid   "### This is a YAML representation of the certificate.\n"
         "### Note that the fingerprint is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -251,7 +251,7 @@ msgid   "### This is a YAML representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid   "### This is a YAML representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -321,7 +321,7 @@ msgstr  ""
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid   "(none)"
 msgstr  ""
 
@@ -340,15 +340,15 @@ msgstr  ""
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid   "--console can't be used while forcing instance shutdown"
 msgstr  ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid   "--console only works with a single instance"
 msgstr  ""
 
@@ -380,15 +380,15 @@ msgstr  ""
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid   "<alias>"
 msgstr  ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid   "<alias> <target>"
 msgstr  ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
@@ -416,7 +416,7 @@ msgstr  ""
 msgid   "<target>"
 msgstr  ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
@@ -482,7 +482,7 @@ msgstr  ""
 msgid   "Add instance devices"
 msgstr  ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid   "Add new aliases"
 msgstr  ""
 
@@ -524,11 +524,11 @@ msgstr  ""
 msgid   "Add ports to a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid   "Add profiles to instances"
 msgstr  ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid   "Add roles to a cluster member"
 msgstr  ""
 
@@ -556,12 +556,12 @@ msgstr  ""
 msgid   "Admin secret key: %s"
 msgstr  ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid   "Alias %s already exists"
 msgstr  ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid   "Alias %s doesn't exist"
 msgstr  ""
@@ -614,11 +614,11 @@ msgstr  ""
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid   "Assign sets of groups to cluster members"
 msgstr  ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid   "Assign sets of profiles to instances"
 msgstr  ""
 
@@ -722,7 +722,7 @@ msgstr  ""
 msgid   "Bond:"
 msgstr  ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid   "Both --all and instance name given"
 msgstr  ""
 
@@ -922,22 +922,22 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid   "Cluster group %s created"
 msgstr  ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid   "Cluster group %s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid   "Cluster group %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
@@ -947,12 +947,12 @@ msgstr  ""
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid   "Cluster member %s added to cluster groups %s"
 msgstr  ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
@@ -1008,7 +1008,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581 lxc/network_forward.go:596 lxc/network_load_balancer.go:599 lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066 lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056 lxc/storage_volume.go:989 lxc/storage_volume.go:1021
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581 lxc/network_forward.go:596 lxc/network_load_balancer.go:599 lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056 lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1069,7 +1069,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -1085,7 +1085,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250 lxc/storage_volume.go:338
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252 lxc/storage_volume.go:338
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1155,7 +1155,7 @@ msgstr  ""
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid   "Create a cluster group"
 msgstr  ""
 
@@ -1238,7 +1238,7 @@ msgstr  ""
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid   "Create profiles"
 msgstr  ""
 
@@ -1277,7 +1277,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968 lxc/network_acl.go:148 lxc/network_forward.go:145 lxc/network_load_balancer.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163 lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634 lxc/storage_bucket.go:495 lxc/storage_bucket.go:791 lxc/storage_volume.go:1491
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968 lxc/network_acl.go:148 lxc/network_forward.go:145 lxc/network_load_balancer.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163 lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634 lxc/storage_bucket.go:495 lxc/storage_bucket.go:791 lxc/storage_volume.go:1491
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1305,7 +1305,7 @@ msgstr  ""
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid   "Delete a cluster group"
 msgstr  ""
 
@@ -1365,7 +1365,7 @@ msgstr  ""
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid   "Delete profiles"
 msgstr  ""
 
@@ -1389,7 +1389,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403 lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650 lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022 lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29 lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204 lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439 lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626 lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216 lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503 lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895 lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109 lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396 lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614 lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727 lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:629 lxc/network_forward.go:691 lxc/network_forward.go:706 lxc/network_forward.go:771 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384 lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:934 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453 lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770 lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954 lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148 lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23 lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184 lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248 lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539 lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775 lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397 lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654 lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342 lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725 lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:375 lxc/storage_bucket.go:441 lxc/storage_bucket.go:516 lxc/storage_bucket.go:593 lxc/storage_bucket.go:660 lxc/storage_bucket.go:691 lxc/storage_bucket.go:732 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:530 lxc/storage_volume.go:609 lxc/storage_volume.go:684 lxc/storage_volume.go:766 lxc/storage_volume.go:847 lxc/storage_volume.go:1054 lxc/storage_volume.go:1153 lxc/storage_volume.go:1302 lxc/storage_volume.go:1386 lxc/storage_volume.go:1592 lxc/storage_volume.go:1625 lxc/storage_volume.go:1738 lxc/storage_volume.go:1835 lxc/storage_volume.go:1942 lxc/storage_volume.go:1985 lxc/storage_volume.go:2082 lxc/storage_volume.go:2149 lxc/storage_volume.go:2303 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403 lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650 lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022 lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30 lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210 lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452 lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626 lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216 lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503 lxc/network.go:588 lxc/network.go:714 lxc/network.go:772 lxc/network.go:895 lxc/network.go:988 lxc/network.go:1059 lxc/network.go:1109 lxc/network.go:1179 lxc/network.go:1241 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:264 lxc/network_acl.go:313 lxc/network_acl.go:396 lxc/network_acl.go:456 lxc/network_acl.go:483 lxc/network_acl.go:614 lxc/network_acl.go:663 lxc/network_acl.go:712 lxc/network_acl.go:727 lxc/network_acl.go:848 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:327 lxc/network_forward.go:382 lxc/network_forward.go:460 lxc/network_forward.go:487 lxc/network_forward.go:629 lxc/network_forward.go:691 lxc/network_forward.go:706 lxc/network_forward.go:771 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:329 lxc/network_load_balancer.go:384 lxc/network_load_balancer.go:462 lxc/network_load_balancer.go:489 lxc/network_load_balancer.go:632 lxc/network_load_balancer.go:693 lxc/network_load_balancer.go:708 lxc/network_load_balancer.go:772 lxc/network_load_balancer.go:858 lxc/network_load_balancer.go:873 lxc/network_load_balancer.go:934 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:329 lxc/network_peer.go:384 lxc/network_peer.go:453 lxc/network_peer.go:480 lxc/network_peer.go:605 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:209 lxc/network_zone.go:258 lxc/network_zone.go:339 lxc/network_zone.go:399 lxc/network_zone.go:426 lxc/network_zone.go:545 lxc/network_zone.go:593 lxc/network_zone.go:650 lxc/network_zone.go:720 lxc/network_zone.go:770 lxc/network_zone.go:818 lxc/network_zone.go:898 lxc/network_zone.go:954 lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148 lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23 lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550 lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786 lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397 lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654 lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:342 lxc/storage.go:402 lxc/storage.go:574 lxc/storage.go:651 lxc/storage.go:725 lxc/storage.go:809 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:375 lxc/storage_bucket.go:441 lxc/storage_bucket.go:516 lxc/storage_bucket.go:593 lxc/storage_bucket.go:660 lxc/storage_bucket.go:691 lxc/storage_bucket.go:732 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:530 lxc/storage_volume.go:609 lxc/storage_volume.go:684 lxc/storage_volume.go:766 lxc/storage_volume.go:847 lxc/storage_volume.go:1054 lxc/storage_volume.go:1153 lxc/storage_volume.go:1302 lxc/storage_volume.go:1386 lxc/storage_volume.go:1592 lxc/storage_volume.go:1625 lxc/storage_volume.go:1738 lxc/storage_volume.go:1835 lxc/storage_volume.go:1942 lxc/storage_volume.go:1985 lxc/storage_volume.go:2082 lxc/storage_volume.go:2149 lxc/storage_volume.go:2303 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1541,7 +1541,7 @@ msgstr  ""
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid   "Edit a cluster group"
 msgstr  ""
 
@@ -1597,7 +1597,7 @@ msgstr  ""
 msgid   "Edit network zone record configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
@@ -1924,7 +1924,7 @@ msgstr  ""
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid   "Force the instance to stop"
 msgstr  ""
 
@@ -1955,7 +1955,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842 lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653 lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399 lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576 lxc/storage_bucket.go:442 lxc/storage_bucket.go:733 lxc/storage_volume.go:1402 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842 lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653 lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399 lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576 lxc/storage_bucket.go:442 lxc/storage_bucket.go:733 lxc/storage_volume.go:1402 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2063,7 +2063,7 @@ msgstr  ""
 msgid   "Get values for network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
@@ -2194,7 +2194,7 @@ msgstr  ""
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid   "Ignore the instance state"
 msgstr  ""
 
@@ -2232,7 +2232,7 @@ msgstr  ""
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid   "Immediately attach to the console"
 msgstr  ""
 
@@ -2460,7 +2460,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061 lxc/cluster_group.go:403
+#: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061 lxc/cluster_group.go:415
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2492,7 +2492,7 @@ msgstr  ""
 msgid   "List DHCP leases"
 msgstr  ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid   "List aliases"
 msgstr  ""
 
@@ -2504,7 +2504,7 @@ msgstr  ""
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid   "List all the cluster groups"
 msgstr  ""
 
@@ -2691,7 +2691,7 @@ msgstr  ""
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid   "List profiles"
 msgstr  ""
 
@@ -2810,7 +2810,7 @@ msgstr  ""
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid   "MEMBERS"
 msgstr  ""
 
@@ -2856,7 +2856,7 @@ msgstr  ""
 msgid   "Manage and attach instances to networks"
 msgstr  ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid   "Manage cluster groups"
 msgstr  ""
 
@@ -2864,11 +2864,11 @@ msgstr  ""
 msgid   "Manage cluster members"
 msgstr  ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid   "Manage cluster roles"
 msgstr  ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid   "Manage command aliases"
 msgstr  ""
 
@@ -2962,7 +2962,7 @@ msgstr  ""
 msgid   "Manage network zones"
 msgstr  ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid   "Manage profiles"
 msgstr  ""
 
@@ -3021,12 +3021,12 @@ msgstr  ""
 msgid   "Mdev profiles:"
 msgstr  ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid   "Member %q already has role %q"
 msgstr  ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid   "Member %q does not have role %q"
 msgstr  ""
@@ -3084,15 +3084,15 @@ msgstr  ""
 msgid   "Missing certificate fingerprint"
 msgstr  ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278 lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287 lxc/cluster_group.go:598
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109 lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112 lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:91 lxc/config_template.go:134 lxc/config_template.go:176 lxc/config_template.go:265 lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200 lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_metadata.go:103 lxc/config_metadata.go:204 lxc/config_template.go:91 lxc/config_template.go:134 lxc/config_template.go:176 lxc/config_template.go:265 lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201 lxc/profile.go:684 lxc/rebuild.go:59
 msgid   "Missing instance name"
 msgstr  ""
 
@@ -3132,7 +3132,7 @@ msgstr  ""
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563 lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574 lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid   "Missing profile name"
 msgstr  ""
 
@@ -3140,7 +3140,7 @@ msgstr  ""
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -3240,11 +3240,11 @@ msgstr  ""
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632 lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626 lxc/storage_bucket.go:494 lxc/storage_bucket.go:790 lxc/storage_volume.go:1490
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643 lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626 lxc/storage_bucket.go:494 lxc/storage_bucket.go:790 lxc/storage_volume.go:1490
 msgid   "NAME"
 msgstr  ""
 
@@ -3583,7 +3583,7 @@ msgstr  ""
 msgid   "Password for %s: "
 msgstr  ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid   "Pause instances"
 msgstr  ""
 
@@ -3620,7 +3620,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1057 lxc/storage_volume.go:990 lxc/storage_volume.go:1022
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1057 lxc/storage_volume.go:990 lxc/storage_volume.go:1022
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3655,32 +3655,32 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
@@ -3697,7 +3697,7 @@ msgstr  ""
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -3941,7 +3941,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
@@ -3953,7 +3953,7 @@ msgstr  ""
 msgid   "Remove a network zone record entry"
 msgstr  ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid   "Remove aliases"
 msgstr  ""
 
@@ -3981,7 +3981,7 @@ msgstr  ""
 msgid   "Remove instance devices"
 msgstr  ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid   "Remove member from group"
 msgstr  ""
 
@@ -3993,7 +3993,7 @@ msgstr  ""
 msgid   "Remove ports from a load balancer"
 msgstr  ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid   "Remove profiles from instances"
 msgstr  ""
 
@@ -4001,7 +4001,7 @@ msgstr  ""
 msgid   "Remove remotes"
 msgstr  ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid   "Remove roles from a cluster member"
 msgstr  ""
 
@@ -4013,7 +4013,7 @@ msgstr  ""
 msgid   "Remove trusted client"
 msgstr  ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid   "Rename a cluster group"
 msgstr  ""
 
@@ -4021,7 +4021,7 @@ msgstr  ""
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254 lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254 lxc/image_alias.go:255
 msgid   "Rename aliases"
 msgstr  ""
 
@@ -4037,7 +4037,7 @@ msgstr  ""
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid   "Rename profiles"
 msgstr  ""
 
@@ -4079,11 +4079,11 @@ msgstr  ""
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid   "Restart instances"
 msgstr  ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid   "Restart instances\n"
         "\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
@@ -4137,7 +4137,7 @@ msgstr  ""
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid   "Run against all instances"
 msgstr  ""
 
@@ -4344,11 +4344,11 @@ msgstr  ""
 msgid   "Set network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4427,7 +4427,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid   "Show cluster group configurations"
 msgstr  ""
 
@@ -4511,7 +4511,7 @@ msgstr  ""
 msgid   "Show network zone record configurations"
 msgstr  ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid   "Show profile configurations"
 msgstr  ""
 
@@ -4610,7 +4610,7 @@ msgstr  ""
 msgid   "Socket %d:"
 msgstr  ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
@@ -4619,7 +4619,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid   "Start instances"
 msgstr  ""
 
@@ -4646,7 +4646,7 @@ msgstr  ""
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid   "Stop instances"
 msgstr  ""
 
@@ -4720,7 +4720,7 @@ msgstr  ""
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid   "Store the instance state"
 msgstr  ""
 
@@ -4755,7 +4755,7 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid   "TARGET"
 msgstr  ""
 
@@ -4890,7 +4890,7 @@ msgstr  ""
 msgid   "Threads:"
 msgstr  ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
@@ -4968,7 +4968,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -5011,7 +5011,7 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140 lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635 lxc/storage_volume.go:1493
+#: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140 lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635 lxc/storage_volume.go:1493
 msgid   "USED BY"
 msgstr  ""
 
@@ -5128,7 +5128,7 @@ msgstr  ""
 msgid   "Unset network zone record configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
@@ -5163,6 +5163,10 @@ msgstr  ""
 
 #: lxc/cluster.go:1023
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
+msgstr  ""
+
+#: lxc/profile.go:253
+msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
 #: lxc/image.go:955
@@ -5297,7 +5301,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394 lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394 lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -5389,11 +5393,11 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252 lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260 lxc/cluster_group.go:571
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
@@ -5453,11 +5457,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid   "[<remote>:]<instance> <profile>"
 msgstr  ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid   "[<remote>:]<instance> <profiles>"
 msgstr  ""
 
@@ -5473,7 +5477,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [<snapshot name>]"
 msgstr  ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid   "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr  ""
 
@@ -5521,7 +5525,7 @@ msgstr  ""
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
@@ -5537,7 +5541,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
@@ -5737,7 +5741,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307 lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318 lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
@@ -5753,11 +5757,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid   "[<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid   "[<remote>:]<profile> <key><value>..."
 msgstr  ""
 
@@ -5765,11 +5769,11 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid   "[<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -5865,7 +5869,7 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid   "error: %v"
 msgstr  ""
@@ -5874,17 +5878,17 @@ msgstr  ""
 msgid   "info"
 msgstr  ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid   "lxc alias add list \"list -c ns46S\"\n"
         "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr  ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid   "lxc alias remove my-list\n"
         "    Remove the \"my-list\" alias."
 msgstr  ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
@@ -5894,7 +5898,7 @@ msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid   "lxc cluster group assign foo default,bar\n"
         "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -6032,7 +6036,7 @@ msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -6051,7 +6055,7 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -114,7 +114,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -458,7 +458,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -563,7 +563,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(geen)"
 
@@ -582,15 +582,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -623,15 +623,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -726,7 +726,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -775,11 +775,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -807,12 +807,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -865,11 +865,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1180,22 +1180,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1205,12 +1205,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1294,12 +1294,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1455,7 +1455,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1697,17 +1697,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1763,10 +1763,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1953,7 +1953,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2383,13 +2383,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2500,7 +2500,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2906,7 +2906,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2938,7 +2938,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2950,7 +2950,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3268,7 +3268,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3314,7 +3314,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3322,11 +3322,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3421,7 +3421,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3482,12 +3482,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3551,21 +3551,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3653,8 +3653,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3663,7 +3663,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3770,14 +3770,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4123,7 +4123,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4160,12 +4160,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4203,32 +4203,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4245,7 +4245,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4506,7 +4506,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4518,7 +4518,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4546,7 +4546,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4578,7 +4578,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4645,11 +4645,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4705,7 +4705,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4931,11 +4931,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5024,7 +5024,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5108,7 +5108,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5207,7 +5207,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5216,7 +5216,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5243,7 +5243,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5317,7 +5317,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5352,7 +5352,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5576,7 +5576,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5623,7 +5623,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5742,7 +5742,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5779,6 +5779,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5921,10 +5925,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -6018,12 +6022,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6084,11 +6088,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6105,7 +6109,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6156,7 +6160,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6172,7 +6176,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6391,8 +6395,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6408,11 +6412,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6420,11 +6424,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6521,7 +6525,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6530,19 +6534,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6554,7 +6558,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6719,7 +6723,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6742,7 +6746,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -116,7 +116,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -488,7 +488,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -597,7 +597,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -616,15 +616,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -657,15 +657,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -809,11 +809,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -841,12 +841,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -899,11 +899,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1214,22 +1214,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1239,12 +1239,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1328,12 +1328,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1418,7 +1418,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1612,12 +1612,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1647,7 +1647,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1707,7 +1707,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1731,17 +1731,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1797,10 +1797,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1987,7 +1987,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2417,13 +2417,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2667,7 +2667,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2705,7 +2705,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2940,7 +2940,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3181,7 +3181,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3302,7 +3302,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3348,7 +3348,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3356,11 +3356,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3455,7 +3455,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3516,12 +3516,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3585,21 +3585,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3687,8 +3687,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3804,14 +3804,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4157,7 +4157,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4194,12 +4194,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4237,32 +4237,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4540,7 +4540,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4552,7 +4552,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4580,7 +4580,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4592,7 +4592,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4620,7 +4620,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4679,11 +4679,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4739,7 +4739,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4965,11 +4965,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5142,7 +5142,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5241,7 +5241,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5250,7 +5250,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5277,7 +5277,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5386,7 +5386,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5530,7 +5530,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5610,7 +5610,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5657,7 +5657,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5776,7 +5776,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5813,6 +5813,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5955,10 +5959,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -6052,12 +6056,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -6118,11 +6122,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6139,7 +6143,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6190,7 +6194,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6206,7 +6210,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6425,8 +6429,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6442,11 +6446,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6454,11 +6458,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6555,7 +6559,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6564,19 +6568,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6588,7 +6592,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6753,7 +6757,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6776,7 +6780,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -117,7 +117,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -479,7 +479,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -587,7 +587,7 @@ msgstr "%s não é um diretório"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -606,17 +606,17 @@ msgstr "- Partição %d"
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -657,15 +657,15 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -764,7 +764,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
@@ -814,12 +814,12 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 #, fuzzy
 msgid "Add profiles to instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Nome de membro do cluster"
@@ -849,12 +849,12 @@ msgstr "Senha de administrador para %s: "
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr "Alias %s já existe"
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
@@ -909,12 +909,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 #, fuzzy
 msgid "Assign sets of profiles to instances"
 msgstr "Atribuir conjuntos de perfis aos containers"
@@ -1028,7 +1028,7 @@ msgstr "Propriedade ruim: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1234,22 +1234,22 @@ msgstr "Certificado do cliente armazenado no servidor: "
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1259,12 +1259,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, fuzzy, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
@@ -1357,12 +1357,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -1448,7 +1448,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1520,7 +1520,7 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr "Criar novas redes"
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr "Criar perfis"
 
@@ -1658,12 +1658,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1694,7 +1694,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1764,7 +1764,7 @@ msgstr "Criar novas redes"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1789,17 +1789,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1855,10 +1855,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2052,7 +2052,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2119,7 +2119,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
@@ -2461,7 +2461,7 @@ msgstr "Forçar alocação de pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Ignorar o estado do container"
@@ -2498,13 +2498,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2625,7 +2625,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
@@ -3037,7 +3037,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3069,7 +3069,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -3083,7 +3083,7 @@ msgstr "Nome de membro do cluster"
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
@@ -3284,7 +3284,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr "Em cache: %s"
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3453,7 +3453,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3461,12 +3461,12 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Nome de membro do cluster"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3576,7 +3576,7 @@ msgstr "Criar novas redes"
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3642,12 +3642,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3713,14 +3713,14 @@ msgstr "Nome de membro do cluster"
 msgid "Missing certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
@@ -3728,8 +3728,8 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3823,8 +3823,8 @@ msgstr "Nome de membro do cluster"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3833,7 +3833,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3943,14 +3943,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4296,7 +4296,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4334,12 +4334,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4377,32 +4377,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4422,7 +4422,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4733,7 +4733,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4747,7 +4747,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove ports from a load balancer"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 #, fuzzy
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4756,7 +4756,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Nome de membro do cluster"
@@ -4771,7 +4771,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove trusted client"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4779,7 +4779,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4797,7 +4797,7 @@ msgstr "Criar novas redes"
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4839,12 +4839,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4908,7 +4908,7 @@ msgstr "Nome de membro do cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5144,11 +5144,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5239,7 +5239,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5337,7 +5337,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network zone record configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -5450,7 +5450,7 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5477,7 +5477,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5551,7 +5551,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
@@ -5587,7 +5587,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5817,7 +5817,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5865,7 +5865,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5999,7 +5999,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network zone record configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6039,6 +6039,10 @@ msgstr "Aceitar certificado"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6183,10 +6187,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -6294,13 +6298,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
@@ -6365,11 +6369,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6388,7 +6392,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6440,7 +6444,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
@@ -6459,7 +6463,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
@@ -6706,8 +6710,8 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
@@ -6724,11 +6728,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6736,11 +6740,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6847,7 +6851,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6856,19 +6860,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6880,7 +6884,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7045,7 +7049,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7068,7 +7072,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -121,7 +121,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -487,7 +487,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the profile.\n"
@@ -596,7 +596,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -615,15 +615,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -656,16 +656,16 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 #, fuzzy
 msgid "<alias>"
 msgstr "Псевдонимы:"
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -698,7 +698,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
@@ -817,11 +817,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 #, fuzzy
 msgid "Add roles to a cluster member"
 msgstr "Копирование образа: %s"
@@ -850,12 +850,12 @@ msgstr "Пароль администратора для %s: "
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -910,12 +910,12 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 #, fuzzy
 msgid "Assign sets of groups to cluster members"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1231,22 +1231,22 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, fuzzy, c-format
 msgid "Cluster group %s created"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, fuzzy, c-format
 msgid "Cluster group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1256,12 +1256,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1345,12 +1345,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1419,7 +1419,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1508,7 +1508,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1605,7 +1605,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1647,12 +1647,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1775,17 +1775,17 @@ msgstr "Копирование образа: %s"
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1841,10 +1841,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -2037,7 +2037,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -2099,7 +2099,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit network zone record configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2447,7 +2447,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2484,13 +2484,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2607,7 +2607,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2742,7 +2742,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -3023,7 +3023,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3055,7 +3055,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 #, fuzzy
 msgid "List aliases"
 msgstr "Псевдонимы:"
@@ -3070,7 +3070,7 @@ msgstr "Копирование образа: %s"
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 #, fuzzy
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
@@ -3274,7 +3274,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3401,7 +3401,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 #, fuzzy
 msgid "Manage cluster groups"
 msgstr "Копирование образа: %s"
@@ -3456,12 +3456,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 #, fuzzy
 msgid "Manage cluster roles"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3569,7 +3569,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3637,12 +3637,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3709,14 +3709,14 @@ msgstr "Имя контейнера: %s"
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 #, fuzzy
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 #, fuzzy
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
@@ -3724,8 +3724,8 @@ msgstr "Копирование образа: %s"
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
@@ -3820,8 +3820,8 @@ msgstr "Имя контейнера: %s"
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3831,7 +3831,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3943,14 +3943,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4338,12 +4338,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4381,32 +4381,32 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4423,7 +4423,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 #, fuzzy
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
@@ -4702,7 +4702,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr "Копирование образа: %s"
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4746,7 +4746,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4754,7 +4754,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 #, fuzzy
 msgid "Remove roles from a cluster member"
 msgstr "Копирование образа: %s"
@@ -4767,7 +4767,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4775,7 +4775,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4793,7 +4793,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4837,12 +4837,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 #, fuzzy
 msgid "Restart instances"
 msgstr "Псевдонимы:"
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4903,7 +4903,7 @@ msgstr "Копирование образа: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -5135,11 +5135,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -5229,7 +5229,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 #, fuzzy
 msgid "Show cluster group configurations"
 msgstr "Копирование образа: %s"
@@ -5323,7 +5323,7 @@ msgstr "Копирование образа: %s"
 msgid "Show network zone record configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5428,7 +5428,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5437,7 +5437,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5465,7 +5465,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 #, fuzzy
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5541,7 +5541,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5577,7 +5577,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5721,7 +5721,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5801,7 +5801,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5849,7 +5849,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5977,7 +5977,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset network zone record configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -6016,6 +6016,10 @@ msgstr "Принять сертификат"
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -6167,10 +6171,10 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
@@ -6356,8 +6360,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6365,7 +6369,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 #, fuzzy
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
@@ -6486,7 +6490,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 #, fuzzy
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
@@ -6494,7 +6498,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 #, fuzzy
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
@@ -6527,7 +6531,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -6626,7 +6630,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 #, fuzzy
 msgid "[<remote>:]<member> <group>"
 msgstr ""
@@ -6658,7 +6662,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 #, fuzzy
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
@@ -7073,8 +7077,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr ""
@@ -7106,7 +7110,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 #, fuzzy
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
@@ -7114,7 +7118,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 #, fuzzy
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -7130,7 +7134,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 #, fuzzy
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
@@ -7138,7 +7142,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 #, fuzzy
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
@@ -7311,7 +7315,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -7320,19 +7324,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -7344,7 +7348,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -7509,7 +7513,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -7532,7 +7536,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -444,7 +444,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -559,11 +559,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -591,12 +591,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -964,22 +964,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -989,12 +989,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1362,12 +1362,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1481,17 +1481,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1547,10 +1547,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1737,7 +1737,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2167,13 +2167,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2690,7 +2690,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3106,11 +3106,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3266,12 +3266,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3335,21 +3335,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3437,8 +3437,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3554,14 +3554,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3944,12 +3944,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3987,32 +3987,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4290,7 +4290,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4330,7 +4330,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4370,7 +4370,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4429,11 +4429,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4715,11 +4715,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4808,7 +4808,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5000,7 +5000,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5360,7 +5360,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5407,7 +5407,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5563,6 +5563,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5705,10 +5709,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5802,12 +5806,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5868,11 +5872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5889,7 +5893,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5940,7 +5944,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5956,7 +5960,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6175,8 +6179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6192,11 +6196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6204,11 +6208,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6305,7 +6309,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6314,19 +6318,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6338,7 +6342,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6503,7 +6507,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6526,7 +6530,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -444,7 +444,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -559,11 +559,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -591,12 +591,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -964,22 +964,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -989,12 +989,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1362,12 +1362,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1481,17 +1481,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1547,10 +1547,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1737,7 +1737,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2167,13 +2167,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2690,7 +2690,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3106,11 +3106,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3266,12 +3266,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3335,21 +3335,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3437,8 +3437,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3554,14 +3554,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3944,12 +3944,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3987,32 +3987,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4290,7 +4290,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4330,7 +4330,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4370,7 +4370,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4429,11 +4429,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4715,11 +4715,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4808,7 +4808,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5000,7 +5000,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5360,7 +5360,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5407,7 +5407,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5563,6 +5563,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5705,10 +5709,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5802,12 +5806,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5868,11 +5872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5889,7 +5893,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5940,7 +5944,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5956,7 +5960,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6175,8 +6179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6192,11 +6196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6204,11 +6208,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6305,7 +6309,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6314,19 +6318,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6338,7 +6342,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6503,7 +6507,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6526,7 +6530,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -270,7 +270,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -362,15 +362,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -403,15 +403,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -555,11 +555,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -587,12 +587,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -645,11 +645,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -960,22 +960,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -985,12 +985,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1074,12 +1074,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1358,12 +1358,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1393,7 +1393,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1453,7 +1453,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1477,17 +1477,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1543,10 +1543,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1733,7 +1733,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1789,7 +1789,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2163,13 +2163,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2413,7 +2413,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2451,7 +2451,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2686,7 +2686,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2730,7 +2730,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2927,7 +2927,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3094,7 +3094,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3102,11 +3102,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3201,7 +3201,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3262,12 +3262,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3331,21 +3331,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3433,8 +3433,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3443,7 +3443,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3550,14 +3550,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3903,7 +3903,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3940,12 +3940,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3983,32 +3983,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4025,7 +4025,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4286,7 +4286,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4298,7 +4298,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4326,7 +4326,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4346,7 +4346,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4383,7 +4383,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4425,11 +4425,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4485,7 +4485,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4711,11 +4711,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4804,7 +4804,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4888,7 +4888,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4996,7 +4996,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5023,7 +5023,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5097,7 +5097,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5132,7 +5132,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5276,7 +5276,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5403,7 +5403,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5559,6 +5559,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5701,10 +5705,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5798,12 +5802,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5864,11 +5868,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5885,7 +5889,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5936,7 +5940,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5952,7 +5956,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6171,8 +6175,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6188,11 +6192,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6200,11 +6204,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6301,7 +6305,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6310,19 +6314,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6334,7 +6338,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6499,7 +6503,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6522,7 +6526,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -72,7 +72,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -274,7 +274,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -347,7 +347,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -444,7 +444,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -559,11 +559,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -591,12 +591,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -649,11 +649,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -964,22 +964,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -989,12 +989,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1078,12 +1078,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1362,12 +1362,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1397,7 +1397,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1481,17 +1481,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1547,10 +1547,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1737,7 +1737,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1793,7 +1793,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2167,13 +2167,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2284,7 +2284,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2455,7 +2455,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2690,7 +2690,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3098,7 +3098,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3106,11 +3106,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3266,12 +3266,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3335,21 +3335,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3437,8 +3437,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3554,14 +3554,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3944,12 +3944,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3987,32 +3987,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4290,7 +4290,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4330,7 +4330,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4350,7 +4350,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4370,7 +4370,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4429,11 +4429,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4489,7 +4489,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4715,11 +4715,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4808,7 +4808,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4892,7 +4892,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4991,7 +4991,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5000,7 +5000,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5101,7 +5101,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5360,7 +5360,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5407,7 +5407,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5563,6 +5563,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5705,10 +5709,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5802,12 +5806,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5868,11 +5872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5889,7 +5893,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5940,7 +5944,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5956,7 +5960,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6175,8 +6179,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6192,11 +6196,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6204,11 +6208,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6305,7 +6309,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6314,19 +6318,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6338,7 +6342,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6503,7 +6507,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6526,7 +6530,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -116,7 +116,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
@@ -387,7 +387,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr "%s 不是一个目录"
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -497,15 +497,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -538,15 +538,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -575,7 +575,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -690,11 +690,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -722,12 +722,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -780,11 +780,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1095,22 +1095,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -1120,12 +1120,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1209,12 +1209,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1493,12 +1493,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1588,7 +1588,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1612,17 +1612,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1678,10 +1678,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1868,7 +1868,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1924,7 +1924,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2298,13 +2298,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2548,7 +2548,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2586,7 +2586,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3183,7 +3183,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3229,7 +3229,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3237,11 +3237,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3397,12 +3397,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3466,21 +3466,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3568,8 +3568,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3578,7 +3578,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3685,14 +3685,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -4038,7 +4038,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -4075,12 +4075,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -4118,32 +4118,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4421,7 +4421,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4433,7 +4433,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4461,7 +4461,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4481,7 +4481,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4493,7 +4493,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4518,7 +4518,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4560,11 +4560,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4620,7 +4620,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4846,11 +4846,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -5023,7 +5023,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -5122,7 +5122,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5131,7 +5131,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5232,7 +5232,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5267,7 +5267,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5411,7 +5411,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5491,7 +5491,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5538,7 +5538,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5657,7 +5657,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5694,6 +5694,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5836,10 +5840,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5933,12 +5937,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5999,11 +6003,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -6020,7 +6024,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6071,7 +6075,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -6087,7 +6091,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6306,8 +6310,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6323,11 +6327,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6335,11 +6339,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6436,7 +6440,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6445,19 +6449,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6469,7 +6473,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6634,7 +6638,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6657,7 +6661,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-06 03:25-0400\n"
+"POT-Creation-Date: 2023-07-12 11:35+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the fingerprint is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster_group.go:349
+#: lxc/cluster_group.go:359
 msgid ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
@@ -273,7 +273,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:425
+#: lxc/profile.go:436
 msgid ""
 "### This is a YAML representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -346,7 +346,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/cluster_group.go:129 lxc/profile.go:225
+#: lxc/cluster_group.go:132 lxc/profile.go:226
 msgid "(none)"
 msgstr ""
 
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:206
+#: lxc/action.go:220
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:353
+#: lxc/action.go:369
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:357
+#: lxc/action.go:373
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -406,15 +406,15 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:195
+#: lxc/alias.go:211
 msgid "<alias>"
 msgstr ""
 
-#: lxc/alias.go:54
+#: lxc/alias.go:58
 msgid "<alias> <target>"
 msgstr ""
 
-#: lxc/alias.go:144
+#: lxc/alias.go:156
 msgid "<old alias> <new alias>"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr ""
 msgid "<target>"
 msgstr ""
 
-#: lxc/alias.go:129 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Add instance devices"
 msgstr ""
 
-#: lxc/alias.go:55 lxc/alias.go:56
+#: lxc/alias.go:59 lxc/alias.go:60
 msgid "Add new aliases"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "Add ports to a load balancer"
 msgstr ""
 
-#: lxc/profile.go:102 lxc/profile.go:103
+#: lxc/profile.go:103 lxc/profile.go:104
 msgid "Add profiles to instances"
 msgstr ""
 
-#: lxc/cluster_role.go:47 lxc/cluster_role.go:48
+#: lxc/cluster_role.go:49 lxc/cluster_role.go:50
 msgid "Add roles to a cluster member"
 msgstr ""
 
@@ -590,12 +590,12 @@ msgstr ""
 msgid "Admin secret key: %s"
 msgstr ""
 
-#: lxc/alias.go:79 lxc/alias.go:176
+#: lxc/alias.go:85 lxc/alias.go:190
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:170 lxc/alias.go:221
+#: lxc/alias.go:184 lxc/alias.go:239
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
@@ -648,11 +648,11 @@ msgstr ""
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/cluster_group.go:77 lxc/cluster_group.go:78
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:80
 msgid "Assign sets of groups to cluster members"
 msgstr ""
 
-#: lxc/profile.go:165 lxc/profile.go:166
+#: lxc/profile.go:166 lxc/profile.go:167
 msgid "Assign sets of profiles to instances"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:136 lxc/action.go:309
+#: lxc/action.go:148 lxc/action.go:325
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -963,22 +963,22 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/cluster_group.go:187
+#: lxc/cluster_group.go:192
 #, c-format
 msgid "Cluster group %s created"
 msgstr ""
 
-#: lxc/cluster_group.go:238
+#: lxc/cluster_group.go:245
 #, c-format
 msgid "Cluster group %s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:473
+#: lxc/cluster_group.go:487
 #, c-format
 msgid "Cluster group %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/cluster_group.go:540
+#: lxc/cluster_group.go:556
 #, c-format
 msgid "Cluster group %s renamed to %s"
 msgstr ""
@@ -988,12 +988,12 @@ msgstr ""
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
 
-#: lxc/cluster_group.go:133
+#: lxc/cluster_group.go:136
 #, c-format
 msgid "Cluster member %s added to cluster groups %s"
 msgstr ""
 
-#: lxc/cluster_group.go:493
+#: lxc/cluster_group.go:507
 #, c-format
 msgid "Cluster member %s removed from group %s"
 msgstr ""
@@ -1077,12 +1077,12 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:731 lxc/cluster_group.go:326 lxc/config.go:263
+#: lxc/cluster.go:731 lxc/cluster_group.go:335 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:314
 #: lxc/image.go:456 lxc/network.go:682 lxc/network_acl.go:581
 #: lxc/network_forward.go:596 lxc/network_load_balancer.go:599
 #: lxc/network_peer.go:572 lxc/network_zone.go:512 lxc/network_zone.go:1066
-#: lxc/profile.go:507 lxc/project.go:315 lxc/storage.go:310
+#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
 #: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1056
 #: lxc/storage_volume.go:989 lxc/storage_volume.go:1021
 #, c-format
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:247 lxc/profile.go:248
+#: lxc/profile.go:249 lxc/profile.go:250
 msgid "Copy profiles"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:250
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/cluster_group.go:148 lxc/cluster_group.go:149
+#: lxc/cluster_group.go:152 lxc/cluster_group.go:153
 msgid "Create a cluster group"
 msgstr ""
 
@@ -1322,7 +1322,7 @@ msgstr ""
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:308 lxc/profile.go:309
+#: lxc/profile.go:319 lxc/profile.go:320
 msgid "Create profiles"
 msgstr ""
 
@@ -1361,12 +1361,12 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:188 lxc/cluster_group.go:422 lxc/image.go:1058
+#: lxc/cluster.go:188 lxc/cluster_group.go:434 lxc/image.go:1058
 #: lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:968
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/operation.go:163
-#: lxc/profile.go:633 lxc/project.go:492 lxc/storage.go:634
+#: lxc/profile.go:644 lxc/project.go:492 lxc/storage.go:634
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:791
 #: lxc/storage_volume.go:1491
 msgid "DESCRIPTION"
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/cluster_group.go:203 lxc/cluster_group.go:204
+#: lxc/cluster_group.go:209 lxc/cluster_group.go:210
 msgid "Delete a cluster group"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:362 lxc/profile.go:363
+#: lxc/profile.go:373 lxc/profile.go:374
 msgid "Delete profiles"
 msgstr ""
 
@@ -1480,17 +1480,17 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:49 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:56 lxc/alias.go:102 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99
+#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
+#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
 #: lxc/cluster.go:255 lxc/cluster.go:304 lxc/cluster.go:351 lxc/cluster.go:403
 #: lxc/cluster.go:432 lxc/cluster.go:482 lxc/cluster.go:565 lxc/cluster.go:650
 #: lxc/cluster.go:765 lxc/cluster.go:841 lxc/cluster.go:943 lxc/cluster.go:1022
-#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:29
-#: lxc/cluster_group.go:78 lxc/cluster_group.go:149 lxc/cluster_group.go:204
-#: lxc/cluster_group.go:254 lxc/cluster_group.go:367 lxc/cluster_group.go:439
-#: lxc/cluster_group.go:510 lxc/cluster_group.go:556 lxc/cluster_role.go:22
-#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/cluster.go:1129 lxc/cluster.go:1150 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:80 lxc/cluster_group.go:153 lxc/cluster_group.go:210
+#: lxc/cluster_group.go:262 lxc/cluster_group.go:378 lxc/cluster_group.go:452
+#: lxc/cluster_group.go:525 lxc/cluster_group.go:573 lxc/cluster_role.go:23
+#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:30
 #: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:626
 #: lxc/config.go:746 lxc/config_device.go:24 lxc/config_device.go:78
 #: lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356
@@ -1546,10 +1546,10 @@ msgstr ""
 #: lxc/network_zone.go:981 lxc/network_zone.go:1099 lxc/network_zone.go:1148
 #: lxc/network_zone.go:1163 lxc/network_zone.go:1209 lxc/operation.go:23
 #: lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184
-#: lxc/profile.go:28 lxc/profile.go:103 lxc/profile.go:166 lxc/profile.go:248
-#: lxc/profile.go:309 lxc/profile.go:363 lxc/profile.go:413 lxc/profile.go:539
-#: lxc/profile.go:588 lxc/profile.go:649 lxc/profile.go:725 lxc/profile.go:775
-#: lxc/profile.go:834 lxc/profile.go:888 lxc/project.go:29 lxc/project.go:93
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:550
+#: lxc/profile.go:599 lxc/profile.go:660 lxc/profile.go:736 lxc/profile.go:786
+#: lxc/profile.go:845 lxc/profile.go:899 lxc/project.go:29 lxc/project.go:93
 #: lxc/project.go:158 lxc/project.go:221 lxc/project.go:347 lxc/project.go:397
 #: lxc/project.go:510 lxc/project.go:565 lxc/project.go:625 lxc/project.go:654
 #: lxc/project.go:707 lxc/project.go:766 lxc/publish.go:32 lxc/query.go:34
@@ -1736,7 +1736,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/cluster_group.go:253 lxc/cluster_group.go:254
+#: lxc/cluster_group.go:261 lxc/cluster_group.go:262
 msgid "Edit a cluster group"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Edit network zone record configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:412 lxc/profile.go:413
+#: lxc/profile.go:423 lxc/profile.go:424
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
@@ -2130,7 +2130,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:136
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2166,13 +2166,13 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:104 lxc/cluster.go:124 lxc/cluster.go:842
-#: lxc/cluster_group.go:369 lxc/config_template.go:242 lxc/config_trust.go:352
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:842
+#: lxc/cluster_group.go:380 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:899 lxc/network.go:990 lxc/network_acl.go:97
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:653
-#: lxc/operation.go:106 lxc/profile.go:592 lxc/project.go:399
+#: lxc/operation.go:106 lxc/profile.go:603 lxc/project.go:399
 #: lxc/project.go:768 lxc/remote.go:668 lxc/storage.go:576
 #: lxc/storage_bucket.go:442 lxc/storage_bucket.go:733
 #: lxc/storage_volume.go:1402 lxc/warning.go:93
@@ -2283,7 +2283,7 @@ msgstr ""
 msgid "Get values for network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:538 lxc/profile.go:539
+#: lxc/profile.go:549 lxc/profile.go:550
 msgid "Get values for profile configuration keys"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:117
+#: lxc/action.go:127
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:121 lxc/launch.go:41
+#: lxc/action.go:131 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2689,7 +2689,7 @@ msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
 #: lxc/cluster.go:158 lxc/cluster.go:876 lxc/cluster.go:970 lxc/cluster.go:1061
-#: lxc/cluster_group.go:403
+#: lxc/cluster_group.go:415
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:101 lxc/alias.go:102
+#: lxc/alias.go:109 lxc/alias.go:110
 msgid "List aliases"
 msgstr ""
 
@@ -2733,7 +2733,7 @@ msgstr ""
 msgid "List all active cluster member join tokens"
 msgstr ""
 
-#: lxc/cluster_group.go:366 lxc/cluster_group.go:367
+#: lxc/cluster_group.go:377 lxc/cluster_group.go:378
 msgid "List all the cluster groups"
 msgstr ""
 
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/profile.go:587 lxc/profile.go:588
+#: lxc/profile.go:598 lxc/profile.go:599
 msgid "List profiles"
 msgstr ""
 
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster_group.go:423
+#: lxc/cluster_group.go:435
 msgid "MEMBERS"
 msgstr ""
 
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Manage and attach instances to networks"
 msgstr ""
 
-#: lxc/cluster_group.go:28 lxc/cluster_group.go:29
+#: lxc/cluster_group.go:29 lxc/cluster_group.go:30
 msgid "Manage cluster groups"
 msgstr ""
 
@@ -3105,11 +3105,11 @@ msgstr ""
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/cluster_role.go:21 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:22 lxc/cluster_role.go:23
 msgid "Manage cluster roles"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:22 lxc/alias.go:23
 msgid "Manage command aliases"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
@@ -3265,12 +3265,12 @@ msgstr ""
 msgid "Mdev profiles:"
 msgstr ""
 
-#: lxc/cluster_role.go:83
+#: lxc/cluster_role.go:86
 #, c-format
 msgid "Member %q already has role %q"
 msgstr ""
 
-#: lxc/cluster_role.go:137
+#: lxc/cluster_role.go:142
 #, c-format
 msgid "Member %q does not have role %q"
 msgstr ""
@@ -3334,21 +3334,21 @@ msgstr ""
 msgid "Missing certificate fingerprint"
 msgstr ""
 
-#: lxc/cluster_group.go:173 lxc/cluster_group.go:228 lxc/cluster_group.go:278
-#: lxc/cluster_group.go:580
+#: lxc/cluster_group.go:178 lxc/cluster_group.go:235 lxc/cluster_group.go:287
+#: lxc/cluster_group.go:598
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:109
-#: lxc/cluster_group.go:463 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:683 lxc/cluster.go:1179 lxc/cluster_group.go:112
+#: lxc/cluster_group.go:477 lxc/cluster_role.go:73 lxc/cluster_role.go:129
 msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/config_metadata.go:103 lxc/config_metadata.go:204
 #: lxc/config_template.go:91 lxc/config_template.go:134
 #: lxc/config_template.go:176 lxc/config_template.go:265
-#: lxc/config_template.go:324 lxc/profile.go:127 lxc/profile.go:200
-#: lxc/profile.go:673 lxc/rebuild.go:59
+#: lxc/config_template.go:324 lxc/profile.go:128 lxc/profile.go:201
+#: lxc/profile.go:684 lxc/rebuild.go:59
 msgid "Missing instance name"
 msgstr ""
 
@@ -3436,8 +3436,8 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:333 lxc/profile.go:387 lxc/profile.go:461 lxc/profile.go:563
-#: lxc/profile.go:749 lxc/profile.go:802 lxc/profile.go:858
+#: lxc/profile.go:344 lxc/profile.go:398 lxc/profile.go:472 lxc/profile.go:574
+#: lxc/profile.go:760 lxc/profile.go:813 lxc/profile.go:869
 msgid "Missing profile name"
 msgstr ""
 
@@ -3446,7 +3446,7 @@ msgstr ""
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:274
+#: lxc/profile.go:277
 msgid "Missing source profile name"
 msgstr ""
 
@@ -3553,14 +3553,14 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:220
+#: lxc/action.go:234
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:421
+#: lxc/cluster.go:183 lxc/cluster.go:925 lxc/cluster_group.go:433
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:963 lxc/network_acl.go:147 lxc/network_peer.go:139
-#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:632
+#: lxc/network_zone.go:138 lxc/network_zone.go:702 lxc/profile.go:643
 #: lxc/project.go:485 lxc/remote.go:729 lxc/storage.go:626
 #: lxc/storage_bucket.go:494 lxc/storage_bucket.go:790
 #: lxc/storage_volume.go:1490
@@ -3906,7 +3906,7 @@ msgstr ""
 msgid "Password for %s: "
 msgstr ""
 
-#: lxc/action.go:48 lxc/action.go:49
+#: lxc/action.go:52 lxc/action.go:53
 msgid "Pause instances"
 msgstr ""
 
@@ -3943,12 +3943,12 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:264
+#: lxc/cluster.go:732 lxc/cluster_group.go:336 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:683
 #: lxc/network_acl.go:582 lxc/network_forward.go:597
 #: lxc/network_load_balancer.go:600 lxc/network_peer.go:573
-#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508
+#: lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
 #: lxc/storage_bucket.go:1057 lxc/storage_volume.go:990
 #: lxc/storage_volume.go:1022
@@ -3986,32 +3986,32 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:149
+#: lxc/profile.go:150
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:346
+#: lxc/profile.go:357
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:397
+#: lxc/profile.go:408
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:683
+#: lxc/profile.go:694
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:719
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:770
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
@@ -4028,7 +4028,7 @@ msgstr ""
 msgid "Profile to apply to the target instance"
 msgstr ""
 
-#: lxc/profile.go:229
+#: lxc/profile.go:230
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster_group.go:439
+#: lxc/cluster_group.go:452
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
@@ -4301,7 +4301,7 @@ msgstr ""
 msgid "Remove a network zone record entry"
 msgstr ""
 
-#: lxc/alias.go:197 lxc/alias.go:198
+#: lxc/alias.go:213 lxc/alias.go:214
 msgid "Remove aliases"
 msgstr ""
 
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Remove instance devices"
 msgstr ""
 
-#: lxc/cluster_group.go:438
+#: lxc/cluster_group.go:451
 msgid "Remove member from group"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Remove ports from a load balancer"
 msgstr ""
 
-#: lxc/profile.go:648 lxc/profile.go:649
+#: lxc/profile.go:659 lxc/profile.go:660
 msgid "Remove profiles from instances"
 msgstr ""
 
@@ -4349,7 +4349,7 @@ msgstr ""
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/cluster_role.go:101 lxc/cluster_role.go:102
+#: lxc/cluster_role.go:105 lxc/cluster_role.go:106
 msgid "Remove roles from a cluster member"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Remove trusted client"
 msgstr ""
 
-#: lxc/cluster_group.go:509 lxc/cluster_group.go:510
+#: lxc/cluster_group.go:524 lxc/cluster_group.go:525
 msgid "Rename a cluster group"
 msgstr ""
 
@@ -4369,7 +4369,7 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:146 lxc/alias.go:147 lxc/image_alias.go:254
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
 #: lxc/image_alias.go:255
 msgid "Rename aliases"
 msgstr ""
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:724 lxc/profile.go:725
+#: lxc/profile.go:735 lxc/profile.go:736
 msgid "Rename profiles"
 msgstr ""
 
@@ -4428,11 +4428,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:69
+#: lxc/action.go:75
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:70
+#: lxc/action.go:76
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4488,7 +4488,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/action.go:112
+#: lxc/action.go:122
 msgid "Run against all instances"
 msgstr ""
 
@@ -4714,11 +4714,11 @@ msgstr ""
 msgid "Set network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:774
+#: lxc/profile.go:785
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:775
+#: lxc/profile.go:786
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -4807,7 +4807,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/cluster_group.go:555 lxc/cluster_group.go:556
+#: lxc/cluster_group.go:572 lxc/cluster_group.go:573
 msgid "Show cluster group configurations"
 msgstr ""
 
@@ -4891,7 +4891,7 @@ msgstr ""
 msgid "Show network zone record configurations"
 msgstr ""
 
-#: lxc/profile.go:833 lxc/profile.go:834
+#: lxc/profile.go:844 lxc/profile.go:845
 msgid "Show profile configurations"
 msgstr ""
 
@@ -4990,7 +4990,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:386
+#: lxc/action.go:402
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/action.go:29 lxc/action.go:30
+#: lxc/action.go:31 lxc/action.go:32
 msgid "Start instances"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:90 lxc/action.go:91
+#: lxc/action.go:98 lxc/action.go:99
 msgid "Stop instances"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:115
+#: lxc/action.go:125
 msgid "Store the instance state"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:130
+#: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
 
@@ -5279,7 +5279,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:127
+#: lxc/action.go:137
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5359,7 +5359,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:274 lxc/launch.go:110
+#: lxc/action.go:288 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -5406,7 +5406,7 @@ msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:969 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:634 lxc/project.go:493 lxc/storage.go:635
+#: lxc/profile.go:645 lxc/project.go:493 lxc/storage.go:635
 #: lxc/storage_volume.go:1493
 msgid "USED BY"
 msgstr ""
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Unset network zone record configuration keys"
 msgstr ""
 
-#: lxc/profile.go:887 lxc/profile.go:888
+#: lxc/profile.go:898 lxc/profile.go:899
 msgid "Unset profile configuration keys"
 msgstr ""
 
@@ -5562,6 +5562,10 @@ msgstr ""
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
+msgstr ""
+
+#: lxc/profile.go:253
+msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
 #: lxc/image.go:955
@@ -5704,10 +5708,10 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:364
+#: lxc/cluster.go:119 lxc/cluster.go:839 lxc/cluster_group.go:375
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:892 lxc/network_acl.go:91 lxc/network_zone.go:82
-#: lxc/operation.go:101 lxc/profile.go:585 lxc/project.go:394
+#: lxc/operation.go:101 lxc/profile.go:596 lxc/project.go:394
 #: lxc/storage.go:571 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
@@ -5801,12 +5805,12 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/cluster_group.go:147 lxc/cluster_group.go:201 lxc/cluster_group.go:252
-#: lxc/cluster_group.go:554
+#: lxc/cluster_group.go:151 lxc/cluster_group.go:207 lxc/cluster_group.go:260
+#: lxc/cluster_group.go:571
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/cluster_group.go:507
+#: lxc/cluster_group.go:522
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
@@ -5867,11 +5871,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
-#: lxc/profile.go:101 lxc/profile.go:647
+#: lxc/profile.go:102 lxc/profile.go:658
 msgid "[<remote>:]<instance> <profile>"
 msgstr ""
 
-#: lxc/profile.go:163
+#: lxc/profile.go:164
 msgid "[<remote>:]<instance> <profiles>"
 msgstr ""
 
@@ -5888,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:28 lxc/action.go:47 lxc/action.go:68 lxc/action.go:89
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:74 lxc/action.go:97
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -5939,7 +5943,7 @@ msgstr ""
 msgid "[<remote>:]<member>"
 msgstr ""
 
-#: lxc/cluster_group.go:75 lxc/cluster_group.go:437
+#: lxc/cluster_group.go:77 lxc/cluster_group.go:450
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
@@ -5955,7 +5959,7 @@ msgstr ""
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/cluster_role.go:46 lxc/cluster_role.go:100
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:104
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
@@ -6174,8 +6178,8 @@ msgstr ""
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:307
-#: lxc/profile.go:360 lxc/profile.go:411 lxc/profile.go:832
+#: lxc/config_device.go:290 lxc/config_device.go:664 lxc/profile.go:318
+#: lxc/profile.go:371 lxc/profile.go:422 lxc/profile.go:843
 msgid "[<remote>:]<profile>"
 msgstr ""
 
@@ -6191,11 +6195,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:537 lxc/profile.go:886
+#: lxc/profile.go:548 lxc/profile.go:897
 msgid "[<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/profile.go:773
+#: lxc/profile.go:784
 msgid "[<remote>:]<profile> <key><value>..."
 msgstr ""
 
@@ -6203,11 +6207,11 @@ msgstr ""
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
-#: lxc/profile.go:722
+#: lxc/profile.go:733
 msgid "[<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/profile.go:245
+#: lxc/profile.go:247
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -6304,7 +6308,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:378
+#: lxc/action.go:394
 #, c-format
 msgid "error: %v"
 msgstr ""
@@ -6313,19 +6317,19 @@ msgstr ""
 msgid "info"
 msgstr ""
 
-#: lxc/alias.go:58
+#: lxc/alias.go:62
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:200
+#: lxc/alias.go:216
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:149
+#: lxc/alias.go:161
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -6337,7 +6341,7 @@ msgid ""
 "    Update a cluster member using the content of member.yaml"
 msgstr ""
 
-#: lxc/cluster_group.go:80
+#: lxc/cluster_group.go:82
 msgid ""
 "lxc cluster group assign foo default,bar\n"
 "    Set the groups for \"foo\" to \"default\" and \"bar\".\n"
@@ -6502,7 +6506,7 @@ msgid ""
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:168
+#: lxc/profile.go:169
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -6525,7 +6529,7 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:426
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -320,8 +320,15 @@ test_projects_profiles() {
 
   # Try project copy
   lxc project create foo
+  lxc profile set --project default default user.x z
   lxc profile copy --project default --target-project foo default bar
+  # copy to an existing profile without --refresh should fail
+  ! lxc profile copy --project default --target-project foo default bar
+  lxc profile copy --project default --target-project foo default bar --refresh
+  lxc profile get --project foo bar user.x | grep -q 'z'
+  lxc profile copy --project default --target-project foo default bar-non-existent --refresh
   lxc profile delete bar --project foo
+  lxc profile delete bar-non-existent --project foo
   lxc project delete foo
 }
 


### PR DESCRIPTION
lxc profile copy command would refuse to update a profile if it
already exist by sending an error message to the user. There are
cases where we want to update the target profile anyway.
This change adds the --refresh flag which allow to update an
existing target profile with the details of the source one.

resolve https://github.com/canonical/lxd/issues/11819