### PR TITLE
Doc: PoC for adding API instructions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -153,6 +153,17 @@ intersphinx_mapping = {
 
 notfound_urls_prefix = "/lxd/en/latest/"
 
+if ("LOCAL_SPHINX_BUILD" in os.environ) and (os.environ["LOCAL_SPHINX_BUILD"] == "True"):
+    swagger_url_scheme = "/api/#{{path}}"
+else:
+    swagger_url_scheme = "/lxd/en/latest/api/#{{path}}"
+
+myst_url_schemes = {
+    "http": None,
+    "https": None,
+    "swagger": swagger_url_scheme,
+}
+
 # Setup theme.
 templates_path = [".sphinx/_templates"]
 
@@ -252,7 +263,9 @@ ogp_image = "https://documentation.ubuntu.com/lxd/en/latest/_static/tag.png"
 linkcheck_ignore = [
     'https://127.0.0.1:8443/1.0',
     'https://web.libera.chat/#lxd',
-    'http://localhost:8001'
+    'http://localhost:8001',
+    r'/lxd/en/latest/api/.*',
+    r'/api/.*'
 ]
 linkcheck_exclude_documents = [r'.*/manpages/.*']
 

--- a/doc/howto/instances_configure.md
+++ b/doc/howto/instances_configure.md
@@ -1,7 +1,7 @@
 (instances-configure)=
 # How to configure instances
 
-You can configure instances by setting {ref}`instance-options` or by adding and configuring {ref}`devices`.
+You can configure instances by setting {ref}`instance-properties`, {ref}`instance-options`, or by adding and configuring {ref}`devices`.
 
 See the following sections for instructions.
 
@@ -14,27 +14,50 @@ To store and reuse different instance configurations, use {ref}`profiles <profil
 
 You can specify instance options when you {ref}`create an instance <instances-create>`.
 
-To update instance options after the instance is created, use the [`lxc config set`](lxc_config_set.md) command.
+````{tabs}
+```{group-tab} CLI
+Alternatively, to update instance options after the instance is created, use the [`lxc config set`](lxc_config_set.md) command.
 Specify the instance name and the key and value of the instance option:
 
     lxc config set <instance_name> <option_key>=<option_value> <option_key>=<option_value> ...
+```
+
+```{group-tab} API
+Alternatively, to update instance options after the instance is created, send a PATCH request to the instance.
+Specify the instance name and the key and value of the instance option:
+
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"config": {"<option_key>":"<option_value>","<option_key>":"<option_value>"}}'
+
+See [`PATCH /1.0/instances/{name}`](swagger:/instances/instance_patch) for more information.
+```
+````
 
 See {ref}`instance-options` for a list of available options and information about which options are available for which instance type.
 
 For example, to change the memory limit for your container, enter the following command:
 
+````{tabs}
+```{group-tab} CLI
     lxc config set my-container limits.memory=128MiB
+```
+
+```{group-tab} API
+    lxc query --request PATCH /1.0/instances/my-container --data '{"config": {"limits.memory":"128MiB"}}'
+```
+````
 
 ```{note}
 Some of the instance options are updated immediately while the instance is running.
 Others are updated only when the instance is restarted.
 
-See the "Live update" column in the {ref}`instance-options` tables for information about which options are applied immediately while the instance is running.
+See the "Live update" information in the {ref}`instance-options` reference for information about which options are applied immediately while the instance is running.
 ```
 
 (instances-configure-properties)=
 ## Configure instance properties
 
+````{tabs}
+```{group-tab} CLI
 To update instance properties after the instance is created, use the [`lxc config set`](lxc_config_set.md) command with the `--property` flag.
 Specify the instance name and the key and value of the instance property:
 
@@ -47,17 +70,27 @@ Using the same flag, you can also unset a property just like you would unset a c
 You can also retrieve a specific property value with:
 
     lxc config get <instance_name> <property_key> --property
+```
+
+```{group-tab} API
+To update instance properties through the API, use the same mechanism as for configuring instance options.
+The only difference is that properties are on the root level of the configuration, while options are under the `config` field.
+
+Therefore, to set an instance property, send a PATCH request to the instance:
+
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"<property_key>":"<property_value>","<property_key>":"property_value>"}}'
+
+To unset an instance property, send a PUT request that contains the full instance configuration that you want except for the property that you want to unset.
+
+See [`PATCH /1.0/instances/{name}`](swagger:/instances/instance_patch) and [`PUT /1.0/instances/{name}`](swagger:/instances/instance_put) for more information.
+```
+````
 
 (instances-configure-devices)=
 ## Configure devices
 
-To add and configure an instance device for your instance, use the [`lxc config device add`](lxc_config_device_add.md) command.
 Generally, devices can be added or removed for a container while it is running.
 VMs support hotplugging for some device types, but not all.
-
-Specify the instance name, a device name, the device type and maybe device options (depending on the {ref}`device type <devices>`):
-
-    lxc config device add <instance_name> <device_name> <device_type> <device_option_key>=<device_option_value> <device_option_key>=<device_option_value> ...
 
 See {ref}`devices` for a list of available device types and their options.
 
@@ -70,6 +103,14 @@ At each stage, if a device with the same name already exists from an earlier sta
 
 Device names are limited to a maximum of 64 characters.
 ```
