### PR TITLE
Apply MemberConfig to storage config table

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -468,23 +468,23 @@ func Join(state *state.State, gateway *Gateway, networkCert *shared.CertInfo, se
 				return fmt.Errorf("Failed to get storage pool driver: %w", err)
 			}
 
+			// For all pools we add the config provided by the joining node.
+			config, ok := pools[name]
+			if !ok {
+				return fmt.Errorf("Joining member has no config for pool %s", name)
+			}
+
+			err = tx.CreateStoragePoolConfig(id, node.ID, config)
+			if err != nil {
+				return fmt.Errorf("Failed to add joining node's pool config: %w", err)
+			}
+
 			if shared.StringInSlice(driver, []string{"ceph", "cephfs"}) {
 				// For ceph pools we have to create volume
 				// entries for the joining node.
 				err := tx.UpdateCephStoragePoolAfterNodeJoin(ctx, id, node.ID)
 				if err != nil {
 					return fmt.Errorf("Failed to create ceph volumes for joining node: %w", err)
-				}
-			} else {
-				// For other pools we add the config provided by the joining node.
-				config, ok := pools[name]
-				if !ok {
-					return fmt.Errorf("Joining member has no config for pool %s", name)
-				}
-
-				err = tx.CreateStoragePoolConfig(id, node.ID, config)
-				if err != nil {
-					return fmt.Errorf("Failed to add joining node's pool config: %w", err)
 				}
 			}
 		}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -671,18 +671,17 @@ test_clustering_storage() {
     ! stat "${LXD_TWO_SOURCE}/containers" || false
   fi
 
-  # Define storage pools on the two nodes
+  # Set up node-specific storage pool keys for the selected backend.
   driver_config=""
-  if [ "${poolDriver}" = "btrfs" ]; then
+  if [ "${poolDriver}" = "btrfs" ] || [ "${poolDriver}" = "lvm" ] || [ "${poolDriver}" = "zfs" ]; then
       driver_config="size=1GiB"
   fi
-  if [ "${poolDriver}" = "zfs" ]; then
-      driver_config="size=1GiB"
-  fi
+
   if [ "${poolDriver}" = "ceph" ]; then
       driver_config="source=lxdtest-$(basename "${TEST_DIR}")-pool1"
   fi
 
+  # Define storage pools on the two nodes
   driver_config_node1="${driver_config}"
   driver_config_node2="${driver_config}"
 
@@ -780,14 +779,45 @@ test_clustering_storage() {
     LXD_DIR="${LXD_TWO_DIR}" lxc start egg
     LXD_DIR="${LXD_ONE_DIR}" lxc stop egg --force
     LXD_DIR="${LXD_ONE_DIR}" lxc delete egg
+  fi
 
+  # If the driver has the same per-node storage pool config (e.g. size), make sure it's included in the
+  # member_config, and actually added to a joining node so we can validate it.
+  if [ "${poolDriver}" = "zfs" ] || [ "${poolDriver}" = "btrfs" ] || [ "${poolDriver}" = "ceph" ] || [ "${poolDriver}" = "lvm" ]; then
     # Spawn a third node
     setup_clustering_netns 3
     LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_THREE_DIR}"
     ns3="${prefix}3"
-    spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${poolDriver}"
+    LXD_NETNS="${ns3}" spawn_lxd "${LXD_THREE_DIR}" false
 
+    key=$(echo "${driver_config}" | cut -d'=' -f1)
+    value=$(echo "${driver_config}" | cut -d'=' -f2-)
+
+    # Set member_config to match `spawn_lxd_and_join_cluster` for 'data' and `driver_config` for 'pool1'.
+    member_config="{\"entity\": \"storage-pool\",\"name\":\"pool1\",\"key\":\"${key}\",\"value\":\"${value}\"}"
+    if [ "${poolDriver}" = "zfs" ] || [ "${poolDriver}" = "btrfs" ] || [ "${poolDriver}" = "lvm" ] ; then
+      member_config="{\"entity\": \"storage-pool\",\"name\":\"data\",\"key\":\"size\",\"value\":\"1GiB\"},${member_config}"
+    fi
+
+    # Manually send the join request.
+    cert=$(sed ':a;N;$!ba;s/\n/\\n/g' "${LXD_ONE_DIR}/cluster.crt")
+    op=$(curl --unix-socket "${LXD_THREE_DIR}/unix.socket" -X PUT "lxd/1.0/cluster" -d "{\"server_name\":\"node3\",\"enabled\":true,\"member_config\":[${member_config}],\"server_address\":\"10.1.1.103:8443\",\"cluster_address\":\"10.1.1.101:8443\",\"cluster_certificate\":\"${cert}\",\"cluster_password\":\"sekret\"}" | jq -r .operation)
+    curl --unix-socket "${LXD_THREE_DIR}/unix.socket" "lxd${op}/wait"
+
+    # Ensure that node-specific config appears on all nodes,
+    # regardless of the pool being created before or after the node joined.
+    for n in node1 node2 node3 ; do
+      LXD_DIR="${LXD_ONE_DIR}" lxc storage get pool1 "${key}" --target "${n}" | grep -q "${value}"
+    done
+
+    # Other storage backends will be finished with the third node, so we can remove it.
+    if [ "${poolDriver}" != "ceph" ]; then
+      LXD_DIR="${LXD_ONE_DIR}" lxc cluster remove node3 --yes
+    fi
+  fi
+
+  if [ "${poolDriver}" = "ceph" ]; then
     # Move the container to node3, renaming it
     LXD_DIR="${LXD_TWO_DIR}" lxc move foo bar --target node3
     LXD_DIR="${LXD_TWO_DIR}" lxc info bar | grep -q "Location: node3"


### PR DESCRIPTION
There are some target-specific storage pool keys (i.e. source) that are applied to the driver, but not saved to the database when specified in a joining cluster member's MemberConfig data.

This commit ensures all node-specific keys supplied in MemberConfig are applied to the database appropriately.

I'm not sure on the reasoning for why they were explicitly skipped before, but given that that these config keys would exist on a storage pool created on an existing cluster, it stands to reason that adding the storage pool via `MemberConfig` should properly apply these too.
