### PR TITLE
Revert "github: pin curl to older version"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt-get update
 
           sudo apt-get install --no-install-recommends -y \
-            curl=7.81.0-1ubuntu1.10 \
+            curl \
             gettext \
             git \
             libacl1-dev \
@@ -139,7 +139,7 @@ jobs:
           sudo systemctl mask lxc-net.service
 
           sudo apt-get install --no-install-recommends -y \
-            curl=7.81.0-1ubuntu1.10 \
+            curl \
             dnsutils \
             git \
             libacl1-dev \


### PR DESCRIPTION
The regression in `curl` has been fixed in the latest version `7.81.0-1ubuntu1.13`. See https://ubuntu.com/security/notices/USN-6237-2

Reverts canonical/lxd#12046