### PR TITLE
lxd/auth: Exit goroutine if RBAC has been disabled

### DIFF
--- a/lxd/auth/driver_rbac.go
+++ b/lxd/auth/driver_rbac.go
@@ -186,6 +186,10 @@ func (r *rbac) startStatusCheck() {
 
 	go func() {
 		for {
+			if r.ctx.Err() != nil {
+				return
+			}
+
 			if status.LastChange != "" {
 				values := url.Values{}
 				values.Set("last-change", status.LastChange)


### PR DESCRIPTION
This fixes an issue where the goroutine would continue to run even if
RBAC has been disabled.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
