### PR TITLE
instancewriter: Use right header key for tar ACLs

### DIFF
--- a/shared/instancewriter/instance_tar_writer.go
+++ b/shared/instancewriter/instance_tar_writer.go
@@ -117,7 +117,7 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 					continue
 				}
 
-				hdr.PAXRecords["SCHILY.acl.access"] = aclAccess
+				val = aclAccess
 			} else if key == "system.posix_acl_default" && ctw.idmapSet != nil {
 				aclDefault, err := idmap.UnshiftACL(val, ctw.idmapSet)
 				if err != nil {
@@ -125,7 +125,7 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 					continue
 				}
 
-				hdr.PAXRecords["SCHILY.acl.default"] = aclDefault
+				val = aclDefault
 			} else if key == "security.capability" && ctw.idmapSet != nil {
 				vfsCaps, err := idmap.UnshiftCaps(val, ctw.idmapSet)
 				if err != nil {
@@ -133,10 +133,10 @@ func (ctw *InstanceTarWriter) WriteFile(name string, srcPath string, fi os.FileI
 					continue
 				}
 
-				hdr.PAXRecords["SCHILY.xattr."+key] = vfsCaps
-			} else {
-				hdr.PAXRecords["SCHILY.xattr."+key] = val
+				val = vfsCaps
 			}
+
+			hdr.PAXRecords["SCHILY.xattr."+key] = val
 		}
 	}
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -283,6 +283,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_image_prefer_cached "image prefer cached"
     run_test test_image_import_dir "import image from directory"
     run_test test_image_refresh "image refresh"
+    run_test test_image_acl "image acl"
     run_test test_cloud_init "cloud-init"
     run_test test_exec "exec"
     run_test test_concurrent_exec "concurrent exec"

--- a/test/suites/image_acl.sh
+++ b/test/suites/image_acl.sh
@@ -1,0 +1,25 @@
+test_image_acl() {
+  ensure_import_testimage
+
+  # Launch a new container with an ACL applied file
+  lxc launch testimage c1
+  CONTAINER_PID="$(lxc query /1.0/instances/c1?recursion=1 | jq '.state.pid')"
+  lxc exec c1 touch foo
+  setfacl -m user:1000001:rwx "/proc/$CONTAINER_PID/root/root/foo"
+  setfacl -m group:1000001:rwx "/proc/$CONTAINER_PID/root/root/foo"
+
+  # Publish the container to a new image
+  lxc stop c1
+  lxc publish c1 --alias c1-with-acl
+
+  # Launch a new container from the existing image
+  lxc launch c1-with-acl c2
+
+  # Check if the ACLs are still present
+  CONTAINER_PID="$(lxc query /1.0/instances/c2?recursion=1 | jq '.state.pid')"
+  getfacl "/proc/$CONTAINER_PID/root/root/foo" | grep -q "user:1000001:rwx"
+  getfacl "/proc/$CONTAINER_PID/root/root/foo" | grep -q "group:1000001:rwx"
+
+  lxc delete -f c1 c2
+  lxc image delete c1-with-acl
+}


### PR DESCRIPTION
When creating an archive from a container, use the right header key for the go tar module. There is no reference to `SCHILY.acl.*` in the go codebase under `src/archive/tar` which is what we use to create the instances tarball. Instead `SCHILY.xattr.*` is used.

Looks like the `SCHILY.acl.*` keys are from a withdrawn standard, see https://man.freebsd.org/cgi/man.cgi?query=star&sektion=5. Interestingly the page mentions:

> Note that the POSIX 1003.1e draft has been withdrawn in 1997 but some operating systems still support it with some filesystems.

Fixes https://github.com/canonical/lxd/issues/11901