+
+`````{tabs}
+````{group-tab} CLI
+To add and configure an instance device for your instance, use the [`lxc config device add`](lxc_config_device_add.md) command.
+
+Specify the instance name, a device name, the device type and maybe device options (depending on the {ref}`device type <devices>`):
+
+    lxc config device add <instance_name> <device_name> <device_type> <device_option_key>=<device_option_value> <device_option_key>=<device_option_value> ...
 
 For example, to add the storage at `/share/c1` on the host system to your instance at path `/opt`, enter the following command:
 
@@ -86,16 +127,47 @@ This is useful if you want to override device options for a device that is provi
 
 To remove a device, use the [`lxc config device remove`](lxc_config_device_remove.md) command.
 See [`lxc config device --help`](lxc_config_device.md) for a full list of available commands.
+````
+
+````{group-tab} API
+To add and configure an instance device for your instance, use the same mechanism of patching the instance configuration.
+The device configuration is located under the `devices` field of the configuration.
+
+Specify the instance name, a device name, the device type and maybe device options (depending on the {ref}`device type <devices>`):
+
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"devices": {"<device_name>": {"type":"<device_type>","<device_option_key>":"<device_option_value>","<device_option_key>":"device_option_value>"}}}'
+
+For example, to add the storage at `/share/c1` on the host system to your instance at path `/opt`, enter the following command:
+
+    lxc query --request PATCH /1.0/instances/my-container --data '{"devices": {"disk-storage-device": {"type":"disk","source":"/share/c1","path":"/opt"}}}'
+
+See [`PATCH /1.0/instances/{name}`](swagger:/instances/instance_patch) for more information.
+````
+`````
 
 ## Display instance configuration
 
+````{tabs}
+```{group-tab} CLI
 To display the current configuration of your instance, including writable instance properties, instance options, devices and device options, enter the following command:
 
     lxc config show <instance_name> --expanded
+```
+
+```{group-tab} API
+To retrieve the current configuration of your instance, including writable instance properties, instance options, devices and device options, send a GET request to the instance:
+
+    lxc query /1.0/instances/<instance_name>
+
+See [`GET /1.0/instances/{name}`](swagger:/instances/instance_get) for more information.
+```
+````
 
 (instances-configure-edit)=
 ## Edit the full instance configuration
 
+`````{tabs}
+````{group-tab} CLI
 To edit the full instance configuration, including writable instance properties, instance options, devices and device options, enter the following command:
 
     lxc config edit <instance_name>
@@ -105,3 +177,16 @@ For convenience, the [`lxc config edit`](lxc_config_edit.md) command displays th
 However, you cannot edit those properties.
 Any changes are ignored.
 ```
+````
+
+````{group-tab} API
+To update the full instance configuration, including writable instance properties, instance options, devices and device options, send a PUT request to the instance:
+
+    lxc query --request PUT /1.0/instances/<instance_name> --data '<instance_configuration>'
+
+See [`PUT /1.0/instances/{name}`](swagger:/instances/instance_put) for more information.
+
+```{note}
+If you include changes to any read-only instance properties in the configuration you provide, they are ignored.
+````
+`````

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -1,6 +1,11 @@
 (instances-manage)=
 # How to manage instances
 
+When listing the existing instances, you can see their type, status, and location (if applicable).
+You can filter the instances and display only the ones that you are interested in.
+
+````{tabs}
+```{group-tab} CLI
 Enter the following command to list all instances:
 
     lxc list
@@ -18,9 +23,34 @@ For example:
     lxc list ubuntu.*
 
 Enter [`lxc list --help`](lxc_list.md) to see all filter options.
+```
+
+```{group-tab} API
+Query the `/1.0/instances` endpoint to list all instances.
+You can use {ref}`rest-api-recursion` to display more information about the instances:
+
+    lxc query /1.0/instances?recursion=2
+
+You can {ref}`filter <rest-api-filtering>` the instances that are displayed, by name, type, status or the cluster member where the instance is located:
+
+    lxc query /1.0/instances?filter=name+eq+ubuntu
+    lxc query /1.0/instances?filter=type+eq+container
+    lxc query /1.0/instances?filter=status+eq+running
+    lxc query /1.0/instances?filter=location+eq+server1
+
+To list several instances, use a regular expression for the name.
+For example:
+
+    lxc query /1.0/instances?filter=name+eq+ubuntu.*
+
+See [`GET /1.0/instances`](swagger:/instances/instances_get) for more information.
+```
+````
 
 ## Show information about an instance
 
+````{tabs}
+```{group-tab} CLI
 Enter the following command to show detailed information about an instance:
 
     lxc info <instance_name>
@@ -28,9 +58,21 @@ Enter the following command to show detailed information about an instance:
 Add `--show-log` to the command to show the latest log lines for the instance:
 
     lxc info <instance_name> --show-log
+```
+
+```{group-tab} API
+Query the following endpoint to show detailed information about an instance:
+
+    lxc query /1.0/instances/<instance_name>
+
+See [`GET /1.0/instances/{name}`](swagger:/instances/instance_get) for more information.
+```
+````
 
 ## Start an instance
 
