### PR TITLE
Device: Fix disk hot-plug validation for VMs

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -118,7 +118,19 @@ func (d *disk) sourceIsCeph() bool {
 
 // CanHotPlug returns whether the device can be managed whilst the instance is running.
 func (d *disk) CanHotPlug() bool {
-	return !(d.sourceIsDir() || d.sourceIsCephFs()) || d.inst.Type() == instancetype.Container
+	// Containers support hot-plugging all disk types.
+	if d.inst.Type() == instancetype.Container {
+		return true
+	}
+
+	// A mount path indicates a filesystem disk being attached, which cannot be hot-plugged for VMs due to
+	// limitations with virtiofs.
+	if d.config["path"] != "" {
+		return false
+	}
+
+	// Block disks can be hot-plugged into VMs.
+	return true
 }
 
 // validateConfig checks the supplied config for correctness.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -101,11 +101,6 @@ func (d *disk) CanMigrate() bool {
 	return false
 }
 
-// sourceIsDir returns true if the disks source config setting is a directory.
-func (d *disk) sourceIsDir() bool {
-	return shared.IsDir(d.config["source"])
-}
-
 // sourceIsCephFs returns true if the disks source config setting is a CephFS share.
 func (d *disk) sourceIsCephFs() bool {
 	return strings.HasPrefix(d.config["source"], "cephfs:")

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -864,6 +864,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			// directory sharing feature to mount the directory inside the VM, and as such we need to
 			// indicate to the VM the target path to mount to.
 			if shared.IsDir(mount.DevPath) || d.sourceIsCephFs() {
+				if d.config["path"] == "" {
+					return nil, fmt.Errorf(`Missing mount "path" setting`)
+				}
+
 				// Mount the source in the instance devices directory.
 				// This will ensure that if the exported directory configured as readonly that this
 				// takes effect event if using virtio-fs (which doesn't support read only mode) by


### PR DESCRIPTION
This PR fixes a couple of validation issues with `disk` devices relating to detecting whether a disk can be hotplugged into a VM or not.

Before:
```
lxc storage volume create default vol1fs --type=filesystem
lxc launch ubuntu:jammy v1 --vm

lxc config device add v1 vol1 disk source=vol1fs pool=default 
Error: Failed add validation for device "vol1": Custom filesystem volumes require a path to be defined

# Bug 1 - tries to hotplug filesystem volume
lxc config device add v1 vol1 disk source=vol1fs pool=default path=/mnt
Error: Failed to start device "vol1": Failed to add drive config: Invalid device path format "36"

lxc stop v1
lxc config device add v1 vol1 disk source=vol1fs pool=default path=/mnt
lxc start v1

# Bug 2 - allows hot-unplug of filesystem volume
lxc config device remove v1 vol1
Device vol1 removed from v1
lxc exec v1 -- ls /mnt #hangs
```

After:

```
lxc storage volume create default vol1fs --type=filesystem
lxc launch ubuntu:jammy v1 --vm

lxc config device add v1 vol1 disk source=vol1fs pool=default 
Error: Failed add validation for device "vol1": Custom filesystem volumes require a path to be defined

lxc config device add v1 vol1 disk source=vol1fs pool=default path=/mnt
Error: Failed to add device "vol1": Device cannot be added when instance is running

lxc stop v1

lxc config device add v1 vol1 disk source=vol1fs pool=default path=/mnt
lxc start v1

lxc config device remove v1 vol1
Error: Failed to stop device "vol1": Device cannot be stopped when instance is running
```