### PR TITLE
doc: add a link to Ubuntu Discourse

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,9 @@ html_context = {
     "github_version": "main",
     "github_folder": "/doc/",
     "github_filetype": "md",
-    "discourse_prefix": "https://discuss.linuxcontainers.org/t/"
+    "discourse_prefix": {
+        "lxc": "https://discuss.linuxcontainers.org/t/",
+        "ubuntu": "https://discourse.ubuntu.com/t/"}
 }
 
 source_suffix = ".md"

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,5 +1,5 @@
 ---
-discourse: 8178, 16551
+discourse: ubuntu:37214, 16551
 ---
 
 (installing)=


### PR DESCRIPTION
Configure the Discourse link extension to allow for two different Discourse instances (linuxcontainers and ubuntu), and update the link to the snap management tutorial to use the tutorial on the Ubuntu Discourse.