### PR TITLE
Makefile: fix "tags" target and don't make it PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,4 +279,4 @@ endif
 	run-parts --exit-on-error --regex '.sh' test/lint
 
 tags: */*.go
-	find . -type f -name '*.go' | xargs gotags > tags
+	find . -type f -name '*.go' | gotags -L - -f tags

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,5 @@ endif
 	shellcheck test/extras/*.sh
 	run-parts --exit-on-error --regex '.sh' test/lint
 
-.PHONY: tags
-tags: *.go lxd/*.go shared/*.go lxc/*.go
+tags: */*.go
 	find . -type f -name '*.go' | xargs gotags > tags


### PR DESCRIPTION
I don't know if anyone uses `make tags` (I don't) but it's been broken for a while. This should fix it anyway.