### PR TITLE
lxd/auth/rbac: Fix regression

### DIFF
--- a/lxd/auth/authorization.go
+++ b/lxd/auth/authorization.go
@@ -11,8 +11,13 @@ import (
 var ErrUnknownDriver = fmt.Errorf("Unknown driver")
 
 var authorizers = map[string]func() authorizer{
-	"tls":  func() authorizer { return &tls{} },
-	"rbac": func() authorizer { return &rbac{} },
+	"tls": func() authorizer { return &tls{} },
+	"rbac": func() authorizer {
+		return &rbac{
+			resources:   map[string]string{},
+			permissions: map[string]map[string][]string{},
+		}
+	},
 }
 
 type authorizer interface {


### PR DESCRIPTION
This actually initializes the struct like it used to be, fixing LXD from panicing on every request.

Closes #12181