### PR TITLE
shared/cmd/ask: Allow setting CLI function reader

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -831,7 +831,7 @@ func (c *cmdClusterAdd) Run(cmd *cobra.Command, args []string) error {
 
 	if resource.name == "" {
 		if c.flagName == "" {
-			resource.name, err = cli.AskString(i18n.G("Please provide cluster member name: "), "", nil)
+			resource.name, err = c.global.asker.AskString(i18n.G("Please provide cluster member name: "), "", nil)
 			if err != nil {
 				return err
 			}
@@ -1219,7 +1219,7 @@ func (c *cmdClusterEvacuateAction) Run(cmd *cobra.Command, args []string) error 
 	}
 
 	if !c.flagForce {
-		evacuate, err := cli.AskBool(fmt.Sprintf(i18n.G("Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "), cmd.Name(), resource.name), "no")
+		evacuate, err := c.global.asker.AskBool(fmt.Sprintf(i18n.G("Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "), cmd.Name(), resource.name), "no")
 		if err != nil {
 			return err
 		}

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -152,7 +152,7 @@ func (c *cmdConfigTrustAdd) Run(cmd *cobra.Command, args []string) error {
 		if c.flagName != "" {
 			cert.Name = c.flagName
 		} else {
-			cert.Name, err = cli.AskString(i18n.G("Please provide client name: "), "", nil)
+			cert.Name, err = c.global.asker.AskString(i18n.G("Please provide client name: "), "", nil)
 			if err != nil {
 				return err
 			}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/user"
@@ -19,6 +20,8 @@ import (
 )
 
 type cmdGlobal struct {
+	asker cli.Asker
+
 	conf     *config.Config
 	confPath string
 	cmd      *cobra.Command
@@ -86,7 +89,7 @@ For help with any of those, simply call them with --help.`))
 	app.CompletionOptions = cobra.CompletionOptions{DisableDefaultCmd: true}
 
 	// Global flags
-	globalCmd := cmdGlobal{cmd: app}
+	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, i18n.G("Print version number"))
 	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, i18n.G("Print help"))
 	app.PersistentFlags().BoolVar(&globalCmd.flagForceLocal, "force-local", false, i18n.G("Force using the local unix socket"))

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -136,7 +136,7 @@ func (c *cmdRemoteAdd) findProject(d lxd.InstanceServer, project string) (string
 				fmt.Println(" - " + name)
 			}
 
-			return cli.AskChoice(i18n.G("Name of the project to use for this remote:")+" ", names, "")
+			return c.global.asker.AskChoice(i18n.G("Name of the project to use for this remote:")+" ", names, "")
 		}
 
 		return "", nil

--- a/lxd-migrate/main.go
+++ b/lxd-migrate/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"bufio"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/version"
 )
 
 type cmdGlobal struct {
+	asker cli.Asker
+
 	flagVersion bool
 	flagHelp    bool
 }
@@ -24,7 +28,7 @@ func main() {
 	app.Args = cobra.ArbitraryArgs
 
 	// Global flags
-	globalCmd := cmdGlobal{}
+	globalCmd := cmdGlobal{asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
 	migrateCmd.global = &globalCmd
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")
 	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, "Print help")

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -112,7 +112,7 @@ func (c *cmdMigrateData) Render() string {
 
 func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	// Server address
-	serverURL, err := cli.AskString("Please provide LXD server URL: ", "", nil)
+	serverURL, err := c.global.asker.AskString("Please provide LXD server URL: ", "", nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -190,7 +190,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	}
 
 	if len(apiServer.AuthMethods) > 1 || shared.StringInSlice("tls", apiServer.AuthMethods) {
-		authMethodInt, err := cli.AskInt("Please pick an authentication mechanism above: ", 1, int64(i), "", nil)
+		authMethodInt, err := c.global.asker.AskInt("Please pick an authentication mechanism above: ", 1, int64(i), "", nil)
 		if err != nil {
 			return nil, "", err
 		}
@@ -203,7 +203,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	var token string
 
 	if authMethod == authMethodTLSCertificate {
-		certPath, err = cli.AskString("Please provide the certificate path: ", "", func(path string) error {
+		certPath, err = c.global.asker.AskString("Please provide the certificate path: ", "", func(path string) error {
 			if !shared.PathExists(path) {
 				return errors.New("File does not exist")
 			}
@@ -214,7 +214,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 			return nil, "", err
 		}
 
-		keyPath, err = cli.AskString("Please provide the keyfile path: ", "", func(path string) error {
+		keyPath, err = c.global.asker.AskString("Please provide the keyfile path: ", "", func(path string) error {
 			if !shared.PathExists(path) {
 				return errors.New("File does not exist")
 			}
@@ -225,7 +225,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 			return nil, "", err
 		}
 	} else if authMethod == authMethodTLSCertificateToken {
-		token, err = cli.AskString("Please provide the certificate token: ", "", func(token string) error {
+		token, err = c.global.asker.AskString("Please provide the certificate token: ", "", func(token string) error {
 			_, err := shared.CertificateTokenDecode(token)
 			if err != nil {
 				return err
@@ -247,7 +247,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 		authType = "tls"
 	}
 
-	return connectTarget(serverURL, certPath, keyPath, authType, token)
+	return c.connectTarget(serverURL, certPath, keyPath, authType, token)
 }
 
 func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, error) {
@@ -266,7 +266,7 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 	config.InstanceArgs.Devices = map[string]map[string]string{}
 
 	// Provide instance type
-	instanceType, err := cli.AskInt("Would you like to create a container (1) or virtual-machine (2)?: ", 1, 2, "1", nil)
+	instanceType, err := c.global.asker.AskInt("Would you like to create a container (1) or virtual-machine (2)?: ", 1, 2, "1", nil)
 	if err != nil {
 		return cmdMigrateData{}, err
 	}
@@ -284,7 +284,7 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 	}
 
 	if len(projectNames) > 1 {
-		project, err := cli.AskChoice("Project to create the instance in [default=default]: ", projectNames, "default")
+		project, err := c.global.asker.AskChoice("Project to create the instance in [default=default]: ", projectNames, "default")
 		if err != nil {
 			return cmdMigrateData{}, err
 		}
@@ -301,7 +301,7 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 	}
 
 	for {
-		instanceName, err := cli.AskString("Name of the new instance: ", "", nil)
+		instanceName, err := c.global.asker.AskString("Name of the new instance: ", "", nil)
 		if err != nil {
 			return cmdMigrateData{}, err
 		}
@@ -324,7 +324,7 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 		question = "Please provide the path to a root filesystem: "
 	}
 
-	config.SourcePath, err = cli.AskString(question, "", func(s string) error {
+	config.SourcePath, err = c.global.asker.AskString(question, "", func(s string) error {
 		if !shared.PathExists(s) {
 			return errors.New("Path does not exist")
 		}
@@ -344,7 +344,7 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 		architectureName, _ := osarch.ArchitectureGetLocal()
 
 		if shared.StringInSlice(architectureName, []string{"x86_64", "aarch64"}) {
-			hasSecureBoot, err := cli.AskBool("Does the VM support UEFI Secure Boot? [default=no]: ", "no")
+			hasSecureBoot, err := c.global.asker.AskBool("Does the VM support UEFI Secure Boot? [default=no]: ", "no")
 			if err != nil {
 				return cmdMigrateData{}, err
 			}
@@ -359,14 +359,14 @@ func (c *cmdMigrate) RunInteractive(server lxd.InstanceServer) (cmdMigrateData, 
 
 	// Additional mounts for containers
 	if config.InstanceArgs.Type == api.InstanceTypeContainer {
-		addMounts, err := cli.AskBool("Do you want to add additional filesystem mounts? [default=no]: ", "no")
+		addMounts, err := c.global.asker.AskBool("Do you want to add additional filesystem mounts? [default=no]: ", "no")
 		if err != nil {
 			return cmdMigrateData{}, err
 		}
 
 		if addMounts {
 			for {
-				path, err := cli.AskString("Please provide a path the filesystem mount path [empty value to continue]: ", "", func(s string) error {
+				path, err := c.global.asker.AskString("Please provide a path the filesystem mount path [empty value to continue]: ", "", func(s string) error {
 					if s != "" {
 						if shared.PathExists(s) {
 							return nil
@@ -410,7 +410,7 @@ Additional overrides can be applied at this stage:
 
 `)
 
-		choice, err := cli.AskInt("Please pick one of the options above [default=1]: ", 1, 5, "1", nil)
+		choice, err := c.global.asker.AskInt("Please pick one of the options above [default=1]: ", 1, 5, "1", nil)
 		if err != nil {
 			return cmdMigrateData{}, err
 		}
@@ -595,7 +595,7 @@ func (c *cmdMigrate) askProfiles(server lxd.InstanceServer, config *cmdMigrateDa
 		return err
 	}
 
-	profiles, err := cli.AskString("Which profiles do you want to apply to the instance? (space separated) [default=default, \"-\" for none]: ", "default", func(s string) error {
+	profiles, err := c.global.asker.AskString("Which profiles do you want to apply to the instance? (space separated) [default=default, \"-\" for none]: ", "default", func(s string) error {
 		// This indicates that no profiles should be applied.
 		if s == "-" {
 			return nil
@@ -623,7 +623,7 @@ func (c *cmdMigrate) askProfiles(server lxd.InstanceServer, config *cmdMigrateDa
 }
 
 func (c *cmdMigrate) askConfig(config *cmdMigrateData) error {
-	configs, err := cli.AskString("Please specify config keys and values (key=value ...): ", "", func(s string) error {
+	configs, err := c.global.asker.AskString("Please specify config keys and values (key=value ...): ", "", func(s string) error {
 		if s == "" {
 			return nil
 		}
@@ -658,7 +658,7 @@ func (c *cmdMigrate) askStorage(server lxd.InstanceServer, config *cmdMigrateDat
 		return fmt.Errorf("No storage pools available")
 	}
 
-	storagePool, err := cli.AskChoice("Please provide the storage pool to use: ", storagePools, "")
+	storagePool, err := c.global.asker.AskChoice("Please provide the storage pool to use: ", storagePools, "")
 	if err != nil {
 		return err
 	}
@@ -669,13 +669,13 @@ func (c *cmdMigrate) askStorage(server lxd.InstanceServer, config *cmdMigrateDat
 		"path": "/",
 	}
 
-	changeStorageSize, err := cli.AskBool("Do you want to change the storage size? [default=no]: ", "no")
+	changeStorageSize, err := c.global.asker.AskBool("Do you want to change the storage size? [default=no]: ", "no")
 	if err != nil {
 		return err
 	}
 
 	if changeStorageSize {
-		size, err := cli.AskString("Please specify the storage size: ", "", func(s string) error {
+		size, err := c.global.asker.AskString("Please specify the storage size: ", "", func(s string) error {
 			_, err := units.ParseByteSizeString(s)
 			return err
 		})
@@ -695,7 +695,7 @@ func (c *cmdMigrate) askNetwork(server lxd.InstanceServer, config *cmdMigrateDat
 		return err
 	}
 
-	network, err := cli.AskChoice("Please specify the network to use for the instance: ", networks, "")
+	network, err := c.global.asker.AskChoice("Please specify the network to use for the instance: ", networks, "")
 	if err != nil {
 		return err
 	}

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -24,7 +24,6 @@ import (
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
-	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/version"
 	"github.com/canonical/lxd/shared/ws"
 )
@@ -147,7 +146,7 @@ func transferRootfs(ctx context.Context, dst lxd.InstanceServer, op lxd.Operatio
 	return nil
 }
 
-func connectTarget(url string, certPath string, keyPath string, authType string, token string) (lxd.InstanceServer, string, error) {
+func (m *cmdMigrate) connectTarget(url string, certPath string, keyPath string, authType string, token string) (lxd.InstanceServer, string, error) {
 	args := lxd.ConnectionArgs{
 		AuthType: authType,
 	}
@@ -274,7 +273,7 @@ func connectTarget(url string, certPath string, keyPath string, authType string,
 
 			fmt.Println("")
 
-			useTrustPassword, err := cli.AskBool("Would you like to use a trust password? [default=no]: ", "no")
+			useTrustPassword, err := m.global.asker.AskBool("Would you like to use a trust password? [default=no]: ", "no")
 			if err != nil {
 				return nil, "", err
 			}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"math/rand"
 	"os"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/rsync"
+	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -24,6 +26,8 @@ func init() {
 
 type cmdGlobal struct {
 	cmd *cobra.Command
+
+	asker cli.Asker
 
 	flagHelp    bool
 	flagVersion bool
@@ -93,7 +97,7 @@ func main() {
 	app.Args = cobra.ArbitraryArgs
 
 	// Global flags
-	globalCmd := cmdGlobal{cmd: app}
+	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin))}
 	daemonCmd.global = &globalCmd
 	app.PersistentPreRunE = globalCmd.Run
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -77,7 +77,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 	}
 
 	// Print the YAML
-	preSeedPrint, err := cli.AskBool("Would you like a YAML \"lxd init\" preseed to be printed? (yes/no) [default=no]: ", "no")
+	preSeedPrint, err := c.global.asker.AskBool("Would you like a YAML \"lxd init\" preseed to be printed? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (c *cmdInit) RunInteractive(cmd *cobra.Command, args []string, d lxd.Instan
 }
 
 func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, server *api.Server) error {
-	clustering, err := cli.AskBool("Would you like to use LXD clustering? (yes/no) [default=no]: ", "no")
+	clustering, err := c.global.asker.AskBool("Would you like to use LXD clustering? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 		config.Cluster.Enabled = true
 
 		askForServerName := func() error {
-			config.Cluster.ServerName, err = cli.AskString(fmt.Sprintf("What member name should be used to identify this server in the cluster? [default=%s]: ", c.defaultHostname()), c.defaultHostname(), nil)
+			config.Cluster.ServerName, err = c.global.asker.AskString(fmt.Sprintf("What member name should be used to identify this server in the cluster? [default=%s]: ", c.defaultHostname()), c.defaultHostname(), nil)
 			if err != nil {
 				return err
 			}
@@ -151,7 +151,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 			return nil
 		}
 
-		serverAddress, err := cli.AskString(fmt.Sprintf("What IP address or DNS name should be used to reach this server? [default=%s]: ", address), address, validateServerAddress)
+		serverAddress, err := c.global.asker.AskString(fmt.Sprintf("What IP address or DNS name should be used to reach this server? [default=%s]: ", address), address, validateServerAddress)
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 		serverAddress = util.CanonicalNetworkAddress(serverAddress, shared.HTTPSDefaultPort)
 		config.Node.Config["core.https_address"] = serverAddress
 
-		clusterJoin, err := cli.AskBool("Are you joining an existing cluster? (yes/no) [default=no]: ", "no")
+		clusterJoin, err := c.global.asker.AskBool("Are you joining an existing cluster? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}
@@ -197,14 +197,14 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 				return nil
 			}
 
-			clusterJoinToken, err := cli.AskString("Do you have a join token? (yes/no/[token]) [default=no]: ", "no", validInput)
+			clusterJoinToken, err := c.global.asker.AskString("Do you have a join token? (yes/no/[token]) [default=no]: ", "no", validInput)
 			if err != nil {
 				return err
 			}
 
 			if !shared.StringInSlice(strings.ToLower(clusterJoinToken), []string{"no", "n"}) {
 				if shared.StringInSlice(strings.ToLower(clusterJoinToken), []string{"yes", "y"}) {
-					clusterJoinToken, err = cli.AskString("Please provide join token: ", "", validJoinToken)
+					clusterJoinToken, err = c.global.asker.AskString("Please provide join token: ", "", validJoinToken)
 					if err != nil {
 						return err
 					}
@@ -250,7 +250,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 
 				for {
 					// Cluster URL
-					clusterAddress, err := cli.AskString("IP address or FQDN of an existing cluster member (may include port): ", "", nil)
+					clusterAddress, err := c.global.asker.AskString("IP address or FQDN of an existing cluster member (may include port): ", "", nil)
 					if err != nil {
 						return err
 					}
@@ -280,7 +280,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 						return fmt.Errorf("Not yes/no or fingerprint")
 					}
 
-					fingerprintCorrect, err := cli.AskString("Is this the correct fingerprint? (yes/no/[fingerprint]) [default=no]: ", "no", validator)
+					fingerprintCorrect, err := c.global.asker.AskString("Is this the correct fingerprint? (yes/no/[fingerprint]) [default=no]: ", "no", validator)
 					if err != nil {
 						return err
 					}
@@ -298,7 +298,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 			}
 
 			// Confirm wiping
-			clusterWipeMember, err := cli.AskBool("All existing data is lost when joining a cluster, continue? (yes/no) [default=no] ", "no")
+			clusterWipeMember, err := c.global.asker.AskBool("All existing data is lost when joining a cluster, continue? (yes/no) [default=no] ", "no")
 			if err != nil {
 				return err
 			}
@@ -345,7 +345,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 				question := fmt.Sprintf("Choose %s: ", config.Description)
 
 				// Allow for empty values.
-				configValue, err := cli.AskString(question, "", validate.Optional())
+				configValue, err := c.global.asker.AskString(question, "", validate.Optional())
 				if err != nil {
 					return err
 				}
@@ -367,7 +367,7 @@ func (c *cmdInit) askClustering(config *api.InitPreseed, d lxd.InstanceServer, s
 }
 
 func (c *cmdInit) askMAAS(config *api.InitPreseed, d lxd.InstanceServer) error {
-	maas, err := cli.AskBool("Would you like to connect to a MAAS server? (yes/no) [default=no]: ", "no")
+	maas, err := c.global.asker.AskBool("Would you like to connect to a MAAS server? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func (c *cmdInit) askMAAS(config *api.InitPreseed, d lxd.InstanceServer) error {
 		return nil
 	}
 
-	maasHostname, err := cli.AskString(fmt.Sprintf("What's the name of this host in MAAS? [default=%s]: ", c.defaultHostname()), c.defaultHostname(), nil)
+	maasHostname, err := c.global.asker.AskString(fmt.Sprintf("What's the name of this host in MAAS? [default=%s]: ", c.defaultHostname()), c.defaultHostname(), nil)
 	if err != nil {
 		return err
 	}
@@ -385,12 +385,12 @@ func (c *cmdInit) askMAAS(config *api.InitPreseed, d lxd.InstanceServer) error {
 		config.Node.Config["maas.machine"] = maasHostname
 	}
 
-	config.Node.Config["maas.api.url"], err = cli.AskString("URL of your MAAS server (e.g. http://1.2.3.4:5240/MAAS): ", "", nil)
+	config.Node.Config["maas.api.url"], err = c.global.asker.AskString("URL of your MAAS server (e.g. http://1.2.3.4:5240/MAAS): ", "", nil)
 	if err != nil {
 		return err
 	}
 
-	config.Node.Config["maas.api.key"], err = cli.AskString("API key for your MAAS server: ", "", nil)
+	config.Node.Config["maas.api.key"], err = c.global.asker.AskString("API key for your MAAS server: ", "", nil)
 	if err != nil {
 		return err
 	}
@@ -403,7 +403,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 	localBridgeCreate := false
 
 	if config.Cluster == nil {
-		localBridgeCreate, err = cli.AskBool("Would you like to create a new local network bridge? (yes/no) [default=yes]: ", "yes")
+		localBridgeCreate, err = c.global.asker.AskBool("Would you like to create a new local network bridge? (yes/no) [default=yes]: ", "yes")
 		if err != nil {
 			return err
 		}
@@ -419,14 +419,14 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 			}
 		}
 
-		useExistingInterface, err := cli.AskBool("Would you like to configure LXD to use an existing bridge or host interface? (yes/no) [default=no]: ", "no")
+		useExistingInterface, err := c.global.asker.AskBool("Would you like to configure LXD to use an existing bridge or host interface? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}
 
 		if useExistingInterface {
 			for {
-				interfaceName, err := cli.AskString("Name of the existing bridge or host interface: ", "", nil)
+				interfaceName, err := c.global.asker.AskString("Name of the existing bridge or host interface: ", "", nil)
 				if err != nil {
 					return err
 				}
@@ -449,13 +449,13 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 				}
 
 				if config.Node.Config["maas.api.url"] != nil {
-					maasConnect, err := cli.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes")
+					maasConnect, err := c.global.asker.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes")
 					if err != nil {
 						return err
 					}
 
 					if maasConnect {
-						maasSubnetV4, err := cli.AskString("MAAS IPv4 subnet name for this interface (empty for no subnet): ", "", validate.Optional())
+						maasSubnetV4, err := c.global.asker.AskString("MAAS IPv4 subnet name for this interface (empty for no subnet): ", "", validate.Optional())
 						if err != nil {
 							return err
 						}
@@ -464,7 +464,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 							config.Node.Profiles[0].Devices["eth0"]["maas.subnet.ipv4"] = maasSubnetV4
 						}
 
-						maasSubnetV6, err := cli.AskString("MAAS IPv6 subnet name for this interface (empty for no subnet): ", "", validate.Optional())
+						maasSubnetV6, err := c.global.asker.AskString("MAAS IPv6 subnet name for this interface (empty for no subnet): ", "", validate.Optional())
 						if err != nil {
 							return err
 						}
@@ -478,7 +478,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 				break
 			}
 		} else if config.Cluster != nil && fanKernel {
-			fan, err := cli.AskBool("Would you like to create a new Fan overlay network? (yes/no) [default=yes]: ", "yes")
+			fan, err := c.global.asker.AskBool("Would you like to create a new Fan overlay network? (yes/no) [default=yes]: ", "yes")
 			if err != nil {
 				return err
 			}
@@ -493,7 +493,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 				}
 
 				// Select the underlay
-				networkPost.Config["fan.underlay_subnet"], err = cli.AskString("What subnet should be used as the Fan underlay? [default=auto]: ", "auto", func(value string) error {
+				networkPost.Config["fan.underlay_subnet"], err = c.global.asker.AskString("What subnet should be used as the Fan underlay? [default=auto]: ", "auto", func(value string) error {
 					var err error
 					var subnet *net.IPNet
 
@@ -547,7 +547,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		net.Project = project.Default
 
 		// Network name
-		net.Name, err = cli.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error {
+		net.Name, err = c.global.asker.AskString("What should the new bridge be called? [default=lxdbr0]: ", "lxdbr0", func(netName string) error {
 			netType, err := network.LoadByType("bridge")
 			if err != nil {
 				return err
@@ -573,7 +573,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		}
 
 		// IPv4
-		net.Config["ipv4.address"], err = cli.AskString("What IPv4 address should be used? (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
+		net.Config["ipv4.address"], err = c.global.asker.AskString("What IPv4 address should be used? (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
 			if shared.StringInSlice(value, []string{"auto", "none"}) {
 				return nil
 			}
@@ -585,7 +585,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		}
 
 		if !shared.StringInSlice(net.Config["ipv4.address"], []string{"auto", "none"}) {
-			netIPv4UseNAT, err := cli.AskBool("Would you like LXD to NAT IPv4 traffic on your bridge? [default=yes]: ", "yes")
+			netIPv4UseNAT, err := c.global.asker.AskBool("Would you like LXD to NAT IPv4 traffic on your bridge? [default=yes]: ", "yes")
 			if err != nil {
 				return err
 			}
@@ -594,7 +594,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		}
 
 		// IPv6
-		net.Config["ipv6.address"], err = cli.AskString("What IPv6 address should be used? (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
+		net.Config["ipv6.address"], err = c.global.asker.AskString("What IPv6 address should be used? (CIDR subnet notation, “auto” or “none”) [default=auto]: ", "auto", func(value string) error {
 			if shared.StringInSlice(value, []string{"auto", "none"}) {
 				return nil
 			}
@@ -606,7 +606,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		}
 
 		if !shared.StringInSlice(net.Config["ipv6.address"], []string{"auto", "none"}) {
-			netIPv6UseNAT, err := cli.AskBool("Would you like LXD to NAT IPv6 traffic on your bridge? [default=yes]: ", "yes")
+			netIPv6UseNAT, err := c.global.asker.AskBool("Would you like LXD to NAT IPv6 traffic on your bridge? [default=yes]: ", "yes")
 			if err != nil {
 				return err
 			}
@@ -624,7 +624,7 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 
 func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, server *api.Server) error {
 	if config.Cluster != nil {
-		localStoragePool, err := cli.AskBool("Do you want to configure a new local storage pool? (yes/no) [default=yes]: ", "yes")
+		localStoragePool, err := c.global.asker.AskBool("Do you want to configure a new local storage pool? (yes/no) [default=yes]: ", "yes")
 		if err != nil {
 			return err
 		}
@@ -636,7 +636,7 @@ func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, serv
 			}
 		}
 
-		remoteStoragePool, err := cli.AskBool("Do you want to configure a new remote storage pool? (yes/no) [default=no]: ", "no")
+		remoteStoragePool, err := c.global.asker.AskBool("Do you want to configure a new remote storage pool? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}
@@ -651,7 +651,7 @@ func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, serv
 		return nil
 	}
 
-	storagePool, err := cli.AskBool("Do you want to configure a new storage pool? (yes/no) [default=yes]: ", "yes")
+	storagePool, err := c.global.asker.AskBool("Do you want to configure a new storage pool? (yes/no) [default=yes]: ", "yes")
 	if err != nil {
 		return err
 	}
@@ -695,7 +695,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		pool.Config = map[string]string{}
 
 		if poolType == util.PoolTypeAny {
-			pool.Name, err = cli.AskString("Name of the new storage pool [default=default]: ", "default", nil)
+			pool.Name, err = c.global.asker.AskString("Name of the new storage pool [default=default]: ", "default", nil)
 			if err != nil {
 				return err
 			}
@@ -733,7 +733,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 				}
 			}
 
-			pool.Driver, err = cli.AskChoice(fmt.Sprintf("Name of the storage backend to use (%s) [default=%s]: ", strings.Join(availableBackends, ", "), defaultBackend), availableBackends, defaultBackend)
+			pool.Driver, err = c.global.asker.AskChoice(fmt.Sprintf("Name of the storage backend to use (%s) [default=%s]: ", strings.Join(availableBackends, ", "), defaultBackend), availableBackends, defaultBackend)
 			if err != nil {
 				return err
 			}
@@ -749,7 +749,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 
 		// Optimization for btrfs on btrfs
 		if pool.Driver == "btrfs" && backingFs == "btrfs" {
-			btrfsSubvolume, err := cli.AskBool(fmt.Sprintf("Would you like to create a new btrfs subvolume under %s? (yes/no) [default=yes]: ", shared.VarPath("")), "yes")
+			btrfsSubvolume, err := c.global.asker.AskBool(fmt.Sprintf("Would you like to create a new btrfs subvolume under %s? (yes/no) [default=yes]: ", shared.VarPath("")), "yes")
 			if err != nil {
 				return err
 			}
@@ -765,7 +765,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		if pool.Driver == "zfs" && backingFs == "zfs" {
 			poolName, _ := shared.RunCommand("zpool", "get", "-H", "-o", "value", "name", "rpool")
 			if strings.TrimSpace(poolName) == "rpool" {
-				zfsDataset, err := cli.AskBool("Would you like to create a new zfs dataset under rpool/lxd? (yes/no) [default=yes]: ", "yes")
+				zfsDataset, err := c.global.asker.AskBool("Would you like to create a new zfs dataset under rpool/lxd? (yes/no) [default=yes]: ", "yes")
 				if err != nil {
 					return err
 				}
@@ -778,7 +778,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 			}
 		}
 
-		poolCreate, err := cli.AskBool(fmt.Sprintf("Create a new %s pool? (yes/no) [default=yes]: ", strings.ToUpper(pool.Driver)), "yes")
+		poolCreate, err := c.global.asker.AskBool(fmt.Sprintf("Create a new %s pool? (yes/no) [default=yes]: ", strings.ToUpper(pool.Driver)), "yes")
 		if err != nil {
 			return err
 		}
@@ -786,42 +786,42 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		if poolCreate {
 			if pool.Driver == "ceph" {
 				// Ask for the name of the cluster
-				pool.Config["ceph.cluster_name"], err = cli.AskString("Name of the existing CEPH cluster [default=ceph]: ", "ceph", nil)
+				pool.Config["ceph.cluster_name"], err = c.global.asker.AskString("Name of the existing CEPH cluster [default=ceph]: ", "ceph", nil)
 				if err != nil {
 					return err
 				}
 
 				// Ask for the name of the osd pool
-				pool.Config["ceph.osd.pool_name"], err = cli.AskString("Name of the OSD storage pool [default=lxd]: ", "lxd", nil)
+				pool.Config["ceph.osd.pool_name"], err = c.global.asker.AskString("Name of the OSD storage pool [default=lxd]: ", "lxd", nil)
 				if err != nil {
 					return err
 				}
 
 				// Ask for the number of placement groups
-				pool.Config["ceph.osd.pg_num"], err = cli.AskString("Number of placement groups [default=32]: ", "32", nil)
+				pool.Config["ceph.osd.pg_num"], err = c.global.asker.AskString("Number of placement groups [default=32]: ", "32", nil)
 				if err != nil {
 					return err
 				}
 			} else if pool.Driver == "cephfs" {
 				// Ask for the name of the cluster
-				pool.Config["cephfs.cluster_name"], err = cli.AskString("Name of the existing CEPHfs cluster [default=ceph]: ", "ceph", nil)
+				pool.Config["cephfs.cluster_name"], err = c.global.asker.AskString("Name of the existing CEPHfs cluster [default=ceph]: ", "ceph", nil)
 				if err != nil {
 					return err
 				}
 
 				// Ask for the name of the cluster
-				pool.Config["source"], err = cli.AskString("Name of the CEPHfs volume: ", "", nil)
+				pool.Config["source"], err = c.global.asker.AskString("Name of the CEPHfs volume: ", "", nil)
 				if err != nil {
 					return err
 				}
 			} else {
-				useEmptyBlockDev, err := cli.AskBool("Would you like to use an existing empty block device (e.g. a disk or partition)? (yes/no) [default=no]: ", "no")
+				useEmptyBlockDev, err := c.global.asker.AskBool("Would you like to use an existing empty block device (e.g. a disk or partition)? (yes/no) [default=no]: ", "no")
 				if err != nil {
 					return err
 				}
 
 				if useEmptyBlockDev {
-					pool.Config["source"], err = cli.AskString("Path to the existing block device: ", "", func(path string) error {
+					pool.Config["source"], err = c.global.asker.AskString("Path to the existing block device: ", "", func(path string) error {
 						if !shared.IsBlockdevPath(path) {
 							return fmt.Errorf("%q is not a block device", path)
 						}
@@ -848,7 +848,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 						defaultSize = 5
 					}
 
-					pool.Config["size"], err = cli.AskString(
+					pool.Config["size"], err = c.global.asker.AskString(
 						fmt.Sprintf("Size in GiB of the new loop device (1GiB minimum) [default=%dGiB]: ", defaultSize),
 						fmt.Sprintf("%dGiB", defaultSize),
 						func(input string) error {
@@ -878,13 +878,13 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		} else {
 			if pool.Driver == "ceph" {
 				// ask for the name of the cluster
-				pool.Config["ceph.cluster_name"], err = cli.AskString("Name of the existing CEPH cluster [default=ceph]: ", "ceph", nil)
+				pool.Config["ceph.cluster_name"], err = c.global.asker.AskString("Name of the existing CEPH cluster [default=ceph]: ", "ceph", nil)
 				if err != nil {
 					return err
 				}
 
 				// ask for the name of the existing pool
-				pool.Config["source"], err = cli.AskString("Name of the existing OSD storage pool [default=lxd]: ", "lxd", nil)
+				pool.Config["source"], err = c.global.asker.AskString("Name of the existing OSD storage pool [default=lxd]: ", "lxd", nil)
 				if err != nil {
 					return err
 				}
@@ -892,7 +892,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 				pool.Config["ceph.osd.pool_name"] = pool.Config["source"]
 			} else {
 				question := fmt.Sprintf("Name of the existing %s pool or dataset: ", strings.ToUpper(pool.Driver))
-				pool.Config["source"], err = cli.AskString(question, "", nil)
+				pool.Config["source"], err = c.global.asker.AskString(question, "", nil)
 				if err != nil {
 					return err
 				}
@@ -911,7 +911,7 @@ If you wish to use thin provisioning, abort now, install the tools from your Lin
 and make sure that your user can see and run the "thin_check" command before running "lxd init" again.
 
 `)
-				lvmContinueNoThin, err := cli.AskBool("Do you want to continue without thin provisioning? (yes/no) [default=yes]: ", "yes")
+				lvmContinueNoThin, err := c.global.asker.AskBool("Do you want to continue without thin provisioning? (yes/no) [default=yes]: ", "yes")
 				if err != nil {
 					return err
 				}
@@ -947,7 +947,7 @@ they otherwise would.
 
 `)
 
-		shareParentAllocation, err := cli.AskBool("Would you like to have your containers share their parent's allocation? (yes/no) [default=yes]: ", "yes")
+		shareParentAllocation, err := c.global.asker.AskBool("Would you like to have your containers share their parent's allocation? (yes/no) [default=yes]: ", "yes")
 		if err != nil {
 			return err
 		}
@@ -959,7 +959,7 @@ they otherwise would.
 
 	// Network listener
 	if config.Cluster == nil {
-		lxdOverNetwork, err := cli.AskBool("Would you like the LXD server to be available over the network? (yes/no) [default=no]: ", "no")
+		lxdOverNetwork, err := c.global.asker.AskBool("Would you like the LXD server to be available over the network? (yes/no) [default=no]: ", "no")
 		if err != nil {
 			return err
 		}
@@ -973,7 +973,7 @@ they otherwise would.
 				return nil
 			}
 
-			netAddr, err := cli.AskString("Address to bind LXD to (not including port) [default=all]: ", "all", isIPAddress)
+			netAddr, err := c.global.asker.AskString("Address to bind LXD to (not including port) [default=all]: ", "all", isIPAddress)
 			if err != nil {
 				return err
 			}
@@ -986,7 +986,7 @@ they otherwise would.
 				netAddr = fmt.Sprintf("[%s]", netAddr)
 			}
 
-			netPort, err := cli.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.HTTPSDefaultPort), 1, 65535, fmt.Sprintf("%d", shared.HTTPSDefaultPort), func(netPort int64) error {
+			netPort, err := c.global.asker.AskInt(fmt.Sprintf("Port to bind LXD to [default=%d]: ", shared.HTTPSDefaultPort), 1, 65535, fmt.Sprintf("%d", shared.HTTPSDefaultPort), func(netPort int64) error {
 				address := util.CanonicalNetworkAddressFromAddressAndPort(netAddr, int(netPort), shared.HTTPSDefaultPort)
 
 				if err == nil {
@@ -1013,7 +1013,7 @@ they otherwise would.
 	}
 
 	// Ask if the user wants images to be automatically refreshed
-	imageStaleRefresh, err := cli.AskBool("Would you like stale cached images to be updated automatically? (yes/no) [default=yes]: ", "yes")
+	imageStaleRefresh, err := c.global.asker.AskBool("Would you like stale cached images to be updated automatically? (yes/no) [default=yes]: ", "yes")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_recover.go
+++ b/lxd/main_recover.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -72,7 +71,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 		var supportedDriverNames []string
 
 		for {
-			addUnknownPool, err := cli.AskBool("Would you like to recover another storage pool? (yes/no) [default=no]: ", "no")
+			addUnknownPool, err := c.global.asker.AskBool("Would you like to recover another storage pool? (yes/no) [default=no]: ", "no")
 			if err != nil {
 				return err
 			}
@@ -94,7 +93,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 				},
 			}
 
-			unknownPool.Name, err = cli.AskString("Name of the storage pool: ", "", validate.Required(func(value string) error {
+			unknownPool.Name, err = c.global.asker.AskString("Name of the storage pool: ", "", validate.Required(func(value string) error {
 				if value == "" {
 					return fmt.Errorf("Pool name cannot be empty")
 				}
@@ -111,19 +110,19 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			unknownPool.Driver, err = cli.AskString(fmt.Sprintf("Name of the storage backend (%s): ", strings.Join(supportedDriverNames, ", ")), "", validate.IsOneOf(supportedDriverNames...))
+			unknownPool.Driver, err = c.global.asker.AskString(fmt.Sprintf("Name of the storage backend (%s): ", strings.Join(supportedDriverNames, ", ")), "", validate.IsOneOf(supportedDriverNames...))
 			if err != nil {
 				return err
 			}
 
-			unknownPool.Config["source"], err = cli.AskString("Source of the storage pool (block device, volume group, dataset, path, ... as applicable): ", "", validate.IsNotEmpty)
+			unknownPool.Config["source"], err = c.global.asker.AskString("Source of the storage pool (block device, volume group, dataset, path, ... as applicable): ", "", validate.IsNotEmpty)
 			if err != nil {
 				return err
 			}
 
 			for {
 				var configKey, configValue string
-				_, _ = cli.AskString("Additional storage pool configuration property (KEY=VALUE, empty when done): ", "", validate.Optional(func(value string) error {
+				_, _ = c.global.asker.AskString("Additional storage pool configuration property (KEY=VALUE, empty when done): ", "", validate.Optional(func(value string) error {
 					configParts := strings.SplitN(value, "=", 2)
 					if len(configParts) < 2 {
 						return fmt.Errorf("Config option should be in the format KEY=VALUE")
@@ -155,7 +154,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 		fmt.Printf(" - NEW: %q (backend=%q, source=%q)\n", p.Name, p.Driver, p.Config["source"])
 	}
 
-	proceed, err := cli.AskBool("Would you like to continue with scanning for lost volumes? (yes/no) [default=yes]: ", "yes")
+	proceed, err := c.global.asker.AskBool("Would you like to continue with scanning for lost volumes? (yes/no) [default=yes]: ", "yes")
 	if err != nil {
 		return err
 	}
@@ -214,7 +213,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 				fmt.Printf(" - %s\n", depErr)
 			}
 
-			_, _ = cli.AskString("Please create those missing entries and then hit ENTER: ", "", validate.Optional())
+			_, _ = c.global.asker.AskString("Please create those missing entries and then hit ENTER: ", "", validate.Optional())
 		} else {
 			if len(unknownPools) == 0 && len(res.UnknownVolumes) == 0 {
 				fmt.Println("No unknown storage pools or volumes found. Nothing to do.")
@@ -225,7 +224,7 @@ func (c *cmdRecover) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	proceed, err = cli.AskBool("Would you like those to be recovered? (yes/no) [default=no]: ", "no")
+	proceed, err = c.global.asker.AskBool("Would you like those to be recovered? (yes/no) [default=no]: ", "no")
 	if err != nil {
 		return err
 	}

--- a/shared/cmd/ask.go
+++ b/shared/cmd/ask.go
@@ -12,12 +12,19 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
-var stdin = bufio.NewReader(os.Stdin)
+// Asker holds a reader for reading input into CLI questions.
+type Asker struct {
+	reader *bufio.Reader
+}
+
+func NewAsker(reader *bufio.Reader) Asker {
+	return Asker{reader: reader}
+}
 
 // AskBool asks a question and expect a yes/no answer.
-func AskBool(question string, defaultAnswer string) (bool, error) {
+func (a *Asker) AskBool(question string, defaultAnswer string) (bool, error) {
 	for {
-		answer, err := askQuestion(question, defaultAnswer)
+		answer, err := a.askQuestion(question, defaultAnswer)
 		if err != nil {
 			return false, err
 		}
@@ -33,9 +40,9 @@ func AskBool(question string, defaultAnswer string) (bool, error) {
 }
 
 // AskChoice asks the user to select one of multiple options.
-func AskChoice(question string, choices []string, defaultAnswer string) (string, error) {
+func (a *Asker) AskChoice(question string, choices []string, defaultAnswer string) (string, error) {
 	for {
-		answer, err := askQuestion(question, defaultAnswer)
+		answer, err := a.askQuestion(question, defaultAnswer)
 		if err != nil {
 			return "", err
 		}
@@ -49,9 +56,9 @@ func AskChoice(question string, choices []string, defaultAnswer string) (string,
 }
 
 // AskInt asks the user to enter an integer between a min and max value.
-func AskInt(question string, min int64, max int64, defaultAnswer string, validate func(int64) error) (int64, error) {
+func (a *Asker) AskInt(question string, min int64, max int64, defaultAnswer string, validate func(int64) error) (int64, error) {
 	for {
-		answer, err := askQuestion(question, defaultAnswer)
+		answer, err := a.askQuestion(question, defaultAnswer)
 		if err != nil {
 			return -1, err
 		}
@@ -81,9 +88,9 @@ func AskInt(question string, min int64, max int64, defaultAnswer string, validat
 
 // AskString asks the user to enter a string, which optionally
 // conforms to a validation function.
-func AskString(question string, defaultAnswer string, validate func(string) error) (string, error) {
+func (a *Asker) AskString(question string, defaultAnswer string, validate func(string) error) (string, error) {
 	for {
-		answer, err := askQuestion(question, defaultAnswer)
+		answer, err := a.askQuestion(question, defaultAnswer)
 		if err != nil {
 			return "", err
 		}
@@ -151,15 +158,15 @@ func AskPasswordOnce(question string) string {
 }
 
 // Ask a question on the output stream and read the answer from the input stream.
-func askQuestion(question, defaultAnswer string) (string, error) {
+func (a *Asker) askQuestion(question, defaultAnswer string) (string, error) {
 	fmt.Print(question)
 
-	return readAnswer(defaultAnswer)
+	return a.readAnswer(defaultAnswer)
 }
 
 // Read the user's answer from the input stream, trimming newline and providing a default.
-func readAnswer(defaultAnswer string) (string, error) {
-	answer, err := stdin.ReadString('\n')
+func (a *Asker) readAnswer(defaultAnswer string) (string, error) {
+	answer, err := a.reader.ReadString('\n')
 	answer = strings.TrimSpace(strings.TrimSuffix(answer, "\n"))
 	if answer == "" {
 		answer = defaultAnswer


### PR DESCRIPTION
Adds SetReader to allow setting the default reader for the CLI (from the default Stdin). This can be helpful for managing inputs to the CLI when testing.
