### PR TITLE
lxc: Fix network list-allocations output format

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2641,18 +2641,16 @@ definitions:
             e.g, instance, network forward, load-balancer, network...
         properties:
             addresses:
-                description: The CIDR subnet of the forward
+                description: The network address of the allocation (in CIDR format)
                 example: 192.0.2.1/24
-                items:
-                    type: string
-                type: array
-                x-go-name: Addresses
+                type: string
+                x-go-name: Address
             hwaddr:
                 description: Hwaddr is the MAC address of the entity consuming the network address
                 type: string
                 x-go-name: Hwaddr
             nat:
-                description: Whether the entity comes from a network that LXD performs NAT on from those that are directly routed from the external network
+                description: Whether the entity comes from a network that LXD performs egress source NAT on
                 type: boolean
                 x-go-name: NAT
             type:

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -698,6 +698,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1871,7 +1875,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2602,11 +2606,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2818,6 +2822,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3474,7 +3482,7 @@ msgstr ""
 "* \"security.privileged=1\" listet alle privilegierten Container\n"
 "* \"s.privileged=1\" ebenfalls\n"
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3832,8 +3840,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4183,6 +4191,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4707,8 +4719,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4744,8 +4756,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -5151,7 +5163,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -5159,7 +5171,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5925,7 +5937,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -6283,9 +6296,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1551,7 +1555,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2244,11 +2248,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2453,6 +2457,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3071,7 +3079,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3399,8 +3407,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3732,6 +3740,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4244,8 +4256,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4281,8 +4293,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4664,7 +4676,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4672,7 +4684,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5407,7 +5419,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5753,9 +5766,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -679,6 +679,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1806,7 +1810,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2505,11 +2509,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2714,6 +2718,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3346,7 +3354,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3677,8 +3685,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4020,6 +4028,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4534,8 +4546,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4571,8 +4583,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4962,7 +4974,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4970,7 +4982,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5707,7 +5719,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -6058,9 +6071,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -696,6 +696,10 @@ msgstr ""
 #: lxc/manpage.go:20
 msgid "<target>"
 msgstr "<cible>"
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
+msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
@@ -1896,7 +1900,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2635,11 +2639,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2852,6 +2856,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3559,7 +3567,7 @@ msgstr ""
 "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
 "hwaddr:MAC"
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Clé de configuration invalide"
@@ -3912,8 +3920,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4270,6 +4278,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr "NOM"
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
+msgstr ""
 
 #: lxc/project.go:504
 msgid "NETWORK ZONES"
@@ -4806,8 +4818,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4843,8 +4855,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -5270,7 +5282,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -5278,7 +5290,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Rendre l'image publique"
@@ -6058,7 +6070,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
@@ -6421,9 +6434,9 @@ msgstr "URL"
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -442,6 +442,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1541,7 +1545,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2225,11 +2229,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2421,6 +2425,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3037,7 +3045,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3355,8 +3363,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3681,6 +3689,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4190,8 +4202,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4227,8 +4239,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4604,7 +4616,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4612,7 +4624,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5324,7 +5336,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5670,9 +5683,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -678,6 +678,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1800,7 +1804,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2500,11 +2504,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2706,6 +2710,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3338,7 +3346,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3674,8 +3682,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4015,6 +4023,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4529,8 +4541,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4566,8 +4578,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4959,7 +4971,7 @@ msgstr "Il nome del container è: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4967,7 +4979,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Creazione del container in corso"
@@ -5702,7 +5714,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -6052,9 +6065,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -670,6 +670,11 @@ msgstr ""
 #: lxc/manpage.go:20
 msgid "<target>"
 msgstr "<target>"
+
+#: lxc/network_allocations.go:26
+#, fuzzy
+msgid "ADDRESS"
+msgstr "IP ADDRESS"
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
 msgid "ALIAS"
@@ -1825,7 +1830,7 @@ msgstr "警告を削除します"
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2558,11 +2563,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -2764,6 +2769,11 @@ msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
+
+#: lxc/network_allocations.go:29
+#, fuzzy
+msgid "HARDWARE ADDRESS"
+msgstr "MAC ADDRESS"
 
 #: lxc/network.go:1052
 msgid "HOSTNAME"
@@ -3506,7 +3516,7 @@ msgstr ""
 "  MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "  デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "ネットワーク設定をYAMLで編集します"
