### PR TITLE
Ensures golangci-lint is latest release version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,6 @@ jobs:
             shellcheck
 
           python3 -m pip install flake8
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
 
       - name: Download go dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ build-mo: $(MOFILES)
 .PHONY: static-analysis
 static-analysis:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
 endif
 ifeq ($(shell command -v shellcheck 2> /dev/null),)
 	echo "Please install shellcheck"

--- a/lxc-to-lxd/main.go
+++ b/lxc-to-lxd/main.go
@@ -42,6 +42,7 @@ __attribute__((constructor)) void init(void) {
 }
 */
 import "C"
+
 import (
 	"os"
 

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -1,27 +1,5 @@
 package main
 
-import (
-	"fmt"
-	"os"
-	"path"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
-
-	"golang.org/x/sys/unix"
-
-	"github.com/canonical/lxd/lxd/cgroup"
-	"github.com/canonical/lxd/lxd/device"
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/lxd/instance"
-	"github.com/canonical/lxd/lxd/instance/instancetype"
-	"github.com/canonical/lxd/lxd/resources"
-	"github.com/canonical/lxd/lxd/state"
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/logger"
-)
-
 /*
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -53,6 +31,28 @@ static int get_hidraw_devinfo(int fd, struct hidraw_devinfo *info)
 
 */
 import "C"
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/cgroup"
+	"github.com/canonical/lxd/lxd/device"
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/lxd/resources"
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+)
 
 type deviceTaskCPU struct {
 	id    int64

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2327,8 +2327,8 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 		}
 
 		allImages = make(map[string][]dbCluster.Image, len(images))
