### PR TITLE
Drop compat with ZFS 0.6

### DIFF
--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -154,11 +154,7 @@ func (d zfs) ensureInitialDatasets(warnOnExistingPolicyApplyError bool) error {
 	for _, dataset := range d.initialDatasets() {
 		properties := []string{"mountpoint=legacy"}
 		if shared.StringInSlice(dataset, []string{"virtual-machines", "deleted/virtual-machines"}) {
-			if len(zfsVersion) >= 3 && zfsVersion[0:3] == "0.6" {
-				d.logger.Warn("Unable to set volmode on parent virtual-machines datasets due to ZFS being too old")
-			} else {
-				properties = append(properties, "volmode=none")
-			}
+			properties = append(properties, "volmode=none")
 		}
 
 		datasetPath := filepath.Join(d.config["zfs.pool_name"], dataset)

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -636,14 +636,10 @@ func (d *zfs) MigrationTypes(contentType ContentType, refresh bool, copySnapshot
 	}
 
 	// Detect ZFS features.
-	features := []string{migration.ZFSFeatureMigrationHeader}
+	features := []string{migration.ZFSFeatureMigrationHeader, "compress"}
 
 	if contentType == ContentTypeFS {
 		features = append(features, migration.ZFSFeatureZvolFilesystems)
-	}
-
-	if len(zfsVersion) >= 3 && zfsVersion[0:3] != "0.6" {
-		features = append(features, "compress")
 	}
 
 	if IsContentBlock(contentType) {

--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -195,18 +195,6 @@ func (d *zfs) getDatasets(dataset string, types string) ([]string, error) {
 }
 
 func (d *zfs) setDatasetProperties(dataset string, options ...string) error {
-	if len(zfsVersion) >= 3 && zfsVersion[0:3] == "0.6" {
-		// Slow path for ZFS 0.6
-		for _, option := range options {
-			_, err := shared.RunCommand("zfs", "set", option, dataset)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-
 	args := []string{"set"}
 	args = append(args, options...)
 	args = append(args, dataset)


### PR DESCRIPTION
ZFS 0.6 was last supported in 16.04 which is EOL for a while now:

```
$ rmadison zfsutils-linux
 zfsutils-linux | 0.6.5.6-0ubuntu8       | xenial/universe | amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 zfsutils-linux | 0.6.5.6-0ubuntu30      | xenial-updates  | amd64, arm64, armhf, i386, powerpc, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu15        | bionic          | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu16.12     | bionic-security | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.7.5-1ubuntu16.12     | bionic-updates  | amd64, arm64, armhf, i386, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12        | focal           | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12.15     | focal-security  | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 0.8.3-1ubuntu12.15     | focal-updates   | amd64, arm64, armhf, ppc64el, s390x
 zfsutils-linux | 2.1.2-1ubuntu3         | jammy           | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.5-1ubuntu6~22.04.1 | jammy-security  | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.5-1ubuntu6~22.04.1 | jammy-updates   | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.9-2ubuntu1         | lunar           | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.9-2ubuntu1.1       | lunar-security  | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.1.9-2ubuntu1.1       | lunar-updates   | amd64, arm64, armhf, ppc64el, riscv64, s390x
 zfsutils-linux | 2.2.0~rc3-0ubuntu4     | mantic          | amd64, arm64, armhf, ppc64el, riscv64, s390x
```

Note: do **NOT** backport to `stable-5.0`