@@ -3870,8 +3880,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -4219,6 +4229,10 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr "NAME"
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
+msgstr ""
 
 #: lxc/project.go:504
 msgid "NETWORK ZONES"
@@ -4732,8 +4746,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4769,8 +4783,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -5158,7 +5172,7 @@ msgstr "クラスターメンバーに join するためのトークンを失効
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -5166,7 +5180,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
@@ -5947,7 +5961,8 @@ msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr "TYPE"
@@ -6319,9 +6334,9 @@ msgstr "URL"
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -9488,8 +9503,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect \"custom"
-#~ "\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect "
+#~ "\"custom\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-07-18 19:22+0200\n"
+        "POT-Creation-Date: 2023-07-21 08:56+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -414,6 +414,10 @@ msgstr  ""
 
 #: lxc/manpage.go:20
 msgid   "<target>"
+msgstr  ""
+
+#: lxc/network_allocations.go:26
+msgid   "ADDRESS"
 msgstr  ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1407,7 +1411,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:35 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:23 lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:757 lxc/storage.go:843 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:530 lxc/storage_volume.go:609 lxc/storage_volume.go:684 lxc/storage_volume.go:766 lxc/storage_volume.go:847 lxc/storage_volume.go:1056 lxc/storage_volume.go:1171 lxc/storage_volume.go:1318 lxc/storage_volume.go:1402 lxc/storage_volume.go:1608 lxc/storage_volume.go:1641 lxc/storage_volume.go:1756 lxc/storage_volume.go:1900 lxc/storage_volume.go:2009 lxc/storage_volume.go:2055 lxc/storage_volume.go:2152 lxc/storage_volume.go:2219 lxc/storage_volume.go:2373 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:76 lxc/action.go:99 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:40 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:52 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:23 lxc/operation.go:55 lxc/operation.go:104 lxc/operation.go:184 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:757 lxc/storage.go:843 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:530 lxc/storage_volume.go:609 lxc/storage_volume.go:684 lxc/storage_volume.go:766 lxc/storage_volume.go:847 lxc/storage_volume.go:1056 lxc/storage_volume.go:1171 lxc/storage_volume.go:1318 lxc/storage_volume.go:1402 lxc/storage_volume.go:1608 lxc/storage_volume.go:1641 lxc/storage_volume.go:1756 lxc/storage_volume.go:1900 lxc/storage_volume.go:2009 lxc/storage_volume.go:2055 lxc/storage_volume.go:2152 lxc/storage_volume.go:2219 lxc/storage_volume.go:2373 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1998,7 +2002,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1418 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:58 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2189,6 +2193,10 @@ msgstr  ""
 
 #: lxc/exec.go:60
 msgid   "Group ID to run the command as (default 0)"
+msgstr  ""
+
+#: lxc/network_allocations.go:29
+msgid   "HARDWARE ADDRESS"
 msgstr  ""
 
 #: lxc/network.go:1052
@@ -2786,7 +2794,7 @@ msgid   "List instances\n"
         "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr  ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid   "List network allocations in use"
 msgstr  ""
 
@@ -3349,6 +3357,10 @@ msgstr  ""
 
 #: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1506
 msgid   "NAME"
+msgstr  ""
+
+#: lxc/network_allocations.go:28
+msgid   "NAT"
 msgstr  ""
 
 #: lxc/project.go:504
@@ -4240,7 +4252,7 @@ msgstr  ""
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid   "Run again a specific project"
 msgstr  ""
 
@@ -4248,7 +4260,7 @@ msgstr  ""
 msgid   "Run against all instances"
 msgstr  ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid   "Run against all projects"
 msgstr  ""
 
@@ -4930,7 +4942,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162 lxc/storage_volume.go:1505 lxc/warning.go:215
+#: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:27 lxc/operation.go:162 lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid   "TYPE"
 msgstr  ""
 
