### PR TITLE
Skip loop devices from IO stats

### DIFF
--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -1042,6 +1042,11 @@ func (cg *CGroup) GetIOStats() (map[string]*IOStats, error) {
 					continue
 				}
 
+				// Skip loop devices (major dev ID 7) as they are irrelevant.
+				if strings.HasPrefix(devID, "7:") {
+					continue
+				}
+
 				// Parse the stat value.
 				statName, statValueStr, found := strings.Cut(statPart, "=")
 				if !found {

--- a/lxd/cgroup/abstraction.go
+++ b/lxd/cgroup/abstraction.go
@@ -971,6 +971,11 @@ func (cg *CGroup) GetIOStats() (map[string]*IOStats, error) {
 				continue
 			}
 
+			// Skip loop devices (major dev ID 7) as they are irrelevant.
+			if strings.HasPrefix(fields[0], "7:") {
+				continue
+			}
+
 			if ioMap[partMap[fields[0]]] == nil {
 				ioMap[partMap[fields[0]]] = &IOStats{}
 			}
@@ -998,6 +1003,11 @@ func (cg *CGroup) GetIOStats() (map[string]*IOStats, error) {
 			fields := strings.Fields(scanner.Text())
 
 			if len(fields) != 3 {
+				continue
+			}
+
+			// Skip loop devices (major dev ID 7) as they are irrelevant.
+			if strings.HasPrefix(fields[0], "7:") {
 				continue
 			}
 


### PR DESCRIPTION
Sometimes (not always), something in LXD's snap loop device causes some IOs to be accounted against a given container:

```
# cgroup2 host
sdeziel@ocelot:~$ lxc query /1.0/metrics | grep -F 'device="loop'
lxd_disk_read_bytes_total{device="loop2",name="git",project="default",type="container"} 2048
lxd_disk_read_bytes_total{device="loop2",name="git",project="default",type="container"} 2048
lxd_disk_reads_completed_total{device="loop2",name="git",project="default",type="container"} 1
lxd_disk_reads_completed_total{device="loop2",name="git",project="default",type="container"} 1
lxd_disk_written_bytes_total{device="loop2",name="git",project="default",type="container"} 0
lxd_disk_written_bytes_total{device="loop2",name="git",project="default",type="container"} 0
lxd_disk_writes_completed_total{device="loop2",name="git",project="default",type="container"} 0
lxd_disk_writes_completed_total{device="loop2",name="git",project="default",type="container"} 0

sdeziel@ocelot:~$ lsblk | grep -wF loop2
loop2    7:2    0 111.9M  1 loop /snap/lxd/24322

# cgroup1 host
sdeziel@mars:~$ lxc query /1.0/metrics | grep -F 'device="loop'
lxd_disk_read_bytes_total{device="loop0",name="smb",project="default",type="container"} 2048
lxd_disk_reads_completed_total{device="loop0",name="smb",project="default",type="container"} 1
lxd_disk_written_bytes_total{device="loop0",name="smb",project="default",type="container"} 0
lxd_disk_writes_completed_total{device="loop0",name="smb",project="default",type="container"} 0

sdeziel@mars:~$ lsblk | grep -wF loop0
loop0     7:0    0  112M  1 loop  /snap/lxd/24322
```

It is not entirely clear what is causing this but @mihalicyn suggested ignoring all loop devices because their stats are never useful.