### PR TITLE
fix: bgp.ipv*.nexthop keys treated as unknown

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -579,14 +579,14 @@ func (n *common) bgpValidationRules(config map[string]string) (map[string]func(v
 	rules := map[string]func(value string) error{}
 	for k := range config {
 		// BGP keys have the peer name in their name, extract the suffix.
-		if !strings.HasPrefix(k, "bgp.") {
+		if !strings.HasPrefix(k, "bgp.peers.") {
 			continue
 		}
 
 		// Validate remote name in key.
 		fields := strings.Split(k, ".")
 		if len(fields) != 4 {
-			return nil, fmt.Errorf("Invalid network configuration key: %s", k)
+			return nil, fmt.Errorf("Invalid network configuration key: %q", k)
 		}
 
 		bgpKey := fields[3]


### PR DESCRIPTION
These keys were added to validation rules in `driver_bridge.go` instead of inside `bgpValidationRules()` in `driver_common.go`, leading the latter to declare them as "invalid network keys".