### PR TITLE
doc/cluster: add an example for a ZFS storage pool to preseed

### DIFF
--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -226,6 +226,8 @@ config:
 storage_pools:
 - name: default
   driver: dir
+- name: my-pool
+  driver: zfs
 networks:
 - name: lxdbr0
   type: bridge
@@ -234,7 +236,7 @@ profiles:
   devices:
     root:
       path: /
-      pool: default
+      pool: my-pool
       type: disk
     eth0:
       name: eth0
@@ -269,6 +271,8 @@ config:
 storage_pools:
 - name: default
   driver: dir
+- name: my-pool
+  driver: zfs
 networks:
 - name: lxdbr0
   type: bridge
@@ -277,7 +281,7 @@ profiles:
   devices:
     root:
       path: /
-      pool: default
+      pool: my-pool
       type: disk
     eth0:
       name: eth0
@@ -322,6 +326,15 @@ cluster:
     name: default
     key: source
     value: ""
+  - entity: storage-pool
+    name: my-pool
+    key: source
+    value: ""
+  - entity: storage-pool
+    name: my-pool
+    key: driver
+    value: "zfs"
+
 ```
 
 ````
@@ -370,6 +383,15 @@ opyQ1VRpAg2sV2C4W8irbNqeUsTeZZxhLqp4vNOXXBBrSqUCdPu1JXADV0kavg1l
     name: default
     key: source
     value: ""
+  - entity: storage-pool
+    name: my-pool
+    key: source
+    value: ""
+  - entity: storage-pool
+    name: my-pool
+    key: driver
+    value: "zfs"
+
 ```
 
 ````


### PR DESCRIPTION
The preseed file uses a different syntax than normal configuration. Add an example for adding a ZFS storage pool to the example.