### PR TITLE
shared/util: use LC_ALL instead of LANG in RunCommandCLocale()

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -1010,11 +1010,11 @@ func RunCommandInheritFds(ctx context.Context, filesInherit []*os.File, name str
 	return stdout, err
 }
 
-// RunCommandCLocale runs a command with a LANG=C.UTF-8 and LANGUAGE=en environment set with optional arguments and
+// RunCommandCLocale runs a command with a LC_ALL=C.UTF-8 and LANGUAGE=en environment set with optional arguments and
 // returns stdout. If the command fails to start or returns a non-zero exit code then an error is
 // returned containing the output of stderr.
 func RunCommandCLocale(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(context.TODO(), append(os.Environ(), "LANG=C.UTF-8", "LANGUAGE=en"), nil, name, arg...)
+	stdout, _, err := RunCommandSplit(context.TODO(), append(os.Environ(), "LC_ALL=C.UTF-8", "LANGUAGE=en"), nil, name, arg...)
 	return stdout, err
 }
 


### PR DESCRIPTION
https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Locale-Environment-Variables.html:

> LC_ALL is an environment variable that overrides all of the LC_*.
> It is typically used in scripts that run particular programs.

This *might* help with #11902

Closes #11902