### PR TITLE
Small ISO workaround

### DIFF
--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -238,7 +238,7 @@ test_storage_local_volume_handling() {
           ! lxc storage volume get "lxdtest-$(basename "${LXD_DIR}")-${target_driver}" vol5/snapremove user.foo || false
 
           # copy ISO custom volumes
-          truncate -s 8MiB foo.iso
+          truncate -s 25MiB foo.iso
           lxc storage volume import "lxdtest-$(basename "${LXD_DIR}")-${source_driver}" ./foo.iso iso1
           lxc storage volume copy "lxdtest-$(basename "${LXD_DIR}")-${source_driver}"/iso1 "lxdtest-$(basename "${LXD_DIR}")-${target_driver}"/iso1
           lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${target_driver}" iso1 | grep -q 'content_type: iso'

--- a/test/suites/storage_volume_import.sh
+++ b/test/suites/storage_volume_import.sh
@@ -1,6 +1,6 @@
 test_storage_volume_import() {
-  truncate -s 8MiB foo.iso
-  truncate -s 8MiB foo.img
+  truncate -s 25MiB foo.iso
+  truncate -s 25MiB foo.img
 
   ensure_import_testimage
 


### PR DESCRIPTION
In #12113, all ISO files were shrunk down to 8MiB. Smaller sizes (1, 2 and 4MiB) were tried but caused increased failure rate in the `migration`, `storage_local_volume_handling` and `storage_volume_import` test cases. 

It seems that even 8MiB is too small causing those tests to fail and account for ~25% of all the failures. Until the root cause can be find and fixed, it's better to revert those commits.