### PR TITLE
Bail if the rootfs and the ephemeral one are on the same disk

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,6 +219,17 @@ jobs:
         if: ${{ matrix.backend == 'ceph' }}
         run: |
           set -x
+
+          # If the rootfs and the ephemeral part are on the same physical disk, giving the whole
+          # disk to microceph would wipe our rootfs. Since it is pretty rare for GitHub Action
+          # runners to have a single disk, we immediately bail rather than trying to gracefully
+          # handle it. Once snapd releases with https://github.com/snapcore/snapd/pull/13150,
+          # we will be able to stop worrying about that special case.
+          if [ "$(stat -c '%d' /)" = "$(stat -c '%d' /mnt)" ]; then
+            echo "FAIL: rootfs and ephemeral part on the same disk, aborting"
+            exit 1
+          fi
+
           sudo apt-get install --no-install-recommends -y ceph-common
           sudo snap install microceph --edge
           sleep 5


### PR DESCRIPTION
@tomponline I opted to bail for 3 reasons:

* it's a rare condition (haven't witnessed it, yet)
* the fix is on it's way (https://github.com/snapcore/snapd/pull/13150)
* the workarounds feel like hacks

The cleanest workaround I could think of was to use a loop-dev but backed by the partition instead of a FS:

```
sudo swapoff /mnt/swapfile
sudo umount /mnt
ephemeral_disk="$(findmnt --noheadings --output SOURCE --target /mnt)"
blkdiscard "${ephemeral_disk}"
loop_dev="$(sudo losetup --show --direct-io=on --nooverlap -f "${ephemeral_disk}")"
devInfo=($(sudo stat -c '%t %T' "${loop_dev}"))
sudo mknod -m 0660 /dev/sdia b 0x"${devInfo[0]}" 0x"${devInfo[1]}"
sudo microceph disk add --wipe /dev/sdia
```