### PR TITLE
shared/cmd: Use SetAutoMergeCells(true) for table|compact table rendering

### DIFF
--- a/shared/cmd/table.go
+++ b/shared/cmd/table.go
@@ -28,12 +28,14 @@ func RenderTable(format string, header []string, data [][]string, raw any) error
 	case TableFormatTable:
 		table := getBaseTable(header, data)
 		table.SetRowLine(true)
+		table.SetAutoMergeCells(true)
 		table.Render()
 	case TableFormatCompact:
 		table := getBaseTable(header, data)
 		table.SetColumnSeparator("")
 		table.SetHeaderLine(false)
 		table.SetBorder(false)
+		table.SetAutoMergeCells(true)
 		table.Render()
 	case TableFormatCSV:
 		w := csv.NewWriter(os.Stdout)


### PR DESCRIPTION
This feature allows us to merge cells in adjacent rows if the fields are identical within the same column. Here is an example:

```
+----------------------+-------------------------------------------+----------+-------+-------------------+
|       USED BY        |                 ADDRESSES                 |   TYPE   |  NAT  | HARDWARE ADDRESS  |
+----------------------+-------------------------------------------+----------+-------+-------------------+
| /1.0/networks/lxdbr0 | 10.6.105.1/24                             | network  | false |                   |
+                      +-------------------------------------------+          +       +-------------------+
|                      | fd42:3cce:990:a1fd::1/64                  |          |       |                   |
+----------------------+-------------------------------------------+----------+       +-------------------+
| /1.0/instances/u1    | fd42:3cce:990:a1fd:216:3eff:fe04:f095/128 | instance |       | 00:16:3e:04:f0:95 |
+                      +-------------------------------------------+          +       +                   +
|                      | 10.6.105.160/32                           |          |       |                   |
+----------------------+-------------------------------------------+----------+-------+-------------------+
```