### PR TITLE
doc: add an index.html redirect for topical navigation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,6 +175,8 @@ redirects = {
 if ("TOPICAL" in os.environ) and (os.environ["TOPICAL"] == "True"):
     root_doc = "index_topical"
     exclude_patterns.extend(['index.md','tutorial/index.md','howto/index.md','explanation/index.md','reference/index.md','howto/troubleshoot.md'])
+    redirects["index/index"] = "../index_topical/"
+    redirects["index"] = "../index_topical/"
     tags.add('topical')
 else:
     exclude_patterns.extend(['index_topical.md','security.md','external_resources.md','reference/network_external.md'])


### PR DESCRIPTION
The start page is called differently for topical navigation (so that we can have different toctrees). However, RTD requires an `index` page to be present (even though Sphinx doesn't need it ...) So this is a workaround for this problem.