### PR TITLE
VM: Fix boot from Windows ISO by setting correct FSType for .iso files

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -948,6 +948,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				runConf.PostHooks = append(runConf.PostHooks, f.Close)
 				runConf.Revert = func() { _ = f.Close() } // Close file on VM start failure.
 
+				// Detect ISO files to set correct FSType before DevPath is encoded below.
+				// This is very important to support Windows ISO images (amongst other).
+				if strings.HasSuffix(mount.DevPath, ".iso") {
+					mount.FSType = "iso9660"
+				}
+
 				// Encode the file descriptor and original srcPath into the DevPath field.
 				mount.DevPath = fmt.Sprintf("%s:%d:%s", DiskFileDescriptorMountPrefix, f.Fd(), mount.DevPath)
 			}


### PR DESCRIPTION
Fixes regression caused by 81ffb0146a5cc770b3a0fa130c4e9b716cf6323e from https://github.com/canonical/lxd/pull/11852