### PR TITLE
doc: Align header of macaroon_authentication

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -420,7 +420,7 @@ files for the container via `nofile`. The format is `limits.kernel.[limit name]`
 
 This adds support for renaming custom storage volumes.
 
-## `external_authentication`
+## `macaroon_authentication`
 
 This adds support for external authentication via Macaroons.
 


### PR DESCRIPTION
This changes the header of the API extension to match the actual API
extension.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