-		for i := range images {
-			allImages[images[i].Fingerprint] = append(allImages[images[i].Fingerprint], images[i])
+		for _, image := range images {
+			allImages[image.Fingerprint] = append(allImages[image.Fingerprint], image)
 		}
 
 		return nil

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -1,16 +1,5 @@
 package main
 
-import (
-	"os"
-	"runtime"
-
-	"golang.org/x/sys/unix"
-
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/logger"
-)
-
 /*
 #include "config.h"
 
@@ -588,6 +577,17 @@ static bool kernel_supports_idmapped_mounts(void)
 }
 */
 import "C"
+
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+)
 
 func canUseNetnsGetifaddrs() bool {
 	if !bool(C.is_empty_string(&C.errbuf[0])) {

--- a/lxd/main_forkcoresched.go
+++ b/lxd/main_forkcoresched.go
@@ -1,14 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	// Used by cgo
-	_ "github.com/canonical/lxd/lxd/include"
-)
-
 /*
 #include "config.h"
 
@@ -91,6 +82,15 @@ void forkcoresched(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// Used by cgo
+	_ "github.com/canonical/lxd/lxd/include"
+)
 
 type cmdForkcoresched struct {
 	global *cmdGlobal

--- a/lxd/main_forkexec.go
+++ b/lxd/main_forkexec.go
@@ -1,14 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	// Used by cgo
-	_ "github.com/canonical/lxd/lxd/include"
-)
-
 /*
 #include "config.h"
 
@@ -335,6 +326,15 @@ void forkexec(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// Used by cgo
+	_ "github.com/canonical/lxd/lxd/include"
+)
 
 type cmdForkexec struct {
 	global *cmdGlobal

--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -1,18 +1,5 @@
 package main
 
-import (
-	"net"
-	"os"
-	"os/signal"
-	"strconv"
-	"sync"
-	"time"
-
-	"github.com/pkg/sftp"
-	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
-)
-
 /*
 #include "config.h"
 
@@ -96,6 +83,19 @@ void forkfile(void)
 }
 */
 import "C"
+
+import (
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+)
 
 type cmdForkfile struct {
 	global *cmdGlobal

--- a/lxd/main_forkmount.go
+++ b/lxd/main_forkmount.go
@@ -1,14 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	// Used by cgo
-	_ "github.com/canonical/lxd/lxd/include"
-)
-
 /*
 #include "config.h"
 
@@ -657,6 +648,15 @@ void forkmount(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// Used by cgo
+	_ "github.com/canonical/lxd/lxd/include"
+)
 
 type cmdForkmount struct {
 	global *cmdGlobal

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -1,17 +1,5 @@
 package main
 
-import (
-	"encoding/json"
-	"fmt"
-	"net"
-
-	"github.com/spf13/cobra"
-
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/lxd/ip"
-	"github.com/canonical/lxd/shared/netutils"
-)
-
 /*
 #include "config.h"
 
@@ -113,6 +101,18 @@ void forknet(void)
 }
 */
 import "C"
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/spf13/cobra"
+
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/lxd/ip"
+	"github.com/canonical/lxd/shared/netutils"
+)
 
 type cmdForknet struct {
 	global *cmdGlobal

--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -1,28 +1,5 @@
 package main
 
-import (
-	"fmt"
-	"io"
-	"net"
-	"os"
-	"os/signal"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-	"unsafe"
-
-	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
-
-	"github.com/canonical/lxd/lxd/daemon"
-	deviceConfig "github.com/canonical/lxd/lxd/device/config"
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/lxd/network"
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/netutils"
-)
-
 /*
 #include "config.h"
 
@@ -262,6 +239,29 @@ void forkproxy(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/daemon"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/lxd/network"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/netutils"
+)
 
 const forkproxyUDSSockFDNum int = C.FORKPROXY_UDS_SOCK_FD_NUM
 

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -1,14 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	// Used by cgo
-	_ "github.com/canonical/lxd/lxd/include"
-)
-
 /*
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -661,6 +652,15 @@ void forksyscall(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	// Used by cgo
+	_ "github.com/canonical/lxd/lxd/include"
+)
 
 type cmdForksyscall struct {
 	global *cmdGlobal

--- a/lxd/main_forkuevent.go
+++ b/lxd/main_forkuevent.go
@@ -1,11 +1,5 @@
 package main
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
-
 /*
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -219,6 +213,12 @@ void forkuevent(void)
 }
 */
 import "C"
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 type cmdForkuevent struct {
 	global *cmdGlobal

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -18,11 +18,6 @@
  */
 package main
 
-import (
-	// Used by cgo
-	_ "github.com/canonical/lxd/lxd/include"
-)
-
 /*
 #include "config.h"
 
@@ -362,3 +357,8 @@ __attribute__((constructor)) void init(void) {
 }
 */
 import "C"
+
+import (
+	// Used by cgo
+	_ "github.com/canonical/lxd/lxd/include"
+)

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -2,39 +2,6 @@
 
 package seccomp
 
-import (
-	"context"
-	"fmt"
-	"io"
-	"net"
-	"os"
-	"path"
-	"regexp"
-	"runtime"
-	"strconv"
-	"strings"
-	"time"
-	"unsafe"
-
-	liblxc "github.com/lxc/go-lxc"
-	"golang.org/x/sys/unix"
-
-	"github.com/canonical/lxd/lxd/cgroup"
-	deviceConfig "github.com/canonical/lxd/lxd/device/config"
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/lxd/project"
-	"github.com/canonical/lxd/lxd/state"
-	"github.com/canonical/lxd/lxd/ucred"
-	"github.com/canonical/lxd/lxd/util"
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/idmap"
-	"github.com/canonical/lxd/shared/linux"
-	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/netutils"
-	"github.com/canonical/lxd/shared/osarch"
-)
-
 /*
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -475,6 +442,39 @@ static int handle_bpf_syscall(pid_t pid_target, int notify_fd, int mem_fd,
 #endif
 */
 import "C"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	liblxc "github.com/lxc/go-lxc"
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/cgroup"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/lxd/project"
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/lxd/ucred"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/idmap"
+	"github.com/canonical/lxd/shared/linux"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/netutils"
+	"github.com/canonical/lxd/shared/osarch"
+)
 
 const lxdSeccompNotifyMknod = C.LXD_SECCOMP_NOTIFY_MKNOD
 const lxdSeccompNotifyMknodat = C.LXD_SECCOMP_NOTIFY_MKNODAT

--- a/lxd/storage/quota/projectquota.go
+++ b/lxd/storage/quota/projectquota.go
@@ -1,18 +1,5 @@
 package quota
 
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
-
-	"github.com/canonical/lxd/shared"
-)
-
 /*
 #include <linux/fs.h>
 #include <linux/dqblk_xfs.h>
@@ -164,6 +151,19 @@ int32_t quota_get_path(char *path) {
 
 */
 import "C"
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/shared"
+)
 
 var errNoDevice = fmt.Errorf("Couldn't find backing device for mountpoint")
 