@@ -5262,7 +5274,7 @@ msgstr  ""
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647 lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25 lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid   "USED BY"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -658,6 +658,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1757,7 +1761,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2441,11 +2445,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2637,6 +2641,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3253,7 +3261,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3571,8 +3579,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3897,6 +3905,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4406,8 +4418,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4443,8 +4455,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4820,7 +4832,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4828,7 +4840,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5540,7 +5552,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5886,9 +5899,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -692,6 +692,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1791,7 +1795,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2475,11 +2479,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2671,6 +2675,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3287,7 +3295,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3605,8 +3613,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3931,6 +3939,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4440,8 +4452,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4477,8 +4489,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4854,7 +4866,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4862,7 +4874,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5574,7 +5586,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5920,9 +5933,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -693,6 +693,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1850,7 +1854,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2557,11 +2561,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2772,6 +2776,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3398,7 +3406,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 #, fuzzy
 msgid "List network allocations in use"
 msgstr "Editar configurações de rede como YAML"
@@ -3738,8 +3746,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4079,6 +4087,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4594,8 +4606,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4631,8 +4643,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -5032,7 +5044,7 @@ msgstr "Nome de membro do cluster"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -5040,7 +5052,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Criar projetos"
@@ -5792,7 +5804,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -6145,9 +6158,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:255 lxc/storage_bucket.go:1000
@@ -696,6 +696,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1836,7 +1840,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2543,11 +2547,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2754,6 +2758,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3389,7 +3397,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3734,8 +3742,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -4079,6 +4087,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4593,8 +4605,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4630,8 +4642,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -5027,7 +5039,7 @@ msgstr "Копирование образа: %s"
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -5035,7 +5047,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 #, fuzzy
 msgid "Run against all projects"
 msgstr "Доступные команды:"
@@ -5783,7 +5795,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -6130,9 +6143,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:255 lxc/storage_bucket.go:1000
@@ -442,6 +442,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1541,7 +1545,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2225,11 +2229,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2421,6 +2425,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3037,7 +3045,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3355,8 +3363,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3681,6 +3689,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4190,8 +4202,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4227,8 +4239,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4604,7 +4616,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4612,7 +4624,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5324,7 +5336,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5670,9 +5683,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:255 lxc/storage_bucket.go:1000
@@ -442,6 +442,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1541,7 +1545,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2225,11 +2229,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2421,6 +2425,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3037,7 +3045,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3355,8 +3363,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3681,6 +3689,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4190,8 +4202,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4227,8 +4239,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4604,7 +4616,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4612,7 +4624,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5324,7 +5336,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5670,9 +5683,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -438,6 +438,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1537,7 +1541,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2221,11 +2225,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2417,6 +2421,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3033,7 +3041,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3351,8 +3359,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3677,6 +3685,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4186,8 +4198,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4223,8 +4235,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4600,7 +4612,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4608,7 +4620,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5320,7 +5332,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5666,9 +5679,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:255 lxc/storage_bucket.go:1000
@@ -442,6 +442,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1541,7 +1545,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2225,11 +2229,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2421,6 +2425,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3037,7 +3045,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3355,8 +3363,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3681,6 +3689,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4190,8 +4202,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4227,8 +4239,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4604,7 +4616,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4612,7 +4624,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5324,7 +5336,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5670,9 +5683,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -573,6 +573,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1672,7 +1676,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2356,11 +2360,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2552,6 +2556,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3168,7 +3176,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3486,8 +3494,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3812,6 +3820,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4321,8 +4333,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4358,8 +4370,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4735,7 +4747,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4743,7 +4755,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5455,7 +5467,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5801,9 +5814,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-07-18 19:22+0200\n"
+"POT-Creation-Date: 2023-07-21 08:56+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -441,6 +441,10 @@ msgstr ""
 
 #: lxc/manpage.go:20
 msgid "<target>"
+msgstr ""
+
+#: lxc/network_allocations.go:26
+msgid "ADDRESS"
 msgstr ""
 
 #: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
@@ -1540,7 +1544,7 @@ msgstr ""
 #: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
 #: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
 #: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:35 lxc/network_forward.go:29
+#: lxc/network_allocations.go:52 lxc/network_forward.go:29
 #: lxc/network_forward.go:86 lxc/network_forward.go:167
 #: lxc/network_forward.go:231 lxc/network_forward.go:329
 #: lxc/network_forward.go:398 lxc/network_forward.go:496
@@ -2224,11 +2228,11 @@ msgstr ""
 #: lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352
 #: lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157
 #: lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97
