### PR TITLE
daemon: Do not fail if metrics listener cannot be set up

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1424,7 +1424,7 @@ func (d *Daemon) init() error {
 	if metricsAddress != "" {
 		err = d.endpoints.UpMetrics(metricsAddress)
 		if err != nil {
-			return err
+			logger.Warn("Failed setting up metrics", logger.Ctx{"err": err})
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where the daemon would fail if it couldn't set up
the metrics listener. Instead of the daemon failing, a log message
will be issued so that the user can fix whatever is causing the failure.

Fixes #12185

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
