### PR TITLE
Allow OVN dynamic IPv4 if only static IPv6 is configured

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -2316,11 +2316,11 @@ func (n *ovn) setup(update bool) error {
 
 	// Set IPv6 router advertisement settings.
 	if routerIntPortIPv6Net != nil {
-		adressMode := openvswitch.OVNIPv6AddressModeSLAAC
+		addressMode := openvswitch.OVNIPv6AddressModeSLAAC
 		if dhcpV6Subnet != nil {
-			adressMode = openvswitch.OVNIPv6AddressModeDHCPStateless
+			addressMode = openvswitch.OVNIPv6AddressModeDHCPStateless
 			if shared.IsTrue(n.config["ipv6.dhcp.stateful"]) {
-				adressMode = openvswitch.OVNIPv6AddressModeDHCPStateful
+				addressMode = openvswitch.OVNIPv6AddressModeDHCPStateful
 			}
 		}
 
@@ -2330,7 +2330,7 @@ func (n *ovn) setup(update bool) error {
 		}
 
 		err = client.LogicalRouterPortSetIPv6Advertisements(n.getRouterIntPortName(), &openvswitch.OVNIPv6RAOpts{
-			AddressMode:        adressMode,
+			AddressMode:        addressMode,
 			SendPeriodic:       true,
 			DNSSearchList:      n.getDNSSearchList(),
 			RecursiveDNSServer: recursiveDNSServer,


### PR DESCRIPTION
This PR *fixes* static IPv4 not being allocated if only static IPv6 is set for an OVN nic.

Currently, this **does not work as expected**. If OVN is instructed to get dynamic IPs, it will generate dynamic IP for both v4 and v6 family.

For example:
```
$ lxc launch ubuntu:22.04 c1 -n ovn -d eth0,ipv6.address=fd42:1000:1000:1000:a:b:c:d

$ lxc network list-leases ovn
+----------+-------------------+----------------------------------------+---------+
| HOSTNAME |    MAC ADDRESS    |               IP ADDRESS               |  TYPE   |
+----------+-------------------+----------------------------------------+---------+
| c1       | 00:16:3e:21:c4:7f | 10.100.100.2                           | DYNAMIC |
+----------+-------------------+----------------------------------------+---------+
| c1       | 00:16:3e:21:c4:7f | fd42:1000:1000:1000:216:3eff:fe21:c47f | DYNAMIC | << EUI64
+----------+-------------------+----------------------------------------+---------+
| c1       | 00:16:3e:21:c4:7f | fd42:1000:1000:1000:a:b:c:d            | STATIC  |
+----------+-------------------+----------------------------------------+---------+
| ovn.gw   |                   | 10.100.100.1                           | GATEWAY |
+----------+-------------------+----------------------------------------+---------+
| ovn.gw   |                   | fd42:1000:1000:1000::1                 | GATEWAY |
+----------+-------------------+----------------------------------------+---------+
```

As a result, instance gets sometimes static IPv6 and sometimes the generated one:
```
$ lxc ls
+------+---------+---------------------+-----------------------------------------------+-----------+-----------+
| NAME |  STATE  |        IPV4         |                     IPV6                      |   TYPE    | SNAPSHOTS |
+------+---------+---------------------+-----------------------------------------------+-----------+-----------+
| c1   | RUNNING | 10.100.100.2 (eth0) | fd42:1000:1000:1000:216:3eff:fe21:c47f (eth0) | CONTAINER | 0         |
+------+---------+---------------------+-----------------------------------------------+-----------+-----------+
                                         ^ Incorrect
```

However, after restart (when last used IPs are directly set as static IPs), it works as expected:
```
$ lxc restart c1

$ lxc ls
+------+---------+---------------------+------------------------------------+-----------+-----------+
| NAME |  STATE  |        IPV4         |                IPV6                |   TYPE    | SNAPSHOTS |
+------+---------+---------------------+------------------------------------+-----------+-----------+
| c1   | RUNNING | 10.100.100.2 (eth0) | fd42:1000:1000:1000:a:b:c:d (eth0) | CONTAINER | 0         |
+------+---------+---------------------+------------------------------------+-----------+-----------+

$ lxc network list-leases ovn
+----------+-------------------+-----------------------------+---------+
| HOSTNAME |    MAC ADDRESS    |         IP ADDRESS          |  TYPE   |
+----------+-------------------+-----------------------------+---------+
| c1       | 00:16:3e:21:c4:7f | 10.100.100.2                | DYNAMIC |
+----------+-------------------+-----------------------------+---------+
| c1       | 00:16:3e:21:c4:7f | fd42:1000:1000:1000:a:b:c:d | STATIC  |
+----------+-------------------+-----------------------------+---------+
| ovn.gw   |                   | 10.100.100.1                | GATEWAY |
+----------+-------------------+-----------------------------+---------+
| ovn.gw   |                   | fd42:1000:1000:1000::1      | GATEWAY |
+----------+-------------------+-----------------------------+---------+
```