### PR TITLE
Send OVN logs to events API and Loki

### DIFF
--- a/doc/.sphinx/.wordlist.txt
+++ b/doc/.sphinx/.wordlist.txt
@@ -123,6 +123,7 @@ LRU
 LTS
 LV
 LVM
+lxc
 LXC
 LXC's
 LXCFS
@@ -249,6 +250,7 @@ symlinks
 syscall
 syscalls
 sysfs
+syslog
 Tbit
 TCP
 Telegraf
@@ -271,6 +273,7 @@ URI
 URIs
 unconfigured
 unevictable
+unixgram
 unmanaged
 unmount
 unmounting

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2285,3 +2285,7 @@ This parameter allows bypassing the project name filter.
 ## `metadata_configuration`
 Adds the `GET /1.0/metadata/configuration` API endpoint to retrieve the generated metadata configuration in a JSON format. The JSON structure adopts the structure ```"configs" > `ENTITY` > `ENTITY_SECTION` > "keys" > [<CONFIG_OPTION_0>, <CONFIG_OPTION_1>, ...]```.
 Check the list of {doc}`configuration options </config-options>` to see which configuration options are included.
+
+## `syslog_socket`
+
+This introduces a syslog socket that can receive syslog formatted log messages. These can be viewed in the events API and `lxc monitor`, and can be forwarded to Loki. To enable this feature, set `core.syslog_socket` to `true`.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1240,6 +1240,13 @@ Specify the number of minutes to wait for running operations to complete before 
 See {ref}`howto-storage-buckets`.
 ```
 
+```{config:option} core.syslog_socket server-core
+:scope: "local"
+:shortdesc: "Whether to enable the syslog unixgram socket listener"
+:type: "bool"
+Set this option to `true` to enable the syslog unixgram socket to receive log messages from external processes.
+```
+
 ```{config:option} core.trust_ca_certificates server-core
 :scope: "global"
 :shortdesc: "Whether to automatically trust clients signed by the CA"
@@ -1346,7 +1353,7 @@ Specify a comma-separated list of values that should be used as labels for a Lok
 :shortdesc: "Events to send to the Loki server"
 :type: "string"
 Specify a comma-separated list of events to send to the Loki server.
