### PR TITLE
doc/storage: mark ZFS as usable inside a container

### DIFF
--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -18,7 +18,9 @@ Unless specified differently during creation (with the `source` configuration op
 (storage-dir-quotas)=
 ### Quotas
 
+<!-- Include start dir quotas -->
 The `dir` driver supports storage quotas when running on either ext4 or XFS with project quotas enabled at the file system level.
+<!-- Include end dir quotas -->
 
 ## Configuration options
 

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -26,21 +26,29 @@ See the corresponding pages for driver-specific information and configuration op
 
 Where possible, LXD uses the advanced features of each storage system to optimize operations.
 
-Feature                                     | Directory | Btrfs | LVM   | ZFS  | Ceph RBD | CephFS | Ceph Object
-:---                                        | :---      | :---  | :---  | :--- | :---     | :---   | :---
-{ref}`storage-optimized-image-storage`      | no        | yes   | yes   | yes  | yes      | n/a    | n/a
-Optimized instance creation                 | no        | yes   | yes   | yes  | yes      | n/a    | n/a
-Optimized snapshot creation                 | no        | yes   | yes   | yes  | yes      | yes    | n/a
-Optimized image transfer                    | no        | yes   | no    | yes  | yes      | n/a    | n/a
-{ref}`storage-optimized-volume-transfer`  | no        | yes   | no    | yes  | yes      | n/a    | n/a
-Copy on write                               | no        | yes   | yes   | yes  | yes      | yes    | n/a
-Block based                                 | no        | no    | yes   | no   | yes      | no     | n/a
-Instant cloning                             | no        | yes   | yes   | yes  | yes      | yes    | n/a
-Storage driver usable inside a container    | yes       | yes   | no    | no   | no       | n/a    | n/a
-Restore from older snapshots (not latest)   | yes       | yes   | yes   | no   | yes      | yes    | n/a
-Storage quotas                              | yes<sup>{ref}`* <storage-dir-quotas>`</sup>| yes   | yes   | yes  | yes  | yes    | yes
-Available on `lxd init`                     | yes       | yes   | yes   | yes  | yes      | no     | no
-Object storage                              | yes       | yes   | yes   | yes  | no       | no     | yes
+Feature                                     | Directory | Btrfs | LVM   | ZFS     | Ceph RBD | CephFS | Ceph Object
+:---                                        | :---      | :---  | :---  | :---    | :---     | :---   | :---
+{ref}`storage-optimized-image-storage`      | no        | yes   | yes   | yes     | yes      | n/a    | n/a
+Optimized instance creation                 | no        | yes   | yes   | yes     | yes      | n/a    | n/a
+Optimized snapshot creation                 | no        | yes   | yes   | yes     | yes      | yes    | n/a
+Optimized image transfer                    | no        | yes   | no    | yes     | yes      | n/a    | n/a
+{ref}`storage-optimized-volume-transfer`    | no        | yes   | no    | yes     | yes      | n/a    | n/a
+Copy on write                               | no        | yes   | yes   | yes     | yes      | yes    | n/a
+Block based                                 | no        | no    | yes   | no      | yes      | no     | n/a
+Instant cloning                             | no        | yes   | yes   | yes     | yes      | yes    | n/a
+Storage driver usable inside a container    | yes       | yes   | no    | yes[^1] | no       | n/a    | n/a
+Restore from older snapshots (not latest)   | yes       | yes   | yes   | no      | yes      | yes    | n/a
+Storage quotas                              | yes[^2]   | yes   | yes   | yes     | yes      | yes    | yes
+Available on `lxd init`                     | yes       | yes   | yes   | yes     | yes      | no     | no
+Object storage                              | yes       | yes   | yes   | yes     | no       | no     | yes
+
+[^1]: Requires [`zfs.delegate`](storage-zfs-vol-config) to be enabled.
+[^2]: % Include content from [storage_dir.md](storage_dir.md)
+
+      ```{include} storage_dir.md
+         :start-after: <!-- Include start dir quotas -->
+         :end-before: <!-- Include end dir quotas -->
+      ```
 
 (storage-optimized-image-storage)=
 ### Optimized image storage


### PR DESCRIPTION
Also add a footnote about zfs.delegate, and make the existing asterisk a valid footnote.

Fixes #12142.