### PR TITLE
simplestreams: Fix regression in lxd_combined.tar.gz handling

### DIFF
--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -10,7 +10,7 @@ import (
 	"github.com/canonical/lxd/shared/osarch"
 )
 
-var lxdCompatCombinedItems = []string{"lxd_combined.tar.xz", "incus_combined.tar.xz"}
+var lxdCompatCombinedItems = []string{"lxd_combined.tar.gz", "incus_combined.tar.gz"}
 var lxdCompatItems = []string{"lxd.tar.xz", "incus.tar.xz"}
 
 // Products represents the base of download.json.


### PR DESCRIPTION
For reasons that are likely lost to history simplestreams uses lxd.tar.xz whereas the combined file is lxd_combined.tar.gz (not xz).

Fixes regression introduced by https://github.com/canonical/lxd/pull/12260