### PR TITLE
Reduce noise in CI/test logs when DEBUG is set 

### DIFF
--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -32,9 +32,10 @@ lxc_remote() {
         cmd="${cmd} ${DEBUG-}"
     fi
     if [ -n "${DEBUG:-}" ]; then
-        set -x
+        eval "set -x;timeout --foreground 120 ${cmd}"
+    else
+        eval "timeout --foreground 120 ${cmd}"
     fi
-    eval "timeout --foreground 120 ${cmd}"
 }
 
 gen_cert() {

--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -1,6 +1,7 @@
 # lxc CLI related test helpers.
 
 lxc() {
+    set +x
     LXC_LOCAL=1 lxc_remote "$@"
 }
 


### PR DESCRIPTION
Turns:

> + LXD_DIR=/home/runner/work/lxd/lxd/test/tmp.GTh/938 lxc ls
> + LXC_LOCAL=1 lxc_remote ls
> + set +x
> + eval timeout --foreground 120 /home/runner/go/bin/lxc "ls" --verbose
> + timeout --foreground 120 /home/runner/go/bin/lxc ls --verbose

Into (2 less lines):

> + LXD_DIR=/home/runner/work/lxd/lxd/test/tmp.GTh/938 lxc ls
> + set +x
> + timeout --foreground 120 /home/runner/go/bin/lxc ls --verbose

While trimming 2 lines for each lxc invocation, might not seem much, I find those 2 lines to be essentially noise.
Also, one of our test outputs ~79k lines which would be reduced by ~11k with that PR so down to ~68k lines. This would make navigating those logs a tad less annoying IMHO.