### PR TITLE
Add support for network device limits.priority option

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -307,3 +307,4 @@ Zettabyte
 ZFS
 zpool
 zpools
+qdisc

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2293,3 +2293,8 @@ This introduces a syslog socket that can receive syslog formatted log messages. 
 ## `event_lifecycle_name_and_project`
 
 This adds the fields `Name` and `Project` to `lifecycle` events.
+
+## `instances_nic_limits_priority`
+
+This introduces a new per-NIC `limits.priority` option that works with both cgroup1 and cgroup2 unlike the deprecated `limits.network.priority` instance setting, which only worked with cgroup1.
+

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -450,6 +450,7 @@ The higher the value, the less likely the instance is to be swapped to disk.
 Controls how much priority to give to the instance's network requests when under load.
 
 Specify an integer between 0 and 10.
+This option is deprecated. Use the per-NIC `limits.priority` option instead.
 ```
 
 ```{config:option} limits.processes instance-resource-limits

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -88,6 +88,7 @@ Key                      | Type    | Default           | Managed | Description
 `limits.egress`          | string  | -                 | no      | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.ingress`         | string  | -                 | no      | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.max`             | string  | -                 | no      | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
+`limits.priority`       | integer | -                 | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
 `maas.subnet.ipv4`       | string  | -                 | yes     | MAAS IPv4 subnet to register the instance in
 `maas.subnet.ipv6`       | string  | -                 | yes     | MAAS IPv6 subnet to register the instance in
 `mtu`                    | integer | parent MTU        | yes     | The MTU of the new interface
@@ -354,6 +355,7 @@ Key                     | Type    | Default           | Description
 `limits.egress`         | string  | -                 | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.ingress`        | string  | -                 | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.max`            | string  | -                 | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
+`limits.priority`       | integer | -                 | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
 `mtu`                   | integer | kernel assigned   | The MTU of the new interface
 `name`                  | string  | kernel assigned   | The name of the interface inside the instance
 `queue.tx.length`       | integer | -                 | The transmit queue length for the NIC
@@ -442,6 +444,7 @@ Key                     | Type    | Default           | Description
 `limits.egress`         | string  | -                 | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.ingress`        | string  | -                 | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
 `limits.max`            | string  | -                 | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
+`limits.priority`       | integer | -                 | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
 `mtu`                   | integer | parent MTU        | The MTU of the new interface
 `name`                  | string  | kernel assigned   | The name of the interface inside the instance
 `parent`                | string  | -                 | The name of the host device to join the instance to

--- a/lxd/cgroup/init.go
+++ b/lxd/cgroup/init.go
@@ -313,7 +313,7 @@ func (info *Info) Warnings() []cluster.Warning {
 	if !info.Supports(NetPrio, nil) {
 		warnings = append(warnings, cluster.Warning{
 			TypeCode:    warningtype.MissingCGroupNetworkPriorityController,
-			LastMessage: "network priority will be ignored",
+			LastMessage: "per-instance network priority will be ignored. Please use per-device limits.priority instead",
 		})
 	}
 

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -26,6 +26,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"limits.ingress":                       validate.IsAny,
 		"limits.egress":                        validate.IsAny,
 		"limits.max":                           validate.IsAny,
+		"limits.priority":                      validate.Optional(validate.IsUint32),
 		"security.mac_filtering":               validate.IsAny,
 		"security.ipv4_filtering":              validate.IsAny,
 		"security.ipv6_filtering":              validate.IsAny,

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -557,7 +557,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Apply host-side limits.
-	err = networkSetupHostVethLimits(d.config)
+	err = networkSetupHostVethLimits(&d.deviceCommon, nil, true)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 		}
 
 		// Apply host-side limits.
-		err = networkSetupHostVethLimits(d.config)
+		err = networkSetupHostVethLimits(&d.deviceCommon, oldConfig, true)
 		if err != nil {
 			return err
 		}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -75,6 +75,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		"limits.ingress",
 		"limits.egress",
 		"limits.max",
+		"limits.priority",
 		"ipv4.address",
 		"ipv6.address",
 		"ipv4.routes",
@@ -456,7 +457,7 @@ func (d *nicBridged) UpdatableFields(oldDevice Type) []string {
 		return []string{}
 	}
 
-	return []string{"limits.ingress", "limits.egress", "limits.max", "ipv4.routes", "ipv6.routes", "ipv4.routes.external", "ipv6.routes.external", "ipv4.address", "ipv6.address", "security.mac_filtering", "security.ipv4_filtering", "security.ipv6_filtering"}
+	return []string{"limits.ingress", "limits.egress", "limits.max", "limits.priority", "ipv4.routes", "ipv6.routes", "ipv4.routes.external", "ipv6.routes.external", "ipv4.address", "ipv6.address", "security.mac_filtering", "security.ipv4_filtering", "security.ipv6_filtering"}
 }
 
 // Add is run when a device is added to a non-snapshot instance whether or not the instance is running.
@@ -796,6 +797,14 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 func (d *nicBridged) Stop() (*deviceConfig.RunConfig, error) {
 	// Remove BGP announcements.
 	err := bgpRemovePrefix(&d.deviceCommon, d.config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate device config with volatile fields (hwaddr and host_name) if needed.
+	networkVethFillFromVolatile(d.config, d.volatileGet())
+
+	err = networkClearHostVethLimits(&d.deviceCommon)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -37,6 +37,7 @@ func (d *nicP2P) validateConfig(instConf instance.ConfigReader) error {
 		"limits.ingress",
 		"limits.egress",
 		"limits.max",
+		"limits.priority",
 		"ipv4.routes",
 		"ipv6.routes",
 		"boot.priority",
@@ -67,7 +68,7 @@ func (d *nicP2P) UpdatableFields(oldDevice Type) []string {
 		return []string{}
 	}
 
-	return []string{"limits.ingress", "limits.egress", "limits.max", "ipv4.routes", "ipv6.routes"}
+	return []string{"limits.ingress", "limits.egress", "limits.max", "limits.priority", "ipv4.routes", "ipv6.routes"}
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
@@ -199,6 +200,14 @@ func (d *nicP2P) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 
 // Stop is run when the device is removed from the instance.
 func (d *nicP2P) Stop() (*deviceConfig.RunConfig, error) {
+	// Populate device config with volatile fields (hwaddr and host_name) if needed.
+	networkVethFillFromVolatile(d.config, d.volatileGet())
+
+	err := networkClearHostVethLimits(&d.deviceCommon)
+	if err != nil {
+		return nil, err
+	}
+
 	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -130,7 +130,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Apply host-side limits.
-	err = networkSetupHostVethLimits(d.config)
+	err = networkSetupHostVethLimits(&d.deviceCommon, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (d *nicP2P) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	}
 
 	// Apply host-side limits.
-	err = networkSetupHostVethLimits(d.config)
+	err = networkSetupHostVethLimits(&d.deviceCommon, oldConfig, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -43,7 +43,7 @@ func (d *nicRouted) UpdatableFields(oldDevice Type) []string {
 		return []string{}
 	}
 
-	return []string{"limits.ingress", "limits.egress", "limits.max"}
+	return []string{"limits.ingress", "limits.egress", "limits.max", "limits.priority"}
 }
 
 // validateConfig checks the supplied config for correctness.
@@ -69,6 +69,7 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 		"limits.ingress",
 		"limits.egress",
 		"limits.max",
+		"limits.priority",
 		"ipv4.gateway",
 		"ipv6.gateway",
 		"ipv4.routes",
@@ -588,6 +589,14 @@ func (d *nicRouted) Update(oldDevices deviceConfig.Devices, isRunning bool) erro
 
 // Stop is run when the device is removed from the instance.
 func (d *nicRouted) Stop() (*deviceConfig.RunConfig, error) {
+	// Populate device config with volatile fields (hwaddr and host_name) if needed.
+	networkVethFillFromVolatile(d.config, d.volatileGet())
+
+	err := networkClearHostVethLimits(&d.deviceCommon)
+	if err != nil {
+		return nil, err
+	}
+
 	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -346,7 +346,7 @@ func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	networkVethFillFromVolatile(d.config, saveData)
 
 	// Apply host-side limits.
-	err = networkSetupHostVethLimits(d.config)
+	err = networkSetupHostVethLimits(&d.deviceCommon, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -577,7 +577,7 @@ func (d *nicRouted) Update(oldDevices deviceConfig.Devices, isRunning bool) erro
 		networkVethFillFromVolatile(d.config, v)
 
 		// Apply host-side limits.
-		err = networkSetupHostVethLimits(d.config)
+		err = networkSetupHostVethLimits(&d.deviceCommon, oldDevices[d.name], false)
 		if err != nil {
 			return err
 		}

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -260,3 +260,11 @@ chain prert{{.chainSeparator}}{{.deviceLabel}} {
 	iif "{{.hostName}}" fib saddr . iif oif missing drop
 }
 `))
