### PR TITLE
Instance: Fix placement when moving within same cluster group

### DIFF
--- a/test/suites/clustering_move.sh
+++ b/test/suites/clustering_move.sh
@@ -52,8 +52,12 @@ test_clustering_move() {
   LXD_DIR="${LXD_ONE_DIR}" lxc info c1 | grep -q "Location: node1"
 
   # c1 can be moved within the same cluster group if it has multiple members
+  current_location="$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/instances/c1 | jq -r '.location')"
   LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@default
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/instances/c1 | jq -re ".location != \"$current_location\""
+  current_location="$(LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/instances/c1 | jq -r '.location')"
   LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@default
+  LXD_DIR="${LXD_ONE_DIR}" lxc query /1.0/instances/c1 | jq -re ".location != \"$current_location\""
 
   # c1 cannot be moved within the same cluster group if it has a single member
   LXD_DIR="${LXD_ONE_DIR}" lxc move c1 --target=@foobar3


### PR DESCRIPTION
First observed in https://github.com/canonical/lxd/pull/12143. 

When moving instances within the same cluster group, the node which is currently hosting the instance should not be selected by the scheduler due to having the least amount of instances. 

`GetNodeWithLeastInstances()` most probably returned the instances in a different order than usual. This led the scheduler to pick the node that is already hosting the instance as candidate.