### PR TITLE
doc: link to manpages

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -70,7 +70,7 @@ To configure `cloud-init` for an instance, add the corresponding configuration o
 
 When configuring `cloud-init` directly for an instance, keep in mind that `cloud-init` runs only on the first start of the instance.
 That means that you must configure `cloud-init` before you start the instance.
-To do so, create the instance with `lxc init` instead of [`lxc launch`](lxc_launch.md), and then start it after completing the configuration.
+To do so, create the instance with [`lxc init`](lxc_init.md) instead of [`lxc launch`](lxc_launch.md), and then start it after completing the configuration.
 
 ### YAML format for `cloud-init` configuration
 

--- a/doc/events.md
+++ b/doc/events.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 Events are messages about actions that have occurred over LXD. Using the API endpoint `/1.0/events` directly or via
-`lxc monitor` will connect to a WebSocket through which logs and life-cycle messages will be streamed.
+[`lxc monitor`](lxc_monitor.md) will connect to a WebSocket through which logs and life-cycle messages will be streamed.
 
 ## Event types
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -85,17 +85,17 @@ The way to diagnose this problem is to run a `tcpdump` on the uplink and you wil
 (faq-monitor)=
 ## How can I monitor what LXD is doing?
 
-To see detailed information about what LXD is doing and what processes it is running, use the `lxc monitor` command.
+To see detailed information about what LXD is doing and what processes it is running, use the [`lxc monitor`](lxc_monitor.md) command.
 
 For example, to show a human-readable output of all types of messages, enter the following command:
 
     lxc monitor --pretty
 
-See `lxc monitor --help` for all options, and {doc}`debugging` for more information.
+See [`lxc monitor --help`](lxc_monitor.md) for all options, and {doc}`debugging` for more information.
 
 ## Why does LXD stall when creating an instance?
 
 Check if your storage pool is out of space (by running [`lxc storage info <pool_name>`](lxc_storage_info.md)).
 In that case, LXD cannot finish unpacking the image, and the instance that you're trying to create shows up as stopped.
 
-To get more insight into what is happening, run `lxc monitor` (see {ref}`faq-monitor`), and check `sudo dmesg` for any I/O errors.
+To get more insight into what is happening, run [`lxc monitor`](lxc_monitor.md) (see {ref}`faq-monitor`), and check `sudo dmesg` for any I/O errors.

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -1,8 +1,8 @@
 (instances-create)=
 # How to create instances
 
-To create an instance, you can use either the `lxc init` or the [`lxc launch`](lxc_launch.md) command.
-The `lxc init` command only creates the instance, while the [`lxc launch`](lxc_launch.md) command creates and starts it.
+To create an instance, you can use either the [`lxc init`](lxc_init.md) or the [`lxc launch`](lxc_launch.md) command.
+The [`lxc init`](lxc_init.md) command only creates the instance, while the [`lxc launch`](lxc_launch.md) command creates and starts it.
 
 ## Usage
 
@@ -22,7 +22,7 @@ Instance name
   See {ref}`instance-properties` for additional requirements.
 
 Flags
-: See [`lxc launch --help`](lxc_launch.md) or `lxc init --help` for a full list of flags.
+: See [`lxc launch --help`](lxc_launch.md) or [`lxc init --help`](lxc_init.md) for a full list of flags.
   The most common flags are:
 
   - `--config` to specify a configuration option for the new instance
@@ -46,7 +46,7 @@ Check the contents of an existing instance configuration ([`lxc config show <ins
 
 ## Examples
 
-The following examples use [`lxc launch`](lxc_launch.md), but you can use `lxc init` in the same way.
+The following examples use [`lxc launch`](lxc_launch.md), but you can use [`lxc init`](lxc_init.md) in the same way.
 
 ### Launch a container
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -25,7 +25,7 @@ Fetching metrics is a relatively expensive operation for LXD to perform, so if t
 
 ## Query the raw data
 
-To view the raw data that LXD collects, use the `lxc query` command to query the `/1.0/metrics` endpoint:
+To view the raw data that LXD collects, use the [`lxc query`](lxc_query.md) command to query the `/1.0/metrics` endpoint:
 
 ```{terminal}
 :input: lxc query /1.0/metrics

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -38,7 +38,7 @@ In addition to the configuration options listed in the following sections, these
 :shortdesc: "Environment variables for the instance"
 
 You can export key/value environment variables to the instance.
-These are then set for `lxc exec`.
+These are then set for [`lxc exec`](lxc_exec.md).
 ```
 
 (instance-options-boot)=

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -11,7 +11,7 @@ See {ref}`authentication` for information about how to access the API remotely.
 ```{tip}
 - For examples on how the API is used, run any command of the LXD client ([`lxc`](lxc.md)) with the `--debug` flag.
 The debug information displays the API calls and the return values.
-- For quickly querying the API, the LXD client provides a `lxc query` command.
+- For quickly querying the API, the LXD client provides a [`lxc query`](lxc_query.md) command.
 ```
 
 ## API versioning


### PR DESCRIPTION
Add references to the manpages for the formerly hidden commands.