### PR TITLE
lxd: expose a documentation server to LXD

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -11,6 +11,7 @@ To get started with LXD, see the documentation in this section.
 ```{toctree}
 :maxdepth: 1
 
+Access the documentation </howto/access_documentation>
 Access the UI </howto/access_ui>
 Contribute to LXD </contributing>
 Get support </support>
@@ -49,6 +50,7 @@ You can also find a series of demos and tutorials on YouTube:
 Install LXD </installing>
 Initialize LXD </howto/initialize>
 Access the UI </howto/access_ui>
+Access the documentation </howto/access_documentation>
 Frequently asked </faq>
 Contribute to LXD </contributing>
 Get support </support>

--- a/doc/howto/access_documentation.md
+++ b/doc/howto/access_documentation.md
@@ -1,0 +1,17 @@
+(access-documentation)=
+# How to access the local LXD documentation
+
+The latest version of the LXD documentation is available at [`documentation.ubuntu.com/lxd`](https://documentation.ubuntu.com/lxd/).
+
+Alternatively, you can access a local version of the LXD documentation that is embedded in the LXD snap.
+This version of the documentation exactly matches the version of your LXD deployment, but might be missing additions, fixes, or clarifications that were added after the release of the snap.
+
+Complete the following steps to access the local LXD documentation:
+
+1. Make sure that your LXD server is {ref}`exposed to the network <server-expose>`.
+   You can expose the server during {ref}`initialization <initialize>`, or afterwards by setting the {config:option}`server-core:core.https_address` server configuration option.
+
+1. Access the documentation in your browser by entering the server address followed by `/documentation/` (for example, `https://192.0.2.10:8443/documentation/`).
+
+   If you have not set up a secure {ref}`authentication-server-certificate`, LXD uses a self-signed certificate, which will cause a security warning in your browser.
+   Use your browser's mechanism to continue despite the security warning.


### PR DESCRIPTION
JIRA task: https://warthogs.atlassian.net/jira/software/c/projects/LXD/boards/54?modal=detail&selectedIssue=LXD-359&assignee=63d9eb6128cddcc70770aff1

Spec: https://discourse.ubuntu.com/t/expose-the-full-lxd-documentation-website-as-part-of-a-lxd-deployment/37516

- [x] Expose documentation pages at `/documentation/`

Once this gets merged, we need to merge https://github.com/canonical/lxd-pkg-snap/pull/136 to make it work with snap