### PR TITLE
doc: update to use the ubuntu: image server

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -4,5 +4,5 @@
 :maxdepth: 1
 
 Project repository <https://github.com/canonical/lxd>
-Image server <https://images.linuxcontainers.org>
+Community image server <https://images.linuxcontainers.org>
 ```

--- a/doc/howto/benchmark_performance.md
+++ b/doc/howto/benchmark_performance.md
@@ -44,14 +44,14 @@ Local image
 
   To do so, run a command similar to the following and specify the fingerprint (for example, `2d21da400963`) of the image when you run `lxd.benchmark`:
 
-      lxc image copy images:ubuntu/22.04 local:
+      lxc image copy ubuntu:22.04 local:
 
   You can also assign an alias to the image and specify that alias (for example, `ubuntu`) when you run `lxd.benchmark`:
 
-      lxc image copy images:ubuntu/22.04 local: --alias ubuntu
+      lxc image copy ubuntu:22.04 local: --alias ubuntu
 
 Remote image
-: If you want to include the download time in the overall result, specify a remote image (for example, `images:ubuntu/22.04`).
+: If you want to include the download time in the overall result, specify a remote image (for example, `ubuntu:22.04`).
   The default image that `lxd.benchmark` uses is the latest Ubuntu image (`ubuntu:`), so if you want to use this image, you can leave out the image name when running the tool.
 
 ### Create and launch containers

--- a/doc/howto/images_copy.md
+++ b/doc/howto/images_copy.md
@@ -36,7 +36,7 @@ There are several ways of obtaining such image files:
 
 - Exporting an existing image (see {ref}`images-manage-export`)
 - Building your own image using `distrobuilder` (see {ref}`images-create-build`)
-- Downloading image files from the [image server](https://images.linuxcontainers.org/images/) (note that it is usually easier to {ref}`use the remote image <images-remote>` directly instead of downloading it to a file and importing it)
+- Downloading image files from a {ref}`remote image server <remote-image-servers>` (note that it is usually easier to {ref}`use the remote image <images-remote>` directly instead of downloading it to a file and importing it)
 
 ### Import from the local file system
 

--- a/doc/howto/images_manage.md
+++ b/doc/howto/images_manage.md
@@ -16,19 +16,19 @@ If you do not specify a remote, the {ref}`default remote <images-remote-default>
 ### Filter available images
 
 To filter the results that are displayed, specify a part of the alias or fingerprint after the command.
-For example, to show all Debian images, enter the following command:
+For example, to show all Ubuntu 22.04 images, enter the following command:
 
-    lxc image list images: debian
+    lxc image list ubuntu: 22.04
 
 You can specify several filters as well.
-For example, to show all 64-bit Debian images, enter the following command:
+For example, to show all Arm 64-bit Ubuntu 22.04 images, enter the following command:
 
-    lxc image list images: debian amd64
+    lxc image list ubuntu: 22.04 arm64
 
 To filter for properties other than alias or fingerprint, specify the filter in `<key>=<value>` format.
 For example:
 
-    lxc image list images: debian architecture=x86_64
+    lxc image list ubuntu: 22.04 architecture=x86_64
 
 ## View image information
 
@@ -37,7 +37,7 @@ To view information about an image, enter the following command:
     lxc image info <image_ID>
 
 As the image ID, you can specify either the image's alias or its fingerprint.
-For a remote image, remember to include the remote server (for example, `images:ubuntu/22.04`).
+For a remote image, remember to include the remote server (for example, `ubuntu:22.04`).
 
 To display only the image properties, enter the following command:
 

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -59,8 +59,8 @@ You are prompted to confirm the remote server fingerprint and then asked for the
 To reference an image, specify its remote and its alias or fingerprint, separated with a colon.
 For example:
 
-    images:ubuntu/22.04
     ubuntu:22.04
+    images:ubuntu/22.04
     local:ed7509d7e83f
 
 (images-remote-default)=

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -15,7 +15,7 @@ Image
   Images for various operating systems are available on the built-in remote image servers.
   See {ref}`images` for more information.
 
-  Unless the image is available locally, you must specify the name of the image server and the name of the image (for example, `images:ubuntu/22.04` for the 22.04 Ubuntu image from LXD's community image server).
+  Unless the image is available locally, you must specify the name of the image server and the name of the image (for example, `ubuntu:22.04` for the official 22.04 Ubuntu image).
 
 Instance name
 : Instance names must be unique within a LXD deployment (also within a cluster).

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -8,12 +8,6 @@ relatedlinks: https://www.youtube.com/watch?v=pM0EgUqj2a0
 
 The `lxc` CLI command comes pre-configured with the following default remote image servers:
 
-`images:`
-: This server provides unofficial images for a variety of Linux distributions.
-  The images are maintained by the LXD team and are built to be compact and minimal.
-
-  See [`images.linuxcontainers.org`](https://images.linuxcontainers.org) for an overview of available images.
-
 `ubuntu:`
 : This server provides official stable Ubuntu images.
   All images are cloud images, which means that they include both `cloud-init` and the `lxd-agent`.
@@ -25,6 +19,12 @@ The `lxc` CLI command comes pre-configured with the following default remote ima
   All images are cloud images, which means that they include both `cloud-init` and the `lxd-agent`.
 
   See [`cloud-images.ubuntu.com/daily`](https://cloud-images.ubuntu.com/daily/) for an overview of available images.
+
+`images:`
+: This server provides unofficial images for a variety of Linux distributions.
+  The images are maintained by the [Linux Containers](https://linuxcontainers.org/) team and are built to be compact and minimal.
+
+  See [`images.linuxcontainers.org`](https://images.linuxcontainers.org) for an overview of available images.
 
 (remote-image-server-types)=
 ## Remote server types


### PR DESCRIPTION
In examples, use the ubuntu: image server instead of the images: server.