### PR TITLE
lxd/storage/drivers/zfs: Fix content type detection for custom block volumes

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1842,16 +1842,19 @@ func (d *zfs) ListVolumes() ([]Volume, error) {
 			continue // Ignore unrecognised volume.
 		}
 
-		// Detect if a volume is block content type using both the defined suffix and the dataset type.
-		isBlock := strings.HasSuffix(volName, zfsBlockVolSuffix) && zfsContentType == "volume"
+		// Detect if a volume is block content type using only the dataset type.
+		isBlock := zfsContentType == "volume"
 
 		if volType == VolumeTypeVM && !isBlock {
 			continue // Ignore VM filesystem volumes as we will just return the VM's block volume.
 		}
 
 		contentType := ContentTypeFS
-		if volType == VolumeTypeVM || isBlock {
+		if isBlock {
 			contentType = ContentTypeBlock
+		}
+
+		if volType == VolumeTypeVM || isBlock {
 			volName = strings.TrimSuffix(volName, zfsBlockVolSuffix)
 		}
 
@@ -1863,7 +1866,7 @@ func (d *zfs) ListVolumes() ([]Volume, error) {
 		if !foundExisting || (existingVol.Type() == VolumeTypeImage && existingVol.ContentType() == ContentTypeFS) {
 			v := NewVolume(d, d.name, volType, contentType, volName, make(map[string]string), d.config)
 
-			if zfsContentType == "volume" {
+			if isBlock {
 				v.SetMountFilesystemProbe(true)
 			}
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -345,6 +345,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_filtering "API filtering"
     run_test test_warnings "Warnings"
     run_test test_metrics "Metrics"
+    run_test test_storage_volume_recover "Recover storage volumes"
 fi
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
This fixes an issue where custom block volumes would be listed as
datasets instead of volumes.

Fixes #11984

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
