### PR TITLE
Makefile: check `shellcheck`'s version only if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,10 @@ endif
 ifeq ($(shell command -v shellcheck),)
 	echo "Please install shellcheck"
 	exit 1
-endif
+else
 ifneq "$(shell shellcheck --version | grep version: | cut -d ' ' -f2)" "0.8.0"
 	@echo "WARN: shellcheck version is not 0.8.0"
+endif
 endif
 ifeq ($(shell command -v flake8),)
 	echo "Please install flake8"


### PR DESCRIPTION
If `shellcheck` is missing, this avoids the following error:

> $ make deps
> /bin/sh: 1: shellcheck: not found
> ...

This affected every targets because each `ifeq` directives are evaluated, irrespective of the target called:

> $ make foo
> /bin/sh: 1: shellcheck: not found
> make: *** No rule to make target 'foo'.  Stop.