+````{tabs}
+```{group-tab} CLI
 Enter the following command to start an instance:
 
     lxc start <instance_name>
@@ -43,24 +85,73 @@ For example:
     lxc start <instance_name> --console
 
 See {ref}`instances-console` for more information.
+```
+
+```{group-tab} API
+To start an instance, send a PUT request to change the instance state:
+
+    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action":"start"}'
+
+<!-- Include start monitor status -->
+The return value of this query contains an operation ID, which you can use to query the status of the operation:
+
+    lxc query /1.0/operations/<operation_ID>
+
+Use the following query to monitor the state of the instance:
+
+    lxc query /1.0/instances/<instance_name>/state
+
+See [`GET /1.0/instances/{name}/state`](swagger:/instances/instance_state_get) and [`PUT /1.0/instances/{name}/state`](swagger:/instances/instance_state_put)for more information.
+<!-- Include end monitor status -->
+```
+````
 
 (instances-manage-stop)=
 ## Stop an instance
 
+`````{tabs}
+````{group-tab} CLI
 Enter the following command to stop an instance:
 
     lxc stop <instance_name>
 
 You will get an error if the instance does not exist or if it is not running.
+````
+
+````{group-tab} API
+To stop an instance, send a PUT request to change the instance state:
+
+    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action":"stop"}'
+
+% Include content from above
+```{include} ./instances_manage.md
+    :start-after: <!-- Include start monitor status -->
+    :end-before: <!-- Include end monitor status -->
+```
+
+````
+`````
 
 ## Delete an instance
 
 If you don't need an instance anymore, you can remove it.
 The instance must be stopped before you can delete it.
 
+````{tabs}
+```{group-tab} CLI
 Enter the following command to delete an instance:
 
     lxc delete <instance_name>
+```
+
+```{group-tab} API
+To delete an instance, send a DELETE request to the instance:
+
+    lxc query --request DELETE /1.0/instances/<instance_name>
+
+See [`DELETE /1.0/instances/{name}`](swagger:/instances/instance_delete) for more information.
+```
+````
 
 ```{caution}
 This command permanently deletes the instance and all its snapshots.
@@ -68,14 +159,13 @@ This command permanently deletes the instance and all its snapshots.
 
 ### Prevent accidental deletion of instances
 
-There are two ways to prevent accidental deletion of instances:
-
-- To be prompted for approval every time you use the [`lxc delete`](lxc_delete.md) command, create an alias for it:
-
-       lxc alias add delete "delete -i"
+There are different ways to prevent accidental deletion of instances:
 
 - To protect a specific instance from being deleted, set {config:option}`instance-security:security.protection.delete` to `true` for the instance.
   See {ref}`instances-configure` for instructions.
+- In the CLI client, you can create an alias to be prompted for approval every time you use the [`lxc delete`](lxc_delete.md) command:
+
+       lxc alias add delete "delete -i"
 
 ## Rebuild an instance
 
@@ -84,14 +174,30 @@ If you want to wipe and re-initialize the root disk of your instance but keep th
 Rebuilding is only possible for instances that do not have any snapshots.
 
 Stop your instance before rebuilding it.
-Then enter one of the following commands:
 
-- Rebuild the instance with a different image:
+````{tabs}
+```{group-tab} CLI
+Enter the following command to rebuild the instance with a different image:
 
-        lxc rebuild <image_name> <instance_name>
+    lxc rebuild <image_name> <instance_name>
 
-- Rebuild the instance with an empty root disk:
+Enter the following command to rebuild the instance with an empty root disk:
 
-        lxc rebuild <instance_name> --empty
+    lxc rebuild <instance_name> --empty
 
 For more information about the `rebuild` command, see [`lxc rebuild --help`](lxc_rebuild.md).
+```
+
+```{group-tab} API
+To rebuild the instance with a different image, send a POST request to the instance's `rebuild` endpoint.
+For example:
+
+    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{"source": {"alias":"<image_alias>","server":"<server_URL>", protocol:"simplestreams"}}'
+
+To rebuild the instance with an empty root disk, specify the source type as `none`:
+
+    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{"source": {"type":"none"}}'
+
+See [`POST /1.0/instances/{name}/rebuild`](swagger:/instances/instance_rebuild_post) for more information.
+```
+````

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -155,6 +155,7 @@ Code  | Meaning
 400   | Failure
 401   | Canceled
 
+(rest-api-recursion)=
 ## Recursion
 
 To optimize queries of large lists, recursion is implemented for collections.
@@ -167,6 +168,7 @@ they point to (typically another JSON object).
 Recursion is implemented by simply replacing any pointer to an job (URL)
 by the object itself.
 
+(rest-api-filtering)=
 ## Filtering
 
 To filter your results on certain values, filter is implemented for collections.


### PR DESCRIPTION
This PR adds an example of how to present API instructions alongside the CLI instructions.
Updating all instructions will be a separate task. In addition, we also want to include UI instructions in the future.