+
+// nftablesInstanceNetPrio defines the rules to perform setting of skb->priority.
+var nftablesInstanceNetPrio = template.Must(template.New("nftablesInstanceNetPrio").Parse(`
+chain egress{{.chainSeparator}}netprio{{.chainSeparator}}{{.deviceLabel}} {
+	type filter hook egress device "{{.deviceName}}" priority 0 ;
+	meta priority set "{{.netPrio}}"
+}
+`))

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -24,4 +24,7 @@ type Firewall interface {
 
 	InstanceSetupRPFilter(projectName string, instanceName string, deviceName string, hostName string) error
 	InstanceClearRPFilter(projectName string, instanceName string, deviceName string) error
+
+	InstanceSetupNetPrio(projectName string, instanceName string, deviceName string, netPrio uint32) error
+	InstanceClearNetPrio(projectName string, instanceName string, deviceName string) error
 }

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -463,7 +463,7 @@
 						"limits.network.priority": {
 							"defaultdesc": "`0` (minimum)",
 							"liveupdate": "yes",
-							"longdesc": "Controls how much priority to give to the instance's network requests when under load.\n\nSpecify an integer between 0 and 10.",
+							"longdesc": "Controls how much priority to give to the instance's network requests when under load.\n\nSpecify an integer between 0 and 10.\nThis option is deprecated. Use the per-NIC `limits.priority` option instead.",
 							"shortdesc": "Priority of the instance's network requests",
 							"type": "integer"
 						}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -278,6 +278,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// Controls how much priority to give to the instance's network requests when under load.
 	//
 	// Specify an integer between 0 and 10.
+	// This option is deprecated. Use the per-NIC `limits.priority` option instead.
 	// ---
 	//  type: integer
 	//  defaultdesc: `0` (minimum)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -384,6 +384,7 @@ var APIExtensions = []string{
 	"metadata_configuration",
 	"syslog_socket",
 	"event_lifecycle_name_and_project",
+	"instances_nic_limits_priority",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
 lxd/device: add support for network device limits.priority option

This is a replacement feature for per-instance limits.network.priority option.
New approach does not require netprio cgroup to be suppored (it's from legacy
cgroup v1) and also it allows to set priority for virtual machine instances.

The recommended Linux kernel version (for full functionality) is 5.16.