### PR TITLE
Fix migration condition for bridged network devices

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -54,7 +54,7 @@ func (d *nicBridged) CanHotPlug() bool {
 
 // CanMigrate returns whether the device can be migrated to any other cluster member.
 func (d *nicBridged) CanMigrate() bool {
-	return d.config["network"] != ""
+	return d.network != nil
 }
 
 // validateConfig checks the supplied config for correctness.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1064,7 +1064,9 @@ func (d *common) warningsDelete() error {
 	return nil
 }
 
-// canMigrate returns whether the instance can be migrated.
+// canMigrate determines if the given instance can be migrated and whether the migration
+// can be live. In "auto" mode, the function checks each attached device of the instance
+// to ensure they are all migratable.
 func (d *common) canMigrate(inst instance.Instance) (bool, bool) {
 	// Check policy for the instance.
 	config := d.ExpandedConfig()
@@ -1091,10 +1093,12 @@ func (d *common) canMigrate(inst instance.Instance) (bool, bool) {
 	for deviceName, rawConfig := range d.ExpandedDevices() {
 		dev, err := device.New(inst, d.state, deviceName, rawConfig, volatileGet, volatileSet)
 		if err != nil {
+			logger.Warn("Instance will not be migrated due to a device error", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "device": dev.Name(), "err": err})
 			return false, false
 		}
 
 		if !dev.CanMigrate() {
+			logger.Warn("Instance will not be migrated because its device cannot be migrated", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "device": dev.Name()})
 			return false, false
 		}
 	}

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -178,7 +178,21 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Legacy version of `cloud-init.vendor-data`
 
 	// lxddoc:generate(group=instance-miscellaneous, key=cluster.evacuate)
-	// Possible values are `auto`, `migrate`, `live-migrate`, or `stop`.
+	// The `cluster.evacuate` provides control over how instances are handled when a cluster member is being
+	// evacuated.
+	//
+	// Available Modes:
+	//   - `auto` *(default)*: The system will automatically decide the best evacuation method based on the
+	//      instance's type and configured devices:
+	//     + If any device is not suitable for migration, the instance will not be migrated (only stopped).
+	//     + Live migration will be used only for virtual machines with the `migration.stateful` setting
+	//       enabled and for which all its devices can be migrated as well.
+	//   - `live-migrate`: Instances are live-migrated to another node. This means the instance remains running
+	//      and operational during the migration process, ensuring minimal disruption.
+	//   - `migrate`: In this mode, instances are migrated to another node in the cluster. The migration
+	//      process will not be live, meaning there will be a brief downtime for the instance during the
+	//      migration.
+	//   -  `stop`: Instances are not migrated. Instead, they are stopped on the current node.
 	//
 	// See {ref}`cluster-evacuate` for more information.
 	// ---


### PR DESCRIPTION
This PR fixes the migration condition of bridged network device.
It also adds logging to show instances where auto-migration is prevented due to a device's lack of migration support.

Fixes #12174