### PR TITLE
doc: don't check validity of GitHub anchors

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -256,6 +256,10 @@ linkcheck_ignore = [
 ]
 linkcheck_exclude_documents = [r'.*/manpages/.*']
 
+linkcheck_anchors_ignore_for_url = [
+    r'https://github\.com/.*'
+]
+
 # Setup redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
 redirects = {
     "howto/instances_snapshots/index": "../instances_backup/",


### PR DESCRIPTION
Anchors in GitHub documentation are handled in a way that the link checker can't deal with.
Therefore, don't check the validity of anchors. The general URLs are still checked.