### PR TITLE
apparmor: Allow /etc/machine-id

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -28,6 +28,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /dev/vhost-net                            rw,
   /dev/vhost-vsock                          rw,
   /etc/ceph/**                              r,
+  /etc/machine-id                           r,
   /run/udev/data/*                          r,
   /sys/bus/                                 r,
   /sys/bus/nd/devices/                      r,


### PR DESCRIPTION
This is causing some apparmor denials in our current policy, and allowing access to this file is acceptable.