### PR TITLE
grafana: add Loki logs section with lifecycle and logging events

### DIFF
--- a/grafana/LXD.json
+++ b/grafana/LXD.json
@@ -7,6 +7,14 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "description": "Loki instance for LXD",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
     }
   ],
   "__elements": {},
@@ -16,6 +24,18 @@
       "id": "grafana",
       "name": "Grafana",
       "version": "9.3.2"
+    },
+    {
+      "type": "panel",
+      "id": "logs",
+      "name": "Logs",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "loki",
+      "name": "Loki",
+      "version": "1.0.0"
     },
     {
       "type": "panel",
@@ -3631,6 +3651,93 @@
       "repeat": "name",
       "title": "Instance: $name",
       "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 521,
+      "panels": [],
+      "title": "Loki logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 572,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "builder",
+          "expr": "{app=\"lxd\", type=\"lifecycle\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Lifecycle event logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "${DS_LOKI}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "id": 573,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "${DS_LOKI}"
+          },
+          "editorMode": "builder",
+          "expr": "{app=\"lxd\", type=\"logging\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Event logs",
+      "type": "logs"
     }
   ],
   "refresh": false,
@@ -3789,6 +3896,6 @@
   "timezone": "",
   "title": "LXD",
   "uid": "bGY-LSB7k",
-  "version": 14,
+  "version": 15,
   "weekStart": ""
 }


### PR DESCRIPTION
Here's what it looks like
![loki-logs](https://github.com/canonical/lxd/assets/545509/457990ff-86f3-43bf-b57b-f96ad1f14d52)

The Loki logs section is static as there is currently no way to know which LXD server generated the associated logs. I think we are missing the equivalent of a Prometheus "instance" label. I also think we'll want to enrich the `lifecycle` events eventually to have `name` and `project` labels. Those are for another day/PR however.

@tomponline if/when that gets merged, I'll deal with updating the copy on Grafana's site.