### PR TITLE
lxd/device/device/utils/disk: Look for virtiofsd in /usr/lib/

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -442,6 +442,8 @@ func DiskVMVirtiofsdStart(execPath string, inst instance.Instance, socketPath st
 			cmd = "/usr/lib/qemu/virtiofsd"
 		} else if shared.PathExists("/usr/libexec/virtiofsd") {
 			cmd = "/usr/libexec/virtiofsd"
+		} else if shared.PathExists("/usr/lib/virtiofsd") {
+			cmd = "/usr/lib/virtiofsd"
 		}
 	}
 


### PR DESCRIPTION
Arch-based distributions install it there because they do not have /usr/libexec/.
Fixes #12086