### PR TITLE
static-analysis: Fix shellcheck 0.9.x complaints

### DIFF
--- a/test/extras/stresstest.sh
+++ b/test/extras/stresstest.sh
@@ -127,20 +127,20 @@ createthread() {
         declare -a pids
         for j in $(seq 20); do
             lxc launch busybox "b.$i.$j" &
-            pids[$j]=$!
+            pids[j]=$!
         done
         for j in $(seq 20); do
             # ignore errors if the task has already exited
-            wait ${pids[$j]} 2>/dev/null || true
+            wait "${pids[j]}" 2>/dev/null || true
         done
         echo "createthread: deleting..."
         for j in $(seq 20); do
             lxc delete "b.$i.$j" &
-            pids[$j]=$!
+            pids[j]=$!
         done
         for j in $(seq 20); do
             # ignore errors if the task has already exited
-            wait ${pids[$j]} 2>/dev/null || true
+            wait "${pids[j]}" 2>/dev/null || true
         done
     done
     exit 0

--- a/test/suites/fdleak.sh
+++ b/test/suites/fdleak.sh
@@ -40,7 +40,7 @@ test_fdleak() {
 
   bad=0
   # shellcheck disable=SC2015
-  [ ${leakedfds} -gt 5 ] && bad=1 || true
+  [ "${leakedfds}" -gt 5 ] && bad=1 || true
   if [ ${bad} -eq 1 ]; then
     echo "${leakedfds} FDS leaked"
     ls "/proc/${pid}/fd" -al


### PR DESCRIPTION
This fixes shellcheck 0.9.x complaints, so that anyone using a recent version of shellcheck can get a clean output when running `make static-analysis`.
