### PR TITLE
lxddoc: Add a readthedoc pre-build hook to build and generate codebase doc

### DIFF
--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    golang: "1.18"
     python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx


### PR DESCRIPTION
@ru-fu Now `lxd-doc` can be built from source and executed entirely from the `conf.py` file which means that we no longer have to use the makefile and it should directly integrates with the readthedoc pipeline. 