-The events can be `lifecycle` and/or `logging`.
+The events can be any combination of `lifecycle`, `logging`, and `ovn`.
 ```
 
 <!-- config group server-loki end -->

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -177,3 +177,39 @@ See the linked YouTube video for the complete tutorial using four machines.
        ping <IP of c1>
        ping <nameserver>
        ping6 -n www.example.com
+
+## Send OVN logs to LXD
+
+Complete the following steps to have the OVN controller send its logs to LXD.
+
+1. Enable the syslog socket:
+
+       lxc config set core.syslog_socket=true
+
+1. Open `/etc/default/ovn-host` for editing.
+
+1. Paste the following configuration:
+
+       OVN_CTL_OPTS=" \
+              --ovn-controller-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket'"
+
+1. Restart the OVN controller:
+
+       systemctl restart ovn-controller.service
+
+You can now use [lxc monitor](lxc_monitor.md) to see logs from the OVN controller:
+
+    lxc monitor --type=ovn
+
+You can also send the logs to Loki.
+To do so, add the `ovn` value to the {config:option}`server-loki:loki.types` configuration key.
+
+```{tip}
+You can include logs for OVN `northd`, OVN north-bound `ovsdb-server`, and OVN south-bound `ovsdb-server` as well.
+To do so, edit `/etc/default/ovn-central`:
+
+    OVN_CTL_OPTS=" \
+       --northd-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
+       --nb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
+       --sb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket'"
+```

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -811,6 +811,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	acmeDomainChanged := false
 	acmeCAURLChanged := false
 	oidcChanged := false
+	syslogSocketChanged := false
 
 	for key := range clusterChanged {
 		switch key {
@@ -899,6 +900,8 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			bgpChanged = true
 		case "core.dns_address":
 			dnsChanged = true
+		case "core.syslog_socket":
+			syslogSocketChanged = true
 		}
 	}
 
@@ -1051,6 +1054,13 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			d.oidcVerifier = nil
 		} else {
 			d.oidcVerifier = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
+		}
+	}
+
+	if syslogSocketChanged {
+		err := d.setupSyslogSocket(nodeConfig.SyslogSocket())
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -676,13 +676,13 @@ var ConfigSchema = config.Schema{
 
 	// lxdmeta:generate(entity=server, group=loki, key=loki.types)
 	// Specify a comma-separated list of events to send to the Loki server.
-	// The events can be `lifecycle` and/or `logging`.
+	// The events can be any combination of `lifecycle`, `logging`, and `ovn`.
 	// ---
 	//  type: string
 	//  scope: global
 	//  defaultdesc: `lifecycle,logging`
 	//  shortdesc: Events to send to the Loki server
-	"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf("lifecycle", "logging"))), Default: "lifecycle,logging"},
+	"loki.types": {Validator: validate.Optional(validate.IsListOf(validate.IsOneOf("lifecycle", "logging", "ovn"))), Default: "lifecycle,logging"},
 
 	// lxdmeta:generate(entity=server, group=miscellaneous, key=maas.api.key)
 	//

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -150,6 +150,9 @@ type Daemon struct {
 
 	// Authorization.
 	authorizer auth.Authorizer
+
+	// Syslog listener cancel function.
+	syslogSocketCancel context.CancelFunc
 }
 
 // DaemonConfig holds configuration values for Daemon.
@@ -1321,7 +1324,7 @@ func (d *Daemon) init() error {
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiLabels, lokiLoglevel, lokiTypes := d.globalConfig.LokiServer()
 	oidcIssuer, oidcClientID, oidcAudience := d.globalConfig.OIDCServer()
-
+	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
 
 	d.endpoints.NetworkUpdateTrustedProxy(d.globalConfig.HTTPSTrustedProxy())
@@ -1330,6 +1333,13 @@ func (d *Daemon) init() error {
 	// Setup Loki logger.
 	if lokiURL != "" {
 		err = d.setupLoki(lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiLabels, lokiLoglevel, lokiTypes)
+		if err != nil {
+			return err
+		}
+	}
+
+	if syslogSocketEnabled {
+		err = d.setupSyslogSocket(true)
 		if err != nil {
 			return err
 		}
@@ -1924,6 +1934,31 @@ func (d *Daemon) setupMAASController(server string, key string, machine string) 
 	}
 
 	d.maas = controller
+	return nil
+}
+
+func (d *Daemon) setupSyslogSocket(enable bool) error {
+	// Always cancel the context to ensure that no goroutines leak.
+	if d.syslogSocketCancel != nil {
+		logger.Debug("Stopping syslog socket")
+		d.syslogSocketCancel()
+	}
+
+	if !enable {
+		return nil
+	}
+
+	var ctx context.Context
+
+	ctx, d.syslogSocketCancel = context.WithCancel(d.shutdownCtx)
+
+	logger.Debug("Starting syslog socket")
+
+	err := StartSyslogListener(ctx, d.events)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -19,7 +19,7 @@ import (
 	"github.com/canonical/lxd/shared/ws"
 )
 
-var eventTypes = []string{api.EventTypeLogging, api.EventTypeOperation, api.EventTypeLifecycle}
+var eventTypes = []string{api.EventTypeLogging, api.EventTypeOperation, api.EventTypeLifecycle, api.EventTypeOVN}
 var privilegedEventTypes = []string{api.EventTypeLogging}
 
 var eventsCmd = APIEndpoint{

--- a/lxd/events/internalListener.go
+++ b/lxd/events/internalListener.go
@@ -38,7 +38,7 @@ func (l *InternalListener) startListener() {
 	aEnd, bEnd := memorypipe.NewPipePair(l.listenerCtx)
 	listenerConnection := NewSimpleListenerConnection(aEnd)
 
-	l.listener, err = l.server.AddListener("", true, listenerConnection, []string{"lifecycle", "logging"}, []EventSource{EventSourcePull}, nil, nil)
+	l.listener, err = l.server.AddListener("", true, listenerConnection, []string{"lifecycle", "logging", "ovn"}, []EventSource{EventSourcePull}, nil, nil)
 	if err != nil {
 		return
 	}

--- a/lxd/loki/loki.go
+++ b/lxd/loki/loki.go
@@ -287,7 +287,7 @@ func (c *Client) HandleEvent(event api.Event) {
 		}
 
 		entry.Line = fmt.Sprintf("%s%s", messagePrefix, lifecycleEvent.Action)
-	} else if event.Type == api.EventTypeLogging {
+	} else if event.Type == api.EventTypeLogging || event.Type == api.EventTypeOVN {
 		logEvent := api.EventLogging{}
 
 		err := json.Unmarshal(event.Metadata, &logEvent)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1360,6 +1360,14 @@
 						}
 					},
 					{
+						"core.syslog_socket": {
+							"longdesc": "Set this option to `true` to enable the syslog unixgram socket to receive log messages from external processes.",
+							"scope": "local",
+							"shortdesc": "Whether to enable the syslog unixgram socket listener",
+							"type": "bool"
+						}
+					},
+					{
 						"core.trust_ca_certificates": {
 							"longdesc": "",
 							"scope": "global",
@@ -1478,7 +1486,7 @@
 					{
 						"loki.types": {
 							"defaultdesc": "`lifecycle,logging`",
-							"longdesc": "Specify a comma-separated list of events to send to the Loki server.\nThe events can be `lifecycle` and/or `logging`.",
+							"longdesc": "Specify a comma-separated list of events to send to the Loki server.\nThe events can be any combination of `lifecycle`, `logging`, and `ovn`.",
 							"scope": "global",
 							"shortdesc": "Events to send to the Loki server",
 							"type": "string"

--- a/lxd/node/config.go
+++ b/lxd/node/config.go
@@ -118,6 +118,11 @@ func (c *Config) StorageImagesVolume() string {
 	return c.m.GetString("storage.images_volume")
 }
 
+// SyslogSocket returns true if the syslog socket is enabled, otherwise false.
+func (c *Config) SyslogSocket() bool {
+	return c.m.GetBool("core.syslog_socket")
+}
+
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
 func (c *Config) Dump() map[string]any {
@@ -234,6 +239,16 @@ var ConfigSchema = config.Schema{
 	//  scope: local
 	//  shortdesc: Address to bind the storage object server to (HTTPS)
 	"core.storage_buckets_address": {Validator: validate.Optional(validate.IsListenAddress(true, true, false))},
+
+	// Syslog socket
+
+	// lxdmeta:generate(entity=server, group=core, key=core.syslog_socket)
+	// Set this option to `true` to enable the syslog unixgram socket to receive log messages from external processes.
+	// ---
+	//  type: bool
+	//  scope: local
+	//  shortdesc: Whether to enable the syslog unixgram socket listener
+	"core.syslog_socket": {Validator: validate.Optional(validate.IsBool), Type: config.Bool},
 
 	// MAAS machine this LXD instance is associated with
 

--- a/lxd/syslog.go
+++ b/lxd/syslog.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/events"
+	"github.com/canonical/lxd/lxd/revert"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// StartSyslogListener starts the log monitor.
+func StartSyslogListener(ctx context.Context, eventServer *events.Server) error {
+	var listenConfig net.ListenConfig
+
+	sockFile := shared.VarPath("syslog.socket")
+
+	if shared.PathExists(sockFile) {
+		err := os.Remove(sockFile)
+		if err != nil {
+			return fmt.Errorf("Failed deleting stale syslog.socket: %w", err)
+		}
+	}
+
+	conn, err := listenConfig.ListenPacket(ctx, "unixgram", sockFile)
+	if err != nil {
+		return fmt.Errorf("Failed listening on syslog socket: %w", err)
+	}
+
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() {
+		_ = conn.Close()
+		_ = os.Remove(sockFile)
+	})
+
+	// Get max size
+	var maxBufSize int
+
+	uc, ok := conn.(*net.UnixConn)
+	if ok {
+		f, err := uc.File()
+		if err != nil {
+			return fmt.Errorf("Failed getting underlying os.File: %w", err)
+		}
+
+		maxBufSize, err = unix.GetsockoptInt(int(f.Fd()), unix.SOL_SOCKET, unix.SO_RCVBUF)
+		if err != nil {
+			_ = f.Close()
+			return fmt.Errorf("Failed getting SO_RCVBUF: %w", err)
+		}
+
+		// This makes the fd non-blocking so that conn.Close() won't block.
+		// See https://github.com/golang/go/issues/29277#issuecomment-447922481
+		err = unix.SetNonblock(int(f.Fd()), true)
+		if err != nil {
+			_ = f.Close()
+			return fmt.Errorf("Failed setting non-block: %w", err)
+		}
+
+		_ = f.Close()
+	}
+
+	// This goroutine waits for the context to be cancelled and then closes the connection causing `ReadFrom` to return an error and exit the goroutine below.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+		_ = os.Remove(sockFile)
+	}()
+
+	// This goroutine is used for reading packets, and processing the log message. `ReadFrom` will block until it either receives data, or an error occurs. If the connection is closed, `ReadFrom` will return an error, and the goroutine will terminate.
+	go func() {
+		buf := make([]byte, maxBufSize)
+
+		// This maps OVN log level names to logrus log levels.
+		logMap := map[string]logrus.Level{
+			"dbg":  logrus.DebugLevel,
+			"info": logrus.InfoLevel,
+			"warn": logrus.WarnLevel,
+			"err":  logrus.ErrorLevel,
+			"emer": logrus.ErrorLevel,
+		}
+
+		for {
+			n, _, err := conn.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+
+			// Acceptable formats:
+			// - <29> ovs|00017|rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected"
+			// - <29> ovs|ovn-controller|00017|rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected"
+			// The first field can be ignored as that information is relevant to syslogd.
+			fields := strings.SplitN(string(buf[:n]), "|", 6)
+
+			if len(fields) < 5 {
+				continue
+			}
+
+			applicationName := ""
+
+			if len(fields) == 6 {
+				applicationName = fields[1]
+			}
+
+			sequenceNumber := fields[len(fields)-4]
+			moduleName := fields[len(fields)-3]
+			logLevel := strings.ToLower(fields[len(fields)-2])
+			message := fields[len(fields)-1]
+
+			event := api.EventLogging{
+				Level:   logMap[logLevel].String(),
+				Message: message,
+				Context: map[string]string{
+					"module":   moduleName,
+					"sequence": sequenceNumber,
+				},
+			}
+
+			if applicationName != "" {
+				event.Context["application"] = applicationName
+			}
+
+			err = eventServer.Send("", api.EventTypeOVN, event)
+			if err != nil {
+				continue
+			}
+		}
+	}()
+
+	revert.Success()
+
+	return nil
+}

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -11,6 +11,7 @@ const (
 	EventTypeLifecycle = "lifecycle"
 	EventTypeLogging   = "logging"
 	EventTypeOperation = "operation"
+	EventTypeOVN       = "ovn"
 )
 
 // Event represents an event entry (over websocket)

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -382,6 +382,7 @@ var APIExtensions = []string{
 	"zfs_delegate",
 	"operations_get_query_all_projects",
 	"metadata_configuration",
+	"syslog_socket",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -357,6 +357,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_warnings "Warnings"
     run_test test_metrics "Metrics"
     run_test test_storage_volume_recover "Recover storage volumes"
+    run_test test_syslog_socket "Syslog socket"
 fi
 
 # shellcheck disable=SC2034

--- a/test/suites/syslog.sh
+++ b/test/suites/syslog.sh
@@ -1,0 +1,20 @@
+test_syslog_socket() {
+  LXD_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  export LXD_DIR
+  chmod +x "${LXD_DIR}"
+  spawn_lxd "${LXD_DIR}" true
+
+  lxc config set core.syslog_socket=true
+  lxc monitor --type=ovn > "${TEST_DIR}/ovn.log" &
+  monitorOVNPID=$!
+
+  sleep 1
+  echo "<29> ovs|ovn-controller|00017|rconn|INFO|unix:/var/run/openvswitch/br-int.mgmt: connected" | socat - unix-sendto:"${LXD_DIR}/syslog.socket"
+  sleep 1
+
+  kill -9 ${monitorOVNPID} || true
+  grep -qF "type: ovn" "${TEST_DIR}/ovn.log"
+  grep -qF "unix:/var/run/openvswitch/br-int.mgmt: connected" "${TEST_DIR}/ovn.log"
+
+  shutdown_lxd "${LXD_DIR}"
+}


### PR DESCRIPTION
This adds an OVN log monitor which listens for log messages on a unix socket. If messages are received, they are sent to the events API which will then forward them to Loki (if configured). The log monitor can be enabled by setting `core.syslog_socket` to `true`. The logs will only be sent to Loki, if `loki.types` contains `ovn`.

In this case, the `ovn` events can also be monitored using `lxc monitor
--type=ovn`.

### Setting up OVN

On Ubuntu, OVN uses the `/etc/default/ovn-host` environment file. To enable the OVN controller to send their logs via unix socket, one needs to add the following:
```
OVN_CTL_OPTS="--ovn-controller-log='-vsyslog:info --syslog-method=unix:/var/lib/lxd/syslog.socket'"
```

There are also `--ovn-sb-log` and `--ovn-nb-log` which take the same arguments. These need to be set in `/etc/default/ovn-central` though.

Specification https://discourse.ubuntu.com/t/send-ovn-logs-to-the-events-api/38445