### PR TITLE
Remove detection of LXC versions that are EOL

### DIFF
--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -164,16 +164,7 @@ test_config_profiles() {
   lxc profile assign foo onenic
   lxc profile create unconfined
 
-  # Look at the LXC version to decide whether to use the new
-  # or the new config key for apparmor.
-  lxc_version=$(lxc info | awk '/driver_version:/ {print $NF}')
-  lxc_major=$(echo "${lxc_version}" | cut -d. -f1)
-  lxc_minor=$(echo "${lxc_version}" | cut -d. -f2)
-  if [ "${lxc_major}" -lt 2 ] || { [ "${lxc_major}" = "2" ] && [ "${lxc_minor}" -lt "1" ]; }; then
-      lxc profile set unconfined raw.lxc "lxc.aa_profile=unconfined"
-  else
-      lxc profile set unconfined raw.lxc "lxc.apparmor.profile=unconfined"
-  fi
+  lxc profile set unconfined raw.lxc "lxc.apparmor.profile=unconfined"
 
   lxc profile assign foo onenic,unconfined
 

--- a/test/suites/console.sh
+++ b/test/suites/console.sh
@@ -1,12 +1,4 @@
 test_console() {
-  lxc_version=$(lxc info | awk '/driver_version:/ {print $NF}')
-  lxc_major=$(echo "${lxc_version}" | cut -d. -f1)
-
-  if [ "${lxc_major}" -lt 3 ]; then
-    echo "==> SKIP: The console ringbuffer require liblxc 3.0 or higher"
-    return
-  fi
-
   echo "==> API extension console"
 
   ensure_import_testimage

--- a/test/suites/kernel_limits.sh
+++ b/test/suites/kernel_limits.sh
@@ -1,13 +1,4 @@
 test_kernel_limits() {
-  lxc_version=$(lxc info | awk '/driver_version:/ {print $NF}')
-  lxc_major=$(echo "${lxc_version}" | cut -d. -f1)
-  lxc_minor=$(echo "${lxc_version}" | cut -d. -f2)
-
-  if [ "${lxc_major}" -lt 2 ] || { [ "${lxc_major}" = "2" ] && [ "${lxc_minor}" -lt "1" ]; }; then
-    echo "==> SKIP: kernel_limits require liblxc 2.1 or higher"
-    return
-  fi
-
   echo "==> API extension kernel_limits"
 
   ensure_import_testimage

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -16,7 +16,7 @@ do_zfs_delegate() {
     return
   fi
 
-  if ! zfs --help | grep -q zone; then
+  if ! zfs --help | grep -q '^\s\+zone\b'; then
     echo "==> SKIP: Skipping ZFS delegation tests due as installed version doesn't support it"
     return
   fi


### PR DESCRIPTION
Also a small tweak to `test/suites/storage_driver_zfs.sh` to only match on `zone` if it's a sub-command of `zfs`.