--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -119,7 +119,6 @@ func ServerTLSConfig(cert *shared.CertInfo) *tls.Config {
 		logger.Infof("LXD is in CA mode, only CA-signed certificates will be allowed")
 	}
 
-	config.BuildNameToCertificate()
 	return config
 }
 

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -2,19 +2,6 @@
 
 package idmap
 
-import (
-	"fmt"
-	"os"
-	"os/exec"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
-
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-	"github.com/canonical/lxd/shared"
-	"github.com/canonical/lxd/shared/logger"
-)
-
 // #cgo LDFLAGS: -lacl
 /*
 #ifndef _GNU_SOURCE
@@ -352,6 +339,19 @@ static int create_detached_idmapped_mount(const char *path, const char *fstype)
 }
 */
 import "C"
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+)
 
 // ShiftOwner updates uid and gid for a file when entering/exiting a namespace
 func ShiftOwner(basepath string, path string, uid int, gid int) error {

--- a/shared/linux/socket_linux_cgo.go
+++ b/shared/linux/socket_linux_cgo.go
@@ -2,15 +2,6 @@
 
 package linux
 
-import (
-	"fmt"
-	"os"
-
-	"golang.org/x/sys/unix"
-
-	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
-)
-
 /*
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE 1
@@ -53,6 +44,15 @@ again:
 }
 */
 import "C"
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+
+	_ "github.com/canonical/lxd/lxd/include" // Used by cgo
+)
 
 const ABSTRACT_UNIX_SOCK_LEN int = C.ABSTRACT_UNIX_SOCK_LEN
 

--- a/shared/netutils/network_linux_cgo.go
+++ b/shared/netutils/network_linux_cgo.go
@@ -2,6 +2,12 @@
 
 package netutils
 
+/*
+#include "unixfd.h"
+#include "netns_getifaddrs.c"
+*/
+import "C"
+
 import (
 	"fmt"
 	"io"
@@ -12,12 +18,6 @@ import (
 
 	"github.com/canonical/lxd/shared/api"
 )
-
-/*
-#include "unixfd.h"
-#include "netns_getifaddrs.c"
-*/
-import "C"
 
 // Allow the caller to set expectations.
 

--- a/shared/network.go
+++ b/shared/network.go
@@ -95,8 +95,6 @@ func finalizeTLSConfig(tlsConfig *tls.Config, tlsRemoteCert *x509.Certificate) {
 			tlsConfig.ServerName = tlsRemoteCert.DNSNames[0]
 		}
 	}
-
-	tlsConfig.BuildNameToCertificate()
 }
 
 func GetTLSConfig(tlsClientCertFile string, tlsClientKeyFile string, tlsClientCAFile string, tlsRemoteCert *x509.Certificate) (*tls.Config, error) {


### PR DESCRIPTION
The PR ensures golangci-lint is the latest version when running in CI. If lint errors occur in CI that a developer did not encounter locally, they can check against the latest version with `rm $GOPATH/bin/golangci-lint && make static-analysis`.

It looks like the `gci` linter has changed a little and is unhappy with any files containing GCO. It is possible to reorder the imports to make this pass but I found the change less clear so I have excluded any files containing CGO from `gci` linting (other linters will still run).

Partially addresses #12011 