### PR TITLE
shared: Add support for OVN logs to `lxc monitor --pretty`

### DIFF
--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -202,14 +202,18 @@ You can now use [lxc monitor](lxc_monitor.md) to see logs from the OVN controlle
     lxc monitor --type=ovn
 
 You can also send the logs to Loki.
-To do so, add the `ovn` value to the {config:option}`server-loki:loki.types` configuration key.
+To do so, add the `ovn` value to the {config:option}`server-loki:loki.types` configuration key, for example:
+
+    lxc config set loki.types=ovn
 
 ```{tip}
 You can include logs for OVN `northd`, OVN north-bound `ovsdb-server`, and OVN south-bound `ovsdb-server` as well.
 To do so, edit `/etc/default/ovn-central`:
 
     OVN_CTL_OPTS=" \
-       --northd-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
-       --nb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
-       --sb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket'"
+       --ovn-northd-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
+       --ovn-nb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket' \
+       --ovn-sb-log='-vsyslog:info --syslog-method=unix:/var/snap/lxd/common/lxd/syslog.socket'"
+
+    sudo systemctl restart ovn-central.service
 ```

--- a/shared/api/event.go
+++ b/shared/api/event.go
@@ -45,7 +45,7 @@ type Event struct {
 
 // ToLogging creates log record for the event.
 func (event *Event) ToLogging() (EventLogRecord, error) {
-	if event.Type == EventTypeLogging {
+	if event.Type == EventTypeLogging || event.Type == EventTypeOVN {
 		e := &EventLogging{}
 		err := json.Unmarshal(event.Metadata, &e)
 		if err != nil {


### PR DESCRIPTION
And improve the OVN syslog setup docs from https://github.com/canonical/lxd/pull/12200