### PR TITLE
Doc: Clarify scope of nexthop config keys in BGP extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1687,6 +1687,9 @@ The following network configurations keys (`bridge` and `physical`):
 * `bgp.peers.<name>.address`
 * `bgp.peers.<name>.asn`
 * `bgp.peers.<name>.password`
+
+The `nexthop` configuration keys (`bridge`):
+
 * `bgp.ipv4.nexthop`
 * `bgp.ipv6.nexthop`
 


### PR DESCRIPTION
Found in https://github.com/canonical/lxd/pull/12125