### PR TITLE
Use smaller ISO files in tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,4 +4,3 @@ API:
 - shared/api/**/*
 Documentation:
 - doc/**/*
-- .sphinx/**/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,10 @@ jobs:
             xfsprogs \
             xz-utils \
             zfsutils-linux
+
+          # reclaim some space
+          sudo apt-get clean
+
           mkdir -p "$(go env GOPATH)/bin"
           curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "$(go env GOPATH)/bin/minio"
           chmod +x "$(go env GOPATH)/bin/minio"

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -10,7 +10,7 @@ test_storage_volume_recover() {
   lxc storage volume create "${poolName}" vol1 --type=block
 
   # Import ISO.
-  truncate -s 25MiB foo.iso
+  truncate -s 8MiB foo.iso
   lxc storage volume import "${poolName}" ./foo.iso vol2 --type=iso
 
   # Delete database entry of the created custom block volume.

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -566,7 +566,7 @@ migration() {
   lxc_remote rm -f l2:c1
 
   # migrate ISO custom volumes
-  truncate -s 25MiB foo.iso
+  truncate -s 8MiB foo.iso
   lxc storage volume import l1:"${pool}" ./foo.iso iso1
   lxc storage volume copy l1:"${pool}"/iso1 l2:"${remote_pool}"/iso1
 

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -238,7 +238,7 @@ test_storage_local_volume_handling() {
           ! lxc storage volume get "lxdtest-$(basename "${LXD_DIR}")-${target_driver}" vol5/snapremove user.foo || false
 
           # copy ISO custom volumes
-          truncate -s 25MiB foo.iso
+          truncate -s 8MiB foo.iso
           lxc storage volume import "lxdtest-$(basename "${LXD_DIR}")-${source_driver}" ./foo.iso iso1
           lxc storage volume copy "lxdtest-$(basename "${LXD_DIR}")-${source_driver}"/iso1 "lxdtest-$(basename "${LXD_DIR}")-${target_driver}"/iso1
           lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${target_driver}" iso1 | grep -q 'content_type: iso'

--- a/test/suites/storage_volume_import.sh
+++ b/test/suites/storage_volume_import.sh
@@ -1,6 +1,6 @@
 test_storage_volume_import() {
-  truncate -s 25MiB foo.iso
-  truncate -s 25MiB foo.img
+  truncate -s 8MiB foo.iso
+  truncate -s 8MiB foo.img
 
   ensure_import_testimage
 


### PR DESCRIPTION
Apparently we are running tight on space and that's causing test failures:

> timeout --foreground 120 /home/runner/go/bin/lxc storage volume copy l1:lxdtest-3vW/iso1 l2:lxdtest-fut/iso1 --verbose
> ...
> time="2023-08-02T10:58:47Z" level=info msg="Migration channels disconnected on target" pool=lxdtest-fut project=default push=false volume=iso1
> Error: Failed storage volume creation: Error transferring storage volume: Error copying from migration connection to "/dev/zvol/lxdtest-fut/custom/default_iso1.iso": write /dev/zvol/lxdtest-fut/custom/default_iso1.iso: no space left on device

**Note**: I tried multiple size for ISO files (1, 2, 4, 8) and only
8MiB was reliable. Smaller sizes would always fail on some tests
with the dir backend. Cause: unknown.

Random drive-by fix: update the Github labeler config.