### PR TITLE
doc/api-extensions: fix extension name for VM support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -1047,7 +1047,7 @@ redirect file-system mounts to their fuse implementation. To this end, set e.g.
 
 This allows for existing a Ceph RBD or CephFS to be directly connected to a LXD container.
 
-## `virtual_machines`
+## `virtual-machines`
 
 Add virtual machine support.
 


### PR DESCRIPTION
While all the other extensions use "_" as word separator, it seems that "virtual-machine" was typo'ed when VM support was introduced. It's too late to change the extension name though but we should have matching doc at least.