### PR TITLE
doc: explicitly state title of related link

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://dqlite.io/, https://github.com/canonical/dqlite
+relatedlinks: "[Canonical&#32;Dqlite](https://dqlite.io/), https://github.com/canonical/dqlite"
 ---
 
 (database)=


### PR DESCRIPTION
For some reason, the title cannot be extracted reliably, so state it explicitly.