### PR TITLE
Enforce `security.shifted` and `security.unmapped` to be mutually exclusive.

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5119,11 +5119,6 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 			return fmt.Errorf("Custom volume 'block.filesystem' property cannot be changed")
 		}
 
-		// Check that security.unmapped and security.shifted aren't set together.
-		if shared.IsTrue(newConfig["security.unmapped"]) && shared.IsTrue(newConfig["security.shifted"]) {
-			return fmt.Errorf("security.unmapped and security.shifted are mutually exclusive")
-		}
-
 		// Check for config changing that is not allowed when running instances are using it.
 		if changedConfig["security.shifted"] != "" {
 			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &curVol.StorageVolume, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -184,6 +184,11 @@ func (d *common) validateVolume(vol Volume, driverRules map[string]func(value st
 		return fmt.Errorf("Volume %q property is not valid for volume type", "size")
 	}
 
+	// Check that security.unmapped and security.shifted are not set together.
+	if shared.IsTrue(vol.config["security.unmapped"]) && shared.IsTrue(vol.config["security.shifted"]) {
+		return fmt.Errorf("security.unmapped and security.shifted are mutually exclusive")
+	}
+
 	return nil
 }
 

--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -40,7 +40,14 @@ test_container_devices_disk_shift() {
 
   # Test shifted custom volumes
   POOL=$(lxc profile device get default root pool)
+
+  # Cannot set both security.shifted and security.unmapped.
+  ! lxc storage volume create "${POOL}" foo-shift security.shifted=true security.unmapped=true || false
+
   lxc storage volume create "${POOL}" foo-shift security.shifted=true
+
+  # Cannot set both security.shifted and security.unmapped.
+  ! lxc storage volume set "${POOL}" foo-shift security.unmapped=true || false
 
   lxc start foo
   lxc launch testimage foo-priv -c security.privileged=true


### PR DESCRIPTION
Adds a check to the common driver volume validation that the `security.shifted` and `security.unmapped` config options are only set on custom volumes and cannot be set at the same time.