### PR TITLE
Network: Prevent unspecified forward address

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -823,6 +823,10 @@ func (n *common) forwardValidate(listenAddress net.IP, forward *api.NetworkForwa
 		return nil, fmt.Errorf("Invalid listen address")
 	}
 
+	if listenAddress.IsUnspecified() {
+		return nil, fmt.Errorf("Cannot use unspecified address: %q", listenAddress.String())
+	}
+
 	listenIsIP4 := listenAddress.To4() != nil
 
 	// For checking target addresses are within network's subnet.

--- a/test/suites/network_forward.sh
+++ b/test/suites/network_forward.sh
@@ -9,6 +9,12 @@ test_network_forward() {
         ipv4.address=192.0.2.1/24 \
         ipv6.address=fd42:4242:4242:1010::1/64
 
+  # Check creating a forward with an unspecified IPv4 address fails.
+  ! lxc network forward create "${netName}" 0.0.0.0 || false
+
+  # Check creating a forward with an unspecified IPv6 address fails.
+  ! lxc network forward create "${netName}" :: || false
+
   # Check creating empty forward doesn't create any firewall rules.
   lxc network forward create "${netName}" 198.51.100.1
   if [ "$firewallDriver" = "xtables" ]; then


### PR DESCRIPTION
Using either `0.0.0.0` or `::` for the forwards listen address is not supported.

Closes https://github.com/canonical/lxd/issues/11975