### PR TITLE
doc: Update docs on loki.api.url

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1308,7 +1308,7 @@ Specify the number of days after which the unused cached image expires.
 :scope: "global"
 :shortdesc: "URL to the Loki server"
 :type: "string"
-Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`.
+Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`. LXD will automatically add the `/loki/api/v1/push` suffix so there's no need to add it here.
 ```
 
 ```{config:option} loki.auth.password server-loki

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -651,7 +651,7 @@ var ConfigSchema = config.Schema{
 	"loki.api.ca_cert": {},
 
 	// lxdmeta:generate(entity=server, group=loki, key=loki.api.url)
-	// Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`.
+	// Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`. LXD will automatically add the `/loki/api/v1/push` suffix so there's no need to add it here.
 	// ---
 	//  type: string
 	//  scope: global

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1436,7 +1436,7 @@
 					},
 					{
 						"loki.api.url": {
-							"longdesc": "Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`.",
+							"longdesc": "Specify the protocol, name or IP and port. For example `https://loki.example.com:3100`. LXD will automatically add the `/loki/api/v1/push` suffix so there's no need to add it here.",
 							"scope": "global",
 							"shortdesc": "URL to the Loki server",
 							"type": "string"


### PR DESCRIPTION
Mention that LXD adds the `/loki/api/v1/push` suffix to the provided
`loki.api.url` config value.

Fixes https://github.com/canonical/lxd/issues/12271

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
