### PR TITLE
doc: restrict Sphinx version

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -16,7 +16,7 @@ pytz
 requests
 six
 snowballstemmer
-Sphinx
+Sphinx<7.2.0
 sphinx-autobuild
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp


### PR DESCRIPTION
The latest Sphinx version that was released today removes functions that some extensions require.
Temporarily restrict the Sphinx version until the extensions have been fixed.