### PR TITLE
Add device parameter for importing instance command

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -582,6 +582,9 @@ type InstanceBackupArgs struct {
 
 	// Name to import backup as
 	Name string
+
+	// If set, it would override devices
+	Devices map[string]map[string]string
 }
 
 // The InstanceCopyArgs struct is used to pass additional options during instance copy.

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -545,7 +545,7 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 		return nil, err
 	}
 
-	if args.PoolName == "" && args.Name == "" {
+	if args.PoolName == "" && args.Name == "" && len(args.Devices) == 0 {
 		// Send the request
 		op, _, err := r.queryOperation("POST", path, args.BackupFile, "", true)
 		if err != nil {
@@ -588,6 +588,21 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 
 	if args.Name != "" {
 		req.Header.Set("X-LXD-name", args.Name)
+	}
+
+	if len(args.Devices) > 0 {
+		devProps := url.Values{}
+
+		for dev := range args.Devices {
+			props := url.Values{}
+			for k, v := range args.Devices[dev] {
+				props.Set(k, v)
+			}
+
+			devProps.Set(dev, props.Encode())
+		}
+
+		req.Header.Set("X-LXD-devices", devProps.Encode())
 	}
 
 	// Send the request

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2340,3 +2340,7 @@ the event as that's usually already covered by the `location` field.
 Adds a new `volatile.uuid` configuration key to all storage volumes, snapshots and buckets.
 This information can be used by storage drivers as a separate identifier besides the name
 when working with volumes.
+
+## `import_instance_devices`
+
+This API extension provides the ability to use flags `--device` when importing an instance to override instance's devices.

--- a/lxd/backup/backup_config_utils.go
+++ b/lxd/backup/backup_config_utils.go
@@ -90,6 +90,33 @@ func ParseConfigYamlFile(path string) (*config.Config, error) {
 	return &backupConf, nil
 }
 
+// OverrideConfigYamlFile overrides the YAML file.
+func OverrideConfigYamlFile(path string, backupConf *config.Config) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	data, err := yaml.Marshal(backupConf)
+	if err != nil {
+		return err
+	}
+
+	err = f.Chmod(0400)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // updateRootDevicePool updates the root disk device in the supplied list of devices to the pool
 // specified. Returns true if a root disk device has been found and updated otherwise false.
 func updateRootDevicePool(devices map[string]map[string]string, poolName string) bool {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -395,6 +395,7 @@ var APIExtensions = []string{
 	"oidc_groups_claim",
 	"loki_config_instance",
 	"storage_volatile_uuid",
+	"import_instance_devices",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Fixes:  [#12000](https://github.com/canonical/lxd/issues/12000)

This PR is for setup device config when importing container.
When the CLI receives the "--device" parameter (just like "lxc copy --device"), it encodes it into a string and places it to "X-LXD-devices" header to send to the LXD API server. These code are referenced from "X-LXD-properties" and "X-LXD-profiles" header.
The "OverrideConfigYamlFile" function is intended to ensure that the device config in backup.yaml match the current instance settings to avoid potential issues.
Maybe we could remove it to make it simple.