### PR TITLE
Fix OVN leases not showing static IPs

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3919,22 +3919,6 @@ func (n *ovn) instanceDeviceACLDefaults(deviceConfig deviceConfig.Device, direct
 	return defaults[fmt.Sprintf("security.acls.default.%s.action", direction)], shared.IsTrue(defaults[fmt.Sprintf("security.acls.default.%s.logged", direction)])
 }
 
-// InstanceDevicePortDynamicIPs returns the dynamically allocated IPs for a device port.
-func (n *ovn) InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error) {
-	if instanceUUID == "" {
-		return nil, fmt.Errorf("Instance UUID is required")
-	}
-
-	instancePortName := n.getInstanceDevicePortName(instanceUUID, deviceName)
-
-	client, err := openvswitch.NewOVN(n.state)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get OVN client: %w", err)
-	}
-
-	return client.LogicalSwitchPortDynamicIPs(instancePortName)
-}
-
 // InstanceDevicePortIPs returns the allocated IPs for a device port.
 func (n *ovn) InstanceDevicePortIPs(instanceUUID string, deviceName string) ([]net.IP, error) {
 	if instanceUUID == "" {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3447,7 +3447,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				// If the sticky IP isn't statically reserved, lets check its not used dynamically
 				// on any active port.
 				if !n.hasDHCPv4Reservation(dhcpReservations, dhcpV4StickyIP) {
-					existingPortIPs, err := client.LogicalSwitchPortIPs(n.getIntSwitchName())
+					existingPortIPs, err := client.LogicalSwitchIPs(n.getIntSwitchName())
 					if err != nil {
 						return "", nil, fmt.Errorf("Failed getting existing switch port IPs: %w", err)
 					}


### PR DESCRIPTION
This PR fixes OVN leases not showing static IPs. Due to this error, dynamic leases also disappeared from the list after instance restart.

Fixes #12177