### PR TITLE
doc: directly link to config options

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -85,7 +85,7 @@ To do so, copy the client certificate to the server and register it using `lxc c
 (authentication-trust-pw)=
 #### Adding client certificates using a trust password
 
-To allow establishing a new trust relationship from the client side, you must set a trust password ([`core.trust_password`](server-options-core)) for the server. Clients can then add their own certificate to the server's trust store by providing the trust password when prompted.
+To allow establishing a new trust relationship from the client side, you must set a trust password ({config:option}`server-core:core.trust_password`) for the server. Clients can then add their own certificate to the server's trust store by providing the trust password when prompted.
 
 In a production setup, unset `core.trust_password` after all clients have been added.
 This prevents brute-force attacks trying to guess the password.
@@ -93,7 +93,7 @@ This prevents brute-force attacks trying to guess the password.
 (authentication-token)=
 #### Adding client certificates using tokens
 
-You can also add new clients by using tokens. This is a safer way than using the trust password, because tokens expire after a configurable time ([`core.remote_token_expiry`](server-options-core)) or once they've been used.
+You can also add new clients by using tokens. This is a safer way than using the trust password, because tokens expire after a configurable time ({config:option}`server-core:core.remote_token_expiry`) or once they've been used.
 
 To use this method, generate a token for each client by calling `lxc config trust add`, which will prompt for the client name.
 The clients can then add their certificates to the server's trust store by providing the generated token when prompted for the trust password.
@@ -162,7 +162,7 @@ The LXD client then retrieves and stores the access and refresh tokens and provi
 ```
 
 You can configure LXD to use [Candid](https://github.com/canonical/candid) authentication by setting the [`candid.*`](server-options-candid-rbac) server configuration options.
-In this case, clients that try to authenticate with the server must get a Discharge token from the authentication server specified by the [`candid.api.url`](server-options-candid-rbac) option.
+In this case, clients that try to authenticate with the server must get a Discharge token from the authentication server specified by the {config:option}`server-candid-and-rbac:candid.api_url` option.
 
 The authentication server certificate must be trusted by the LXD server.
 
@@ -208,12 +208,12 @@ To enable RBAC for your LXD server, set the [`rbac.*`](server-options-candid-rba
 
 LXD supports issuing server certificates using {abbr}`ACME (Automatic Certificate Management Environment)` services, for example, [Let's Encrypt](https://letsencrypt.org/).
 
-To enable this feature, set the following {ref}`server configuration <server-options-acme>`:
+To enable this feature, set the following server configuration:
 
-- `acme.domain`: The domain for which the certificate should be issued.
-- `acme.email`: The email address used for the account of the ACME service.
-- `acme.agree_tos`: Must be set to `true` to agree to the ACME service's terms of service.
-- `acme.ca_url`: The directory URL of the ACME service. By default, LXD uses "Let's Encrypt".
+- {config:option}`server-acme:acme.domain`: The domain for which the certificate should be issued.
+- {config:option}`server-acme:acme.email`: The email address used for the account of the ACME service.
+- {config:option}`server-acme:acme.agree_tos`: Must be set to `true` to agree to the ACME service's terms of service.
+- {config:option}`server-acme:acme.ca_url`: The directory URL of the ACME service. By default, LXD uses "Let's Encrypt".
 
 For this feature to work, LXD must be reachable from port 80.
 This can be achieved by using a reverse proxy such as [HAProxy](http://www.haproxy.org/).

--- a/doc/dev-lxd.md
+++ b/doc/dev-lxd.md
@@ -15,7 +15,7 @@ connect to. It's multi-threaded so multiple clients can be connected at the
 same time.
 
 ```{note}
-[`security.devlxd`](instance-options-security) must be set to `true` (which is the default) for an instance to allow access to the socket.
+{config:option}`instance-security:security.devlxd` must be set to `true` (which is the default) for an instance to allow access to the socket.
 ```
 
 ## Implementation details

--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -57,8 +57,8 @@ Automatic roles are assigned by LXD itself and cannot be modified by the user.
 | `event-hub`           | no            | Exchange point (hub) for the internal LXD events (requires at least two) |
 | `ovn-chassis`         | no            | Uplink gateway candidate for OVN networks |
 
-The default number of voter members ([`cluster.max_voters`](server-options-cluster)) is three.
-The default number of stand-by members ([`cluster.max_standby`](server-options-cluster)) is two.
+The default number of voter members ({config:option}`server-cluster:cluster.max_voters`) is three.
+The default number of stand-by members ({config:option}`server-cluster:cluster.max_standby`) is two.
 With this configuration, your cluster will remain operational as long as you switch off at most one voting member at a time.
 
 See {ref}`cluster-manage` for more information.
@@ -75,11 +75,11 @@ If the member that goes offline is the leader itself, the other members will ele
 
 If you can't or don't want to bring the server back online, you can [delete it from the cluster](cluster-manage-delete-members).
 
-You can tweak the amount of seconds after which a non-responding member is considered offline by setting the [`cluster.offline_threshold`](server-options-cluster) configuration.
+You can tweak the amount of seconds after which a non-responding member is considered offline by setting the {config:option}`server-cluster:cluster.offline_threshold` configuration.
 The default value is 20 seconds.
 The minimum value is 10 seconds.
 
-To automatically {ref}`evacuate <cluster-evacuate>` instances from an offline member, set the [`cluster.healing_threshold`](server-options-cluster) configuration to a non-zero value.
+To automatically {ref}`evacuate <cluster-evacuate>` instances from an offline member, set the {config:option}`server-cluster:cluster.healing_threshold` configuration to a non-zero value.
 
 See {ref}`cluster-recover` for more information.
 
@@ -119,7 +119,7 @@ By default, LXD replicates images on as many cluster members as there are databa
 This typically means up to three copies within the cluster.
 
 You can increase that number to improve fault tolerance and the likelihood of the image being locally available.
-To do so, set the [`cluster.images_minimal_replica`](server-options-cluster) configuration.
+To do so, set the {config:option}`server-cluster:cluster.images_minimal_replica` configuration.
 The special value of `-1` can be used to have the image copied to all cluster members.
 
 (cluster-groups)=
@@ -142,7 +142,7 @@ When you launch an instance, you can target it to a specific cluster member, to 
 By default, the automatic assignment picks the cluster member that has the lowest number of instances.
 If several members have the same amount of instances, one of the members is chosen at random.
 
-However, you can control this behavior with the [`scheduler.instance`](cluster-member-config) configuration option:
+However, you can control this behavior with the {config:option}`cluster:scheduler.instance` configuration option:
 
 - If `scheduler.instance` is set to `all` for a cluster member, this cluster member is selected for an instance if:
 

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -68,7 +68,7 @@ LXD containers can use a wide range of features for security.
 
 By default, containers are *unprivileged*, meaning that they operate inside a user namespace, restricting the abilities of users in the container to that of regular users on the host with limited privileges on the devices that the container owns.
 
-If data sharing between containers isn't needed, you can enable `security.idmap.isolated` (see {ref}`instance-options-security`), which will use non-overlapping UID/GID maps for each container, preventing potential {abbr}`DoS (Denial of Service)` attacks on other containers.
+If data sharing between containers isn't needed, you can enable {config:option}`instance-security:security.idmap.isolated`, which will use non-overlapping UID/GID maps for each container, preventing potential {abbr}`DoS (Denial of Service)` attacks on other containers.
 
 LXD can also run *privileged* containers.
 Note, however, that those aren't root safe, and a user with root access in such a container will be able to DoS the host as well as find ways to escape confinement.

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -179,7 +179,7 @@ Each storage bucket is assigned one or more access keys, which the applications 
 
 Storage buckets can be located on local storage (with `dir`, `btrfs`, `lvm` or `zfs` pools) or on remote storage (with `cephobject` pools).
 
-To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the `core.storage_buckets_address` server setting (see {ref}`server-options-core`).
+To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
 See the following how-to guide for additional information:
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -20,7 +20,7 @@ You can enable it for remote access by following the instructions in {ref}`serve
 ## When I do a `lxc remote add`, it asks for a password or token?
 
 To be able to access the remote API, clients must authenticate with the LXD server.
-Depending on how the remote server is configured, you must provide either a trust token issued by the server or specify a trust password (if [`core.trust_password`](server-options-core) is set).
+Depending on how the remote server is configured, you must provide either a trust token issued by the server or specify a trust password (if {config:option}`server-core:core.trust_password` is set).
 
 See {ref}`server-authenticate` for instructions on how to authenticate using a trust token (the recommended way), and  {doc}`authentication` for information about other authentication methods.
 
@@ -53,7 +53,7 @@ But that's also the cause of most of the security issues with such privileged co
 ```{youtube} https://www.youtube.com/watch?v=_fCSSEyiGro
 ```
 
-To run Docker inside a LXD container, set the [`security.nesting`](instance-options-security) property of the container to `true`:
+To run Docker inside a LXD container, set the {config:option}`instance-security:security.nesting` property of the container to `true`:
 
     lxc config set <container> security.nesting true
 

--- a/doc/howto/access_ui.md
+++ b/doc/howto/access_ui.md
@@ -23,7 +23,7 @@ Complete the following steps to access the LXD web UI:
        sudo systemctl reload snap.lxd.daemon
 
 1. Make sure that your LXD server is {ref}`exposed to the network <server-expose>`.
-   You can expose the server during {ref}`initialization <initialize>`, or afterwards by setting the [`core.https_address`](server-options-core) server configuration option.
+   You can expose the server during {ref}`initialization <initialize>`, or afterwards by setting the {config:option}`server-core:core.https_address` server configuration option.
 
 1. Access the UI in your browser by entering the server address (for example, `https://192.0.2.10:8443`).
 

--- a/doc/howto/cluster_config_networks.md
+++ b/doc/howto/cluster_config_networks.md
@@ -39,7 +39,7 @@ Also see {ref}`network-create-cluster`.
 You can configure different networks for the REST API endpoint of your clients and for internal traffic between the members of your cluster.
 This separation can be useful, for example, to use a virtual address for your REST API, with DNS round robin.
 
-To do so, you must specify different addresses for [`cluster.https_address`](server) (the address for internal cluster traffic) and [`core.https_address`](server) (the address for the REST API):
+To do so, you must specify different addresses for {config:option}`server-cluster:cluster.https_address` (the address for internal cluster traffic) and {config:option}`server-core:core.https_address` (the address for the REST API):
 
 1. Create your cluster as usual, and make sure to use the address that you want to use for internal cluster traffic as the cluster address.
    This address is set as the `cluster.https_address` configuration.

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -113,7 +113,7 @@ Basically, the initialization process consists of the following steps:
 
        lxc cluster add <new_member_name>
 
-   This command returns a single-use join token that is valid for a configurable time (see [`cluster.join_token_expiry`](server-options-cluster)).
+   This command returns a single-use join token that is valid for a configurable time (see {config:option}`server-cluster:cluster.join_token_expiry`).
    Enter this token when `lxd init` prompts you for the join token.
 
    The join token contains the addresses of the existing online members, as well as a single-use secret and the fingerprint of the cluster certificate.

--- a/doc/howto/cluster_groups.md
+++ b/doc/howto/cluster_groups.md
@@ -38,7 +38,7 @@ For example, to add `server1` to the `gpu` group and also keep it in the `defaul
 With cluster groups, you can target an instance to run on one of the members of the cluster group, instead of targeting it to run on a specific member.
 
 ```{note}
-[`scheduler.instance`](cluster-member-config) must be set to either `all` (the default) or `group` to allow instances to be targeted to a cluster group.
+{config:option}`cluster:scheduler.instance` must be set to either `all` (the default) or `group` to allow instances to be targeted to a cluster group.
 
 See {ref}`clustering-instance-placement` for more information.
 ```

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -74,7 +74,7 @@ To do so, use the `lxc cluster evacuate` command.
 This command migrates all instances on the given server, moving them to other cluster members.
 The evacuated cluster member is then transitioned to an "evacuated" state, which prevents the creation of any instances on it.
 
-You can control how each instance is moved through the [`cluster.evacuate`](instance-options-misc) instance configuration key.
+You can control how each instance is moved through the {config:option}`instance-miscellaneous:cluster.evacuate` instance configuration key.
 Instances are shut down cleanly, respecting the `boot.host_shutdown_timeout` configuration key.
 
 When the evacuated server is available again, use the `lxc cluster restore` command to move the server back into a normal running state.
@@ -83,7 +83,7 @@ This command also moves the evacuated instances back from the servers that were 
 (cluster-automatic-evacuation)=
 ### Automatic evacuation
 
-If you set the [`cluster.healing_threshold`](server-options-cluster) configuration to a non-zero value, instances are automatically evacuated if a cluster member goes offline.
+If you set the {config:option}`server-cluster:cluster.healing_threshold` configuration to a non-zero value, instances are automatically evacuated if a cluster member goes offline.
 
 When the evacuated server is available again, you must manually restore it.
 

--- a/doc/howto/cluster_recover.md
+++ b/doc/howto/cluster_recover.md
@@ -18,7 +18,7 @@ Run `lxd cluster --help` for an overview of all available commands.
 
 ## Recover from quorum loss
 
-Every LXD cluster has a specific number of members (configured through [`cluster.max_voters`](server-options-cluster)) that serve as voting members of the distributed database.
+Every LXD cluster has a specific number of members (configured through {config:option}`server-cluster:cluster.max_voters`) that serve as voting members of the distributed database.
 If you permanently lose a majority of these cluster members (for example, you have a three-member cluster and you lose two members), the cluster loses quorum and becomes unavailable.
 However, if at least one database member survives, it is possible to recover the cluster.
 

--- a/doc/howto/instances_backup.md
+++ b/doc/howto/instances_backup.md
@@ -83,7 +83,7 @@ To delete a snapshot, use the following command:
 ### Schedule instance snapshots
 
 You can configure an instance to automatically create snapshots at specific times (at most once every minute).
-To do so, set the [`snapshots.schedule`](instance-options-snapshots) instance option.
+To do so, set the {config:option}`instance-snapshots:snapshots.schedule` instance option.
 
 For example, to configure daily snapshots, use the following command:
 
@@ -93,8 +93,8 @@ To configure taking a snapshot every day at 6 am, use the following command:
 
     lxc config set <instance_name> snapshots.schedule "0 6 * * *"
 
-When scheduling regular snapshots, consider setting an automatic expiry ([`snapshots.expiry`](instance-options-snapshots)) and a naming pattern for snapshots ([`snapshots.pattern`](instance-options-snapshots)).
-You should also configure whether you want to take snapshots of instances that are not running ([`snapshots.schedule.stopped`](instance-options-snapshots)).
+When scheduling regular snapshots, consider setting an automatic expiry ({config:option}`instance-snapshots:snapshots.expiry`) and a naming pattern for snapshots ({config:option}`instance-snapshots:snapshots.pattern`).
+You should also configure whether you want to take snapshots of instances that are not running ({config:option}`instance-snapshots:snapshots.schedule.stopped`).
 
 ### Restore an instance snapshot
 

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -74,7 +74,7 @@ There are two ways to prevent accidental deletion of instances:
 
        lxc alias add delete "delete -i"
 
-- To protect a specific instance from being deleted, set [`security.protection.delete`](instance-options-security) to `true` for the instance.
+- To protect a specific instance from being deleted, set {config:option}`instance-security:security.protection.delete` to `true` for the instance.
   See {ref}`instances-configure` for instructions.
 
 ## Rebuild an instance

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -52,8 +52,8 @@ Virtual machines can be moved to another server while they are running, thus wit
 To allow for live migration, you must enable support for stateful migration.
 To do so, ensure the following configuration:
 
-* Set [`migration.stateful`](instance-options-migration) to `true` on the instance.
-* Set [`size.state`](devices-disk) of the virtual machine's root disk device to at least the size of the virtual machine's [`limits.memory`](instance-options-limits) setting.
+* Set {config:option}`instance-migration:migration.stateful` to `true` on the instance.
+* Set [`size.state`](devices-disk) of the virtual machine's root disk device to at least the size of the virtual machine's {config:option}`instance-resource-limits:limits.memory` setting.
 
 (live-migration-containers)=
 ### Live migration for containers
@@ -70,8 +70,8 @@ If you are using the snap, use the following commands to enable CRIU:
 
 Otherwise, make sure you have CRIU installed on both systems.
 
-To optimize the memory transfer for a container, set the [`migration.incremental.memory`](instance-options-migration) property to `true` to make use of the pre-copy features in CRIU.
+To optimize the memory transfer for a container, set the {config:option}`instance-migration:migration.incremental.memory` property to `true` to make use of the pre-copy features in CRIU.
 With this configuration, LXD instructs CRIU to perform a series of memory dumps for the container.
 After each dump, LXD sends the memory dump to the specified remote.
 In an ideal scenario, each memory dump will decrease the delta to the previous memory dump, thereby increasing the percentage of memory that is already synced.
-When the percentage of synced memory is equal to or greater than the threshold specified via [`migration.incremental.memory.goal`](instance-options-migration), or the maximum number of allowed iterations specified via [`migration.incremental.memory.iterations`](instance-options-migration) is reached, LXD instructs CRIU to perform a final memory dump and transfers it.
+When the percentage of synced memory is equal to or greater than the threshold specified via {config:option}`instance-migration:migration.incremental.memory.goal`, or the maximum number of allowed iterations specified via {config:option}`instance-migration:migration.incremental.memory.iterations` is reached, LXD instructs CRIU to perform a final memory dump and transfers it.

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -41,11 +41,11 @@ If you need this, filter prefixes on the upstream routers.
 
 ## Configure the BGP server
 
-To configure LXD as a BGP server, set the following server configuration options (see {ref}`server-options-core`) on all cluster members:
+To configure LXD as a BGP server, set the following server configuration options on all cluster members:
 
-- `core.bgp_address` - the IP address for the BGP server
-- `core.bgp_asn` - the {abbr}`ASN (Autonomous System Number)` for the local server
-- `core.bgp_routerid` - the unique identifier for the BGP server
+- {config:option}`server-core:core.bgp_address` - the IP address for the BGP server
+- {config:option}`server-core:core.bgp_asn` - the {abbr}`ASN (Autonomous System Number)` for the local server
+- {config:option}`server-core:core.bgp_routerid` - the unique identifier for the BGP server
 
 For example, set the following values:
 

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -105,7 +105,7 @@ For example, running `dig @<DNS_server_IP> -p <DNS_server_PORT> axfr 2.0.192.in-
 
 To make use of network zones, you must enable the built-in DNS server.
 
-To do so, set the `core.dns_address` configuration option (see {ref}`server-options-core`) to a local address on the LXD server.
+To do so, set the {config:option}`server-core:core.dns_address` configuration option to a local address on the LXD server.
 To avoid conflicts with an existing DNS we suggest not using the port 53.
 This is the address on which the DNS server will listen.
 Note that in a LXD cluster, the address may be different on each cluster member.

--- a/doc/howto/server_expose.md
+++ b/doc/howto/server_expose.md
@@ -4,7 +4,7 @@
 By default, LXD can be used only by local users through a Unix socket and is not accessible over the network.
 
 To expose LXD to the network, you must configure it to listen to addresses other than the local Unix socket.
-To do so, set the [`core.https_address`](server) server configuration option.
+To do so, set the {config:option}`server-core:core.https_address` server configuration option.
 
 For example, to allow access to the LXD server on port `8443`, enter the following command:
 

--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -11,7 +11,7 @@ See the following sections for instructions on how to create, configure, view an
 If you want to use storage buckets on local storage (thus in a `dir`, `btrfs`, `lvm`, or `zfs` pool), you must configure the S3 address for your LXD server.
 This is the address that you can then use to access the buckets through the S3 protocol.
 
-To configure the S3 address, set the [`core.storage_buckets_address`](server-options-core) server configuration option.
+To configure the S3 address, set the {config:option}`server-core:core.storage_buckets_address` server configuration option.
 For example:
 
     lxc config set core.storage_buckets_address :8555

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -21,7 +21,7 @@ When you create an instance using a remote image, LXD downloads the image and ca
 It is stored in the local image store with the cached flag set.
 The image is kept locally as a private image until either:
 
-- The image has not been used to create a new instance for the number of days set in [`images.remote_cache_expiry`](server-options-images).
+- The image has not been used to create a new instance for the number of days set in {config:option}`server-images:images.remote_cache_expiry`.
 - The image's expiry date (one of the image properties; see {ref}`images-manage-edit` for information on how to change it) is reached.
 
 LXD keeps track of the image usage by updating the `last_used_at` image property every time a new instance is spawned from the image.
@@ -37,12 +37,12 @@ If you request an image through a fingerprint, you request an exact image versio
 
 Whether auto-update is enabled for an image depends on how the image was downloaded:
 
-- If the image was downloaded and cached when creating an instance, it is automatically updated if [`images.auto_update_cached`](server-options-images) was set to `true` (the default) at download time.
+- If the image was downloaded and cached when creating an instance, it is automatically updated if {config:option}`server-images:images.auto_update_cached` was set to `true` (the default) at download time.
 - If the image was copied from a remote server using the `lxc image copy` command, it is automatically updated only if the `--auto-update` flag was specified.
 
 You can change this behavior for an image by [editing the `auto_update` property](images-manage-edit).
 
-On startup and after every [`images.auto_update_interval`](server-options-images) (by default, every six hours), the LXD daemon checks for more recent versions of all the images in the store that are marked to be auto-updated and have a recorded source server.
+On startup and after every {config:option}`server-images:images.auto_update_interval` (by default, every six hours), the LXD daemon checks for more recent versions of all the images in the store that are marked to be auto-updated and have a recorded source server.
 
 When a new version of an image is found, it is downloaded into the image store.
 Then any aliases pointing to the old image are moved to the new one, and the old image is removed from the store.

--- a/doc/instance-exec.md
+++ b/doc/instance-exec.md
@@ -50,7 +50,7 @@ You can override the user, group and working directory by specifying absolute va
 You can pass environment variables to an exec session in the following two ways:
 
 Set environment variables as instance options
-: To set the `ENVVAR` environment variable to `VALUE` in the instance, set the `environment.ENVVAR` {ref}`instance option <instance-options-misc>`:
+: To set the `ENVVAR` environment variable to `VALUE` in the instance, set the `environment.ENVVAR` instance option (see {config:option}`instance-miscellaneous:environment.*`):
 
       lxc config set <instance_name> environment.ENVVAR=VALUE
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -62,7 +62,7 @@ You can then configure it to scrape the metrics through the metrics API endpoint
 
 To expose the `/1.0/metrics` API endpoint, you must set the address on which it should be available.
 
-To do so, you can set either the [`core.metrics_address`](server-options-core) server configuration option or the [`core.https_address`](server-options-core) server configuration option.
+To do so, you can set either the {config:option}`server-core:core.metrics_address` server configuration option or the {config:option}`server-core:core.https_address` server configuration option.
 The `core.metrics_address` option is intended for metrics only, while the `core.https_address` option exposes the full API.
 So if you want to use a different address for the metrics API than for the full API, or if you want to expose only the metrics endpoint but not the full API, you should set the `core.metrics_address` option.
 

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -61,7 +61,7 @@ ISO file
       lxc config device add <instance_name> <device_name> disk source=<file_path_on_host>
 
 VM `cloud-init`
-: You can generate a `cloud-init` configuration ISO from the `cloud-init.vendor-data` and `cloud-init.user-data` configuration keys (see {ref}`instance-options`) and attach it to a virtual machine.
+: You can generate a `cloud-init` configuration ISO from the {config:option}`instance-cloud-init:cloud-init.vendor-data` and {config:option}`instance-cloud-init:cloud-init.user-data` configuration keys and attach it to a virtual machine.
   The `cloud-init` that is running inside the VM then detects the drive on boot and applies the configuration.
 
   This source type is applicable only to VMs.

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -32,6 +32,15 @@ In addition to the configuration options listed in the following sections, these
     :end-before: <!-- config group instance-miscellaneous end -->
 ```
 
+```{config:option} environment.* instance-miscellaneous
+:type: "string"
+:liveupdate: "yes (exec)"
+:shortdesc: "Environment variables for the instance"
+
+You can export key/value environment variables to the instance.
+These are then set for `lxc exec`.
+```
+
 (instance-options-boot)=
 ## Boot-related options
 

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -38,7 +38,7 @@ Simple streams servers
 Public LXD servers
 : LXD servers that are used solely to serve images and do not run instances themselves.
 
-  To make a LXD server publicly available over the network on port 8443, set the [`core.https_address`](server-options-core) configuration option to `:8443` and do not configure any authentication methods (see {ref}`server-expose` for more information).
+  To make a LXD server publicly available over the network on port 8443, set the {config:option}`server-core:core.https_address` configuration option to `:8443` and do not configure any authentication methods (see {ref}`server-expose` for more information).
   Then set the images that you want to share to `public`.
 
 LXD servers

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -86,7 +86,7 @@ Key                     | Type      | Condition                 | Default       
 
 ### Storage bucket configuration
 
-To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the [`core.storage_buckets_address`](server-options-core) server setting.
+To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
 Key                     | Type      | Condition                 | Default                                        | Description
 :--                     | :---      | :--------                 | :------                                        | :----------

--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -51,7 +51,7 @@ Key                     | Type      | Condition                 | Default       
 
 ### Storage bucket configuration
 
-To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the [`core.storage_buckets_address`](server-options-core) server setting.
+To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
 Storage buckets do not have any configuration for `dir` pools.
 Unlike the other storage pool drivers, the `dir` driver does not support bucket quotas via the `size` setting.

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -79,7 +79,7 @@ Key                     | Type      | Condition     | Default                   
 
 ### Storage bucket configuration
 
-To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the [`core.storage_buckets_address`](server-options-core) server setting.
+To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
 Key                     | Type      | Condition                 | Default                                        | Description
 :--                     | :---      | :--------                 | :------                                        | :----------

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -134,7 +134,7 @@ Key                     | Type      | Condition                 | Default       
 
 ### Storage bucket configuration
 
-To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the [`core.storage_buckets_address`](server-options-core) server setting.
+To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
 Key                     | Type      | Condition                 | Default                                        | Description
 :--                     | :---      | :--------                 | :------                                        | :----------

--- a/doc/remotes.md
+++ b/doc/remotes.md
@@ -12,7 +12,7 @@ For example, you can manage instances or update the server configuration on the 
 
 ## Authentication
 
-To be able to add a LXD server as a remote server, the server's API must be exposed, which means that its [`core.https_address`](server-options-core) server configuration option must be set.
+To be able to add a LXD server as a remote server, the server's API must be exposed, which means that its {config:option}`server-core:core.https_address` server configuration option must be set.
 
 When adding the server, you must then authenticate with it using the chosen method for {ref}`authentication`.
 


### PR DESCRIPTION
Replace the links to config option sections with links directly to the respective config option.