### PR TITLE
doc: fix breaking build

### DIFF
--- a/doc/internals.md
+++ b/doc/internals.md
@@ -30,5 +30,6 @@ Debug LXD </debugging>
 /environment
 /syscall-interception
 User namespace setup </userns-idmap>
+Configuration option index </config-options>
 ```
 ````


### PR DESCRIPTION
The build for topical navigation was failing since the config option index wasn't included in the navigation.