### PR TITLE
Fix info --resources for wwan devices

### DIFF
--- a/lxd/resources/network.go
+++ b/lxd/resources/network.go
@@ -24,8 +24,13 @@ var netProtocols = map[uint64]string{
 }
 
 func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsname, card *api.ResourcesNetworkCard) error {
+	deviceDeviceDir, err := getDeviceDir(devicePath)
+	if err != nil {
+		return fmt.Errorf("Failed to read %q: %w", devicePath, err)
+	}
+
 	// VDPA
-	vDPAMatches, err := filepath.Glob(filepath.Join(devicePath, "vdpa*"))
+	vDPAMatches, err := filepath.Glob(filepath.Join(deviceDeviceDir, "vdpa*"))
 	if err != nil {
 		return fmt.Errorf("Malformed VDPA device name search pattern: %w", err)
 	}
@@ -52,18 +57,18 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	}
 
 	// SRIOV
-	if sysfsExists(filepath.Join(devicePath, "sriov_numvfs")) {
+	if sysfsExists(filepath.Join(deviceDeviceDir, "sriov_numvfs")) {
 		sriov := api.ResourcesNetworkCardSRIOV{}
 
 		// Get maximum and current VF count
-		vfMaximum, err := readUint(filepath.Join(devicePath, "sriov_totalvfs"))
+		vfMaximum, err := readUint(filepath.Join(deviceDeviceDir, "sriov_totalvfs"))
 		if err != nil {
-			return fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "sriov_totalvfs"), err)
+			return fmt.Errorf("Failed to read %q: %w", filepath.Join(deviceDeviceDir, "sriov_totalvfs"), err)
 		}
 
-		vfCurrent, err := readUint(filepath.Join(devicePath, "sriov_numvfs"))
+		vfCurrent, err := readUint(filepath.Join(deviceDeviceDir, "sriov_numvfs"))
 		if err != nil {
-			return fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "sriov_numvfs"), err)
+			return fmt.Errorf("Failed to read %q: %w", filepath.Join(deviceDeviceDir, "sriov_numvfs"), err)
 		}
 
 		sriov.MaximumVFs = vfMaximum
@@ -74,10 +79,10 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	}
 
 	// NUMA node
-	if sysfsExists(filepath.Join(devicePath, "numa_node")) {
-		numaNode, err := readInt(filepath.Join(devicePath, "numa_node"))
+	if sysfsExists(filepath.Join(deviceDeviceDir, "numa_node")) {
+		numaNode, err := readInt(filepath.Join(deviceDeviceDir, "numa_node"))
 		if err != nil {
-			return fmt.Errorf("Failed to read %q: %w", filepath.Join(devicePath, "numa_node"), err)
+			return fmt.Errorf("Failed to read %q: %w", filepath.Join(deviceDeviceDir, "numa_node"), err)
 		}
 
 		if numaNode > 0 {
@@ -86,9 +91,9 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	}
 
 	// USB address
-	usbAddr, err := usbAddress(devicePath)
+	usbAddr, err := usbAddress(deviceDeviceDir)
 	if err != nil {
-		return fmt.Errorf("Failed to find USB address for %q: %w", devicePath, err)
+		return fmt.Errorf("Failed to find USB address for %q: %w", deviceDeviceDir, err)
 	}
 
 	if usbAddr != "" {
@@ -96,7 +101,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	}
 
 	// Vendor and product
-	deviceVendorPath := filepath.Join(devicePath, "vendor")
+	deviceVendorPath := filepath.Join(deviceDeviceDir, "vendor")
 	if sysfsExists(deviceVendorPath) {
 		id, err := os.ReadFile(deviceVendorPath)
 		if err != nil {
@@ -106,7 +111,7 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 		card.VendorID = strings.TrimPrefix(strings.TrimSpace(string(id)), "0x")
 	}
 
-	deviceDevicePath := filepath.Join(devicePath, "device")
+	deviceDevicePath := filepath.Join(deviceDeviceDir, "device")
 	if sysfsExists(deviceDevicePath) {
 		id, err := os.ReadFile(deviceDevicePath)
 		if err != nil {
@@ -132,11 +137,11 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 	}
 
 	// Driver information
-	driverPath := filepath.Join(devicePath, "driver")
+	driverPath := filepath.Join(deviceDeviceDir, "driver")
 	if sysfsExists(driverPath) {
 		linkTarget, err := filepath.EvalSymlinks(driverPath)
 		if err != nil {
-			return fmt.Errorf("Failed to find %q: %w", driverPath, err)
+			return fmt.Errorf("Failed to find device directory %q: %w", driverPath, err)
 		}
 
 		// Set the driver name
@@ -178,9 +183,9 @@ func networkAddDeviceInfo(devicePath string, pciDB *pcidb.PCIDB, uname unix.Utsn
 				protocol, ok := netProtocols[devType]
 				if !ok {
 					info.Protocol = "unknown"
+				} else {
+					info.Protocol = protocol
 				}
-
-				info.Protocol = protocol
 			}
 
 			// Add MAC address


### PR DESCRIPTION
This PR recursively expands the device directory path of `sys/class/net` devices by appending `/device` until the it finds a `device` regular file as a child.

This is needed for devices like wwan which include sub-devices and they differ from typical `sys/class/net` devices. For such kind of devices, the net info is present at the top `./device` directory but rest information needed to fill `Card` struct is located at `./device/device`.

Please take a look below for more info:

```
# ll --time-style='+' /sys/class/net/wwan0/device/
total 0
drwxr-xr-x 7 root root    0  ./
drwxr-xr-x 3 root root    0  ../
lrwxrwxrwx 1 root root    0  device -> ../../../0000:08:00.0/
-r--r--r-- 1 root root 4096  index
drwxr-xr-x 3 root root    0  net/
drwxr-xr-x 2 root root    0  power/
lrwxrwxrwx 1 root root    0  subsystem -> ../../../../../../class/wwan/
-rw-r--r-- 1 root root 4096  uevent
drwxr-xr-x 3 root root    0  wwan0at0/
drwxr-xr-x 3 root root    0  wwan0at1/
drwxr-xr-x 3 root root    0  wwan0mbim0/

# ll --time-style='+' /sys/class/net/wwan0/device/device/
...
-r--r--r--  1 root root 4096  device
...
lrwxrwxrwx  1 root root    0  driver -> ../../../../bus/pci/drivers/iosm/
...
-rw-r--r--  1 root root 4096  numa_node
...
-r--r--r--  1 root root 4096  vendor
...

```

Fixes #12153