### PR TITLE
doc: fix swagger display

### DIFF
--- a/doc/.sphinx/_static/github_issue_links.js
+++ b/doc/.sphinx/_static/github_issue_links.js
@@ -1,4 +1,12 @@
+// if we already have an onload function, save that one
+var prev_handler = window.onload;
+
 window.onload = function() {
+    // call the previous onload function
+    if (prev_handler) {
+        prev_handler();
+    }
+
     const link = document.createElement("a");
     link.classList.add("muted-link");
     link.classList.add("github-issue-link");


### PR DESCRIPTION
The JavaScript we include to display the feedback button uses the window.onload function. Swagger uses the same function ... which means it's overwritten.

Fix the script we control (`github_issue_links.js`) to preserve an existing onload function.

Fixes https://github.com/canonical/lxd/issues/12318