### PR TITLE
lxc: Support parsing of anonymous nested structs for getting properties

### DIFF
--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -315,6 +315,7 @@ test_property() {
   # Create a snap of the instance to set its expiration timestamp
   lxc snapshot foo s1
   lxc config set foo/s1 expires_at="2024-03-23T17:38:37.753398689-04:00" --property
+  lxc config get foo/s1 expires_at --property | grep -q "2024-03-23 17:38:37.753398689 -0400 -0400"
   lxc config show foo/s1 | grep -q "expires_at: 2024-03-23T17:38:37.753398689-04:00"
   lxc config unset foo/s1 expires_at --property
   lxc config show foo/s1 | grep -q "expires_at: 0001-01-01T00:00:00Z"


### PR DESCRIPTION
closes #12071 

Now this will work

```
lxc config set c1/snap0 expires_at="2023-08-01T00:00:00Z" --property
lxc config show c1/snap0 | grep expires_at
expires_at: 2023-08-01T00:00:00Z
lxc config get c1/snap0 architecture --property
x86_64
lxc config get c1/snap0 expires_at --property
2023-08-01T00:00:00Z
```