### PR TITLE
lxd/device/gpu: if `gputype=physical`, check that no processes are tied to the card before unbinding it

### DIFF
--- a/lxd/device/device_utils_generic.go
+++ b/lxd/device/device_utils_generic.go
@@ -1,7 +1,12 @@
 package device
 
 import (
+	"bufio"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/canonical/lxd/shared"
@@ -20,4 +25,40 @@ func validatePCIDevice(address string) error {
 	}
 
 	return nil
+}
+
+// checkAttachedRunningProcess checks if a device is tied to running processes.
+func checkAttachedRunningProcesses(devicePath string) ([]string, error) {
+	var processes []string
+	procDir := "/proc"
+	files, err := ioutil.ReadDir(procDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read /proc directory: %w", err)
+	}
+
+	for _, file := range files {
+		// Check if the directory name is a number (i.e., a PID).
+		_, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+
+		mapsFile := filepath.Join(procDir, file.Name(), "maps")
+		f, err := os.Open(mapsFile)
+		if err != nil {
+			continue // If we can't read a process's maps file, skip it.
+		}
+
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), devicePath) {
+				processes = append(processes, file.Name())
+				break
+			}
+		}
+	}
+
+	return processes, nil
 }


### PR DESCRIPTION
closes #11959 