### PR TITLE
Un-hide hidden commands

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -53,7 +53,6 @@ func (c *cmdPause) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Pause instances`))
 	cmd.Aliases = []string{"freeze"}
-	cmd.Hidden = true
 
 	return cmd
 }

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -44,7 +44,6 @@ func (c *cmdInit) Command() *cobra.Command {
 
 lxc init ubuntu:22.04 u1 < config.yaml
     Create the instance with configuration from config.yaml`))
-	cmd.Hidden = true
 
 	cmd.RunE = c.Run
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new instance")+"``")

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -43,7 +43,6 @@ lxc monitor --pretty --type=logging --loglevel=info
 
 lxc monitor --type=lifecycle
     Only show lifecycle events.`))
-	cmd.Hidden = true
 
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVar(&c.flagPretty, "pretty", false, i18n.G("Pretty rendering (short for --format=pretty)"))

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -36,7 +36,6 @@ func (c *cmdQuery) Command() *cobra.Command {
 	cmd.Example = cli.FormatSection("", i18n.G(
 		`lxc query -X DELETE --wait /1.0/instances/c1
     Delete local instance "c1".`))
-	cmd.Hidden = true
 
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVar(&c.flagRespWait, "wait", false, i18n.G("Wait for the operation to complete"))


### PR DESCRIPTION
This un-hides the following commands:

- `lxc pause`
- `lxc init`
- ~`lxc manpage`~
- `lxc monitor`
- `lxc query`

Fixes #12175
