### PR TITLE
test/container_syscall_interception: supported releases have seccomp_notify support

### DIFF
--- a/test/suites/container_syscall_interception.sh
+++ b/test/suites/container_syscall_interception.sh
@@ -2,11 +2,6 @@ test_container_syscall_interception() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  if [ "$(lxc query /1.0 | jq -r .environment.lxc_features.seccomp_notify)" != "true" ]; then
-    echo "==> SKIP: Seccomp notify not supported"
-    return
-  fi
-
   if [ "$(awk '/^Seccomp:/ {print $2}' "/proc/self/status")" -eq "0" ]; then
     echo "==> SKIP: syscall interception (seccomp filtering is externally enabled)"
     return


### PR DESCRIPTION
```
$ lxc query /1.0 | jq -r .environment.server_version
4.0.9
$ lxc query /1.0 | jq -r .environment.lxc_features.seccomp_notify
true
```