### PR TITLE
lxd/instance/drivers/driver/lxc: make limits.memory.swap work properly

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1126,7 +1126,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 					return nil, err
 				}
 			} else {
-				if d.state.OS.CGInfo.Supports(cgroup.MemorySwap, cg) && shared.IsTrueOrEmpty(memorySwap) {
+				if d.state.OS.CGInfo.Supports(cgroup.MemorySwap, cg) && shared.IsFalse(memorySwap) {
 					err = cg.SetMemoryLimit(valueInt)
 					if err != nil {
 						return nil, err
@@ -4489,7 +4489,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 						return err
 					}
 				} else {
-					if d.state.OS.CGInfo.Supports(cgroup.MemorySwap, cg) && shared.IsTrueOrEmpty(memorySwap) {
+					if d.state.OS.CGInfo.Supports(cgroup.MemorySwap, cg) && shared.IsFalse(memorySwap) {
 						err = cg.SetMemoryLimit(memoryInt)
 						if err != nil {
 							revertMemory()


### PR DESCRIPTION
It was reported that limits.memory.swap container instance config is not working as described in the LXD Documentation. Instead, observable behavior is opposite. Let's fix that.

Fixes #11566