### PR TITLE
doc: unpin Sphinx version

### DIFF
--- a/doc/.sphinx/requirements.txt
+++ b/doc/.sphinx/requirements.txt
@@ -16,7 +16,7 @@ pytz
 requests
 six
 snowballstemmer
-Sphinx==7.1.2
+Sphinx
 sphinx-autobuild
 sphinxcontrib-applehelp
 sphinxcontrib-devhelp


### PR DESCRIPTION
All extensions we use have now been fixed to work fine with the latest Sphinx version, so no need to pin the version anymore.