### PR TITLE
instance_exec: Add contraint validation

### DIFF
--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -542,6 +542,15 @@ func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
+	// Constraint validations.
+	if post.RecordOutput && post.WaitForWS {
+		return response.BadRequest(fmt.Errorf("Cannot use %q in combination with %q", "record-output", "wait-for-websocket"))
+	}
+
+	if post.Interactive && post.RecordOutput {
+		return response.BadRequest(fmt.Errorf("Cannot use %q in combination with %q", "interactive", "record-output"))
+	}
+
 	// Forward the request if the container is remote.
 	client, err := cluster.ConnectIfInstanceIsRemote(s.DB.Cluster, projectName, name, s.Endpoints.NetworkCert(), s.ServerCert(), r, instanceType)
 	if err != nil {


### PR DESCRIPTION
This returns an error if `record-output` and `wait-for-websocket`, or
`interactive` and `record-output` are used in combination.

Fixes #12216

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
