### PR TITLE
github: Adds CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tomponline


### PR DESCRIPTION
This is so we can increase the team's permissions to allow for better management of issues/tags and for allowing pushing to each others pull requests, whilst still requiring approval from code owners before being able to merge.