### PR TITLE
doc/rest-api: Use JSON object as term instead of dict 

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -765,7 +765,7 @@ and `<@hourly> <@daily> <@midnight> <@weekly> <@monthly> <@annually> <@yearly>` 
 
 ## `container_copy_project`
 
-Introduces a `project` field to the container source dict, allowing for
+Introduces a `project` field to the container source JSON object, allowing for
 copy/move of containers between projects.
 
 ## `clustering_server_address`

--- a/doc/dev-lxd.md
+++ b/doc/dev-lxd.md
@@ -79,7 +79,7 @@ Return value:
 ##### GET
 
 * Description: Information about the 1.0 API
-* Return: dict
+* Return: JSON object
 
 Return value:
 
@@ -143,7 +143,7 @@ Return value:
 ##### GET
 
 * Description: Map of instance devices
-* Return: dict
+* Return: JSON object
 
 Return value:
 
@@ -178,7 +178,7 @@ The notification types are:
 * `config` (changes to any of the `user.*` configuration keys)
 * `device` (any device addition, change or removal)
 
-This never returns. Each notification is sent as a separate JSON dict:
+This never returns. Each notification is sent as a separate JSON object:
 
 ```json
 {

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -34,7 +34,7 @@ There are three standard return types:
 
 ### Standard return value
 
-For a standard synchronous operation, the following dict is returned:
+For a standard synchronous operation, the following JSON object is returned:
 
 ```js
 {
@@ -52,7 +52,7 @@ HTTP code must be 200.
 When a request results in a background operation, the HTTP code is set to 202 (Accepted)
 and the Location HTTP header is set to the operation URL.
 
-The body is a dict with the following structure:
+The body is a JSON object with the following structure:
 
 ```js
 {
@@ -162,7 +162,7 @@ A `recursion` argument can be passed to a GET query against a collection.
 
 The default value is 0 which means that collection member URLs are
 returned. Setting it to 1 will have those URLs be replaced by the object
-they point to (typically a dict).
+they point to (typically another JSON object).
 
 Recursion is implemented by simply replacing any pointer to an job (URL)
 by the object itself.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -11929,7 +11929,7 @@ paths:
                 - networks
     /1.0/operations:
         get:
-            description: Returns a dict of operation type to operation list (URLs).
+            description: Returns a JSON object of operation type to operation list (URLs).
             operationId: operations_get
             produces:
                 - application/json
@@ -11944,7 +11944,7 @@ paths:
                                     items:
                                         type: string
                                     type: array
-                                description: Dict of operation types to operation URLs
+                                description: JSON object of operation types to operation URLs
                                 example: |-
                                     {
                                       "running": [

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2066,7 +2066,7 @@ definitions:
             disk:
                 additionalProperties:
                     $ref: '#/definitions/InstanceStateDisk'
-                description: Dict of disk usage
+                description: Disk usage key/value pairs
                 type: object
                 x-go-name: Disk
             memory:
@@ -2074,7 +2074,7 @@ definitions:
             network:
                 additionalProperties:
                     $ref: '#/definitions/InstanceStateNetwork'
-                description: Dict of network usage
+                description: Network usage key/value pairs
                 type: object
                 x-go-name: Network
             pid:
@@ -4631,7 +4631,7 @@ definitions:
             entries:
                 additionalProperties:
                     type: string
-                description: Dict of vendor provided key/value pairs.
+                description: Vendor provided key/value pairs.
                 example: '{"EC": ""A-5545", "MN": "103C", "V0": "5W PCIeGen2"}'
                 type: object
                 x-go-name: Entries

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -368,7 +368,7 @@ func operationCancel(s *state.State, r *http.Request, projectName string, op *ap
 //
 //  Get the operations
 //
-//  Returns a dict of operation type to operation list (URLs).
+//  Returns a JSON object of operation type to operation list (URLs).
 //
 //  ---
 //  produces:
@@ -398,7 +398,7 @@ func operationCancel(s *state.State, r *http.Request, projectName string, op *ap
 //              type: array
 //              items:
 //                type: string
-//            description: Dict of operation types to operation URLs
+//            description: JSON object of operation types to operation URLs
 //            example: |-
 //              {
 //                "running": [

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -37,13 +37,13 @@ type InstanceState struct {
 	// Example: 101
 	StatusCode StatusCode `json:"status_code" yaml:"status_code"`
 
-	// Dict of disk usage
+	// Disk usage key/value pairs
 	Disk map[string]InstanceStateDisk `json:"disk" yaml:"disk"`
 
 	// Memory usage information
 	Memory InstanceStateMemory `json:"memory" yaml:"memory"`
 
-	// Dict of network usage
+	// Network usage key/value pairs
 	Network map[string]InstanceStateNetwork `json:"network" yaml:"network"`
 
 	// PID of the runtime

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -969,7 +969,7 @@ type ResourcesPCIVPD struct {
 	// Example: HP Ethernet 1Gb 4-port 331i Adapter
 	ProductName string `json:"product_name,omitempty" yaml:"product_name,omitempty"`
 
-	// Dict of vendor provided key/value pairs.
+	// Vendor provided key/value pairs.
 	// Example: {"EC": ""A-5545", "MN": "103C", "V0": "5W PCIeGen2"}
 	Entries map[string]string `json:"entries,omitempty" yaml:"entries,omitempty"`
 }


### PR DESCRIPTION
The REST API returns responses in JSON format, and [JSON](https://www.json.org/json-en.html) does not specify the term `dict` but `object` instead. This PR changes the API documentation to use the exact term from the JSON specification. Although the term `dict` may be familiar to many technical people (especially in the Python community), the term `dict` may be confusing to other users of the REST API.