### PR TITLE
Fix metadata-up-to-date lint script

### DIFF
--- a/test/lint/metadata-up-to-date.sh
+++ b/test/lint/metadata-up-to-date.sh
@@ -25,11 +25,8 @@ metadata_hash "$hash_after"
 mv "${json_metadata}.bak" "${json_metadata}"
 mv "${doc_config_options}.bak" "${doc_config_options}"
 
-mkfifo tmphash_before tmphash_after
-cat "$hash_before" > tmphash_before &
-cat "$hash_after" > tmphash_after &
-d=$(diff tmphash_before tmphash_after)
-rm "$hash_before" "$hash_after" tmphash_before tmphash_after
+d="$(diff "$hash_before" "$hash_after")"
+rm "$hash_before" "$hash_after"
 
 if [ -z "$d" ]; then
     echo "==> metadata is up to date"

--- a/test/lint/metadata-up-to-date.sh
+++ b/test/lint/metadata-up-to-date.sh
@@ -25,7 +25,7 @@ metadata_hash "$hash_after"
 mv "${json_metadata}.bak" "${json_metadata}"
 mv "${doc_config_options}.bak" "${doc_config_options}"
 
-d="$(diff "$hash_before" "$hash_after")"
+d="$(diff -Nau "$hash_before" "$hash_after" || true)"
 rm "$hash_before" "$hash_after"
 
 if [ -z "$d" ]; then


### PR DESCRIPTION
The script would abort when a delta between "before" and "after" was noticed because `diff` would return with a non-`0` code. Fix that so that we can see the delta if there is one and use "unified" mode.