### PR TITLE
Update storage_volumes.md

### DIFF
--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -52,6 +52,7 @@ The following restrictions apply:
 - Custom storage volumes of {ref}`content type <storage-content-types>` `block` or `iso` cannot be attached to containers, but only to virtual machines.
 - To avoid data corruption, storage volumes of {ref}`content type <storage-content-types>` `block` should never be attached to more than one virtual machine at a time.
 - Storage volumes of {ref}`content type <storage-content-types>` `iso` are always read-only, and can therefore be attached to more than one virtual machine at a time without corrupting data.
+- Storage volumes can't be attached to virtual machines while they're running.
 
 For custom storage volumes with the content type `filesystem`, use the following command, where `<location>` is the path for accessing the storage volume inside the instance (for example, `/data`):
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -52,7 +52,7 @@ The following restrictions apply:
 - Custom storage volumes of {ref}`content type <storage-content-types>` `block` or `iso` cannot be attached to containers, but only to virtual machines.
 - To avoid data corruption, storage volumes of {ref}`content type <storage-content-types>` `block` should never be attached to more than one virtual machine at a time.
 - Storage volumes of {ref}`content type <storage-content-types>` `iso` are always read-only, and can therefore be attached to more than one virtual machine at a time without corrupting data.
-- Filesystem storage volumes can't be attached to virtual machines while they're running.
+- File system storage volumes can't be attached to virtual machines while they're running.
 
 For custom storage volumes with the content type `filesystem`, use the following command, where `<location>` is the path for accessing the storage volume inside the instance (for example, `/data`):
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -52,7 +52,7 @@ The following restrictions apply:
 - Custom storage volumes of {ref}`content type <storage-content-types>` `block` or `iso` cannot be attached to containers, but only to virtual machines.
 - To avoid data corruption, storage volumes of {ref}`content type <storage-content-types>` `block` should never be attached to more than one virtual machine at a time.
 - Storage volumes of {ref}`content type <storage-content-types>` `iso` are always read-only, and can therefore be attached to more than one virtual machine at a time without corrupting data.
-- Storage volumes can't be attached to virtual machines while they're running.
+- Filesystem storage volumes can't be attached to virtual machines while they're running.
 
 For custom storage volumes with the content type `filesystem`, use the following command, where `<location>` is the path for accessing the storage volume inside the instance (for example, `/data`):
 


### PR DESCRIPTION
Added a point mentioning the restriction that storage volumes can't be attached to running virtual machines. This is mentioned by Stephane Graber in this youtube tutorial [1] and has been confirmed experimentally (at least for a volume with a "dir" backend)

[1] https://youtu.be/dvQ111pbqtk?si=VNRiMlpZ_h6TRzn8&t=410

Signed-off-by: Piper Deck <piper.deck@canonical.com>