### PR TITLE
shared/validate: names starting with a digit are valid

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,6 @@ jobs:
 
           sudo apt-get install --no-install-recommends -y \
             curl \
-            dnsutils \
             git \
             libacl1-dev \
             libcap-dev \

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -727,9 +727,9 @@ func IsHostname(name string) error {
 		return fmt.Errorf(`Name must not end with "-" character`)
 	}
 
-	_, err := strconv.Atoi(string(name[0]))
+	_, err := strconv.ParseUint(name, 10, 64)
 	if err == nil {
-		return fmt.Errorf("Name must not start with a number")
+		return fmt.Errorf("Name cannot be a number")
 	}
 
 	match, err := regexp.MatchString(`^[\-a-zA-Z0-9]+$`, name)

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -230,6 +230,7 @@ test_basic_usage() {
   ! lxc init testimage -abc || false
   ! lxc init testimage abc- || false
   ! lxc init testimage 1234 || false
+  ! lxc init testimage foo.bar || false
   ! lxc init testimage a_b_c || false
   ! lxc init testimage aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa || false
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -226,11 +226,10 @@ test_basic_usage() {
   curl -k -s --cert "${LXD_CONF}/client3.crt" --key "${LXD_CONF}/client3.key" -X GET "https://${LXD_ADDR}/1.0/images" | grep -F "/1.0/images/"
   lxc image delete foo-image2
 
-  # Test invalid container names
+  # Test invalid instance names
   ! lxc init testimage -abc || false
   ! lxc init testimage abc- || false
   ! lxc init testimage 1234 || false
-  ! lxc init testimage 12test || false
   ! lxc init testimage a_b_c || false
   ! lxc init testimage aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa || false
 

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -4,6 +4,18 @@ test_network() {
 
   lxc init testimage nettest
 
+  # Test DNS resolution of instance names
+  lxc network create lxdbr0
+  lxc launch testimage 0abc -n lxdbr0
+  lxc launch testimage def0 -n lxdbr0
+  v4_addr="$(lxc network get lxdbr0 ipv4.address | cut -d/ -f1)"
+  sleep 2
+  dig @"${v4_addr}" 0abc.lxd
+  dig @"${v4_addr}" def0.lxd
+  lxc delete -f 0abc
+  lxc delete -f def0
+  lxc network delete lxdbr0
+
   # Standard bridge with random subnet and a bunch of options
   lxc network create lxdt$$
   lxc network set lxdt$$ dns.mode dynamic


### PR DESCRIPTION
IsHostname() used to refuse name starting with a digit possibly to comply with RFC 952 but this was relaxed in RFC 1123:

> One aspect of host name syntax is hereby changed: the
> restriction on the first character is relaxed to allow either a
> letter or a digit.

Compatibility with DNS and UTS was mentioned in #1122, where the new restrictions were put in place. However, it seems that hostname can also start with a digit:

```
# hostname 0foo
# hostname
0foo
```