-#: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
-#: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
-#: lxc/operation.go:106 lxc/profile.go:617 lxc/project.go:412
-#: lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588
-#: lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
+#: lxc/network_allocations.go:58 lxc/network_forward.go:89
+#: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
+#: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:106
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,6 +2424,10 @@ msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
+msgstr ""
+
+#: lxc/network_allocations.go:29
+msgid "HARDWARE ADDRESS"
 msgstr ""
 
 #: lxc/network.go:1052
@@ -3036,7 +3044,7 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/network_allocations.go:34 lxc/network_allocations.go:35
+#: lxc/network_allocations.go:51 lxc/network_allocations.go:52
 msgid "List network allocations in use"
 msgstr ""
 
@@ -3354,8 +3362,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:32 lxc/remote.go:33
@@ -3680,6 +3688,10 @@ msgstr ""
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1506
 msgid "NAME"
+msgstr ""
+
+#: lxc/network_allocations.go:28
+msgid "NAT"
 msgstr ""
 
 #: lxc/project.go:504
@@ -4189,8 +4201,8 @@ msgid ""
 "Supported types are custom, container and virtual-machine.\n"
 "\n"
 "lxc storage volume info default data\n"
-"    Returns state information for a custom volume \"data\" in pool \"default"
-"\".\n"
+"    Returns state information for a custom volume \"data\" in pool "
+"\"default\".\n"
 "\n"
 "lxc storage volume info default virtual-machine/data\n"
 "    Returns state information for a virtual machine \"data\" in pool "
@@ -4226,8 +4238,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool.\n"
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool.\n"
 "\n"
 "lxc storage volume show default virtual-machine/data/snap0\n"
 "    Will show the properties of snapshot \"snap0\" for a virtual machine "
@@ -4603,7 +4615,7 @@ msgstr ""
 msgid "Role (admin or read-only)"
 msgstr ""
 
-#: lxc/network_allocations.go:41
+#: lxc/network_allocations.go:59
 msgid "Run again a specific project"
 msgstr ""
 
@@ -4611,7 +4623,7 @@ msgstr ""
 msgid "Run against all instances"
 msgstr ""
 
-#: lxc/network_allocations.go:42
+#: lxc/network_allocations.go:60
 msgid "Run against all projects"
 msgstr ""
 
@@ -5323,7 +5335,8 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236
-#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/operation.go:162
+#: lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055
+#: lxc/network_allocations.go:27 lxc/operation.go:162
 #: lxc/storage_volume.go:1505 lxc/warning.go:215
 msgid "TYPE"
 msgstr ""
@@ -5669,9 +5682,9 @@ msgstr ""
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_zone.go:140
-#: lxc/profile.go:659 lxc/project.go:506 lxc/storage.go:647
-#: lxc/storage_volume.go:1509
+#: lxc/network.go:986 lxc/network_acl.go:149 lxc/network_allocations.go:25
+#: lxc/network_zone.go:140 lxc/profile.go:659 lxc/project.go:506
+#: lxc/storage.go:647 lxc/storage_volume.go:1509
 msgid "USED BY"
 msgstr ""
 

--- a/shared/api/network_addresses.go
+++ b/shared/api/network_addresses.go
@@ -7,14 +7,14 @@ package api
 //
 // API extension: network_allocations.
 type NetworkAllocations struct {
-	// The CIDR subnet of the forward
+	// The network address of the allocation (in CIDR format)
 	// Example: 192.0.2.1/24
-	Addresses []string `json:"addresses" yaml:"addresses"`
+	Address string `json:"addresses" yaml:"addresses"`
 	// Name of the entity consuming the network address
 	UsedBy string `json:"used_by" yaml:"used_by"`
 	// Type of the entity consuming the network address
 	Type string `json:"type" yaml:"type"`
-	// Whether the entity comes from a network that LXD performs NAT on from those that are directly routed from the external network
+	// Whether the entity comes from a network that LXD performs egress source NAT on
 	NAT bool `json:"nat" yaml:"nat"`
 	// Hwaddr is the MAC address of the entity consuming the network address
 	Hwaddr string `json:"hwaddr" yaml:"hwaddr"`


### PR DESCRIPTION
This PR changes the `lxc network list-allocations` output format to a tabular table, and uses the same approach that `lxc list` does for outputting multiple IPs in a single row by separating them by a `\n` character. This is for consistency.

Closes #12055