### PR TITLE
lxd/storage: Remove unkown keys when creating snapshots

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -77,6 +77,7 @@ var patches = []patch{
 	{name: "storage_prefix_bucket_names_with_project", stage: patchPostDaemonStorage, run: patchGenericStorage},
 	{name: "storage_move_custom_iso_block_volumes", stage: patchPostDaemonStorage, run: patchStorageRenameCustomISOBlockVolumes},
 	{name: "zfs_set_content_type_user_property", stage: patchPostDaemonStorage, run: patchZfsSetContentTypeUserProperty},
+	{name: "storage_zfs_unset_invalid_block_settings", stage: patchPostDaemonStorage, run: patchStorageZfsUnsetInvalidBlockSettings},
 }
 
 type patch struct {
@@ -909,6 +910,95 @@ func patchZfsSetContentTypeUserProperty(name string, d *Daemon) error {
 			_, err = shared.RunCommand("zfs", "set", fmt.Sprintf("lxd:content_type=%s", vol.ContentType), zfsVolName)
 			if err != nil {
 				logger.Debug("Failed setting lxd:content_type property", logger.Ctx{"name": zfsVolName, "err": err})
+			}
+		}
+	}
+
+	return nil
+}
+
+// patchStorageZfsUnsetInvalidBlockSettings removes invalid block settings from volumes.
+func patchStorageZfsUnsetInvalidBlockSettings(_ string, d *Daemon) error {
+	s := d.State()
+
+	// Get all storage pool names.
+	pools, err := s.DB.Cluster.GetStoragePoolNames()
+	if err != nil {
+		// Skip the rest of the patch if no storage pools were found.
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("Failed getting storage pool names: %w", err)
+	}
+
+	volTypeCustom := db.StoragePoolVolumeTypeCustom
+	volTypeVM := db.StoragePoolVolumeTypeVM
+
+	poolVolumes := make(map[int64][]*db.StorageVolume, 0)
+
+	err = s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		for _, pool := range pools {
+			// Get storage pool ID.
+			poolID, err := tx.GetStoragePoolID(ctx, pool)
+			if err != nil {
+				return fmt.Errorf("Failed getting storage pool ID of pool %q: %w", pool, err)
+			}
+
+			driverName, err := tx.GetStoragePoolDriver(ctx, poolID)
+			if err != nil {
+				return fmt.Errorf("Failed getting storage pool driver of pool %q: %w", pool, err)
+			}
+
+			if driverName != "zfs" {
+				continue
+			}
+
+			// Get the pool's custom storage volumes.
+			volumes, err := tx.GetStoragePoolVolumes(ctx, poolID, false, db.StorageVolumeFilter{Type: &volTypeCustom}, db.StorageVolumeFilter{Type: &volTypeVM})
+			if err != nil {
+				return fmt.Errorf("Failed getting custom storage volumes of pool %q: %w", pool, err)
+			}
+
+			if poolVolumes[poolID] == nil {
+				poolVolumes[poolID] = []*db.StorageVolume{}
+			}
+
+			poolVolumes[poolID] = append(poolVolumes[poolID], volumes...)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	var volType int
+
+	for pool, volumes := range poolVolumes {
+		for _, vol := range volumes {
+			config := vol.Config
+
+			val, ok := config["zfs.block_mode"]
+			if ok && shared.IsTrue(val) {
+				continue
+			}
+
+			delete(config, "block.filesystem")
+			delete(config, "block.mount_options")
+
+			if vol.Type == db.StoragePoolVolumeTypeNameVM {
+				volType = volTypeVM
+			} else if vol.Type == db.StoragePoolVolumeTypeNameCustom {
+				volType = volTypeCustom
+			} else {
+				// Should not happen.
+				continue
+			}
+
+			err = s.DB.Cluster.UpdateStoragePoolVolume(vol.Project, vol.Name, volType, pool, vol.Description, config)
+			if err != nil {
+				return fmt.Errorf("Failed updating volume %q: %w", vol.Name, err)
 			}
 		}
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2830,7 +2830,7 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	defer revert.Fail()
 
 	// Validate config and create database entry for new storage volume.
-	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), srcDBVol.Description, volType, true, srcDBVol.Config, inst.CreationDate(), time.Time{}, contentType, false, true)
+	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), srcDBVol.Description, volType, true, srcDBVol.Config, inst.CreationDate(), time.Time{}, contentType, true, true)
 	if err != nil {
 		return err
 	}
@@ -5545,7 +5545,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 
 	// Validate config and create database entry for new storage volume.
 	// Copy volume config from parent.
-	err = VolumeDBCreate(b, projectName, fullSnapshotName, parentVol.Description, drivers.VolumeTypeCustom, true, parentVol.Config, time.Now().UTC(), newExpiryDate, drivers.ContentType(parentVol.ContentType), false, true)
+	err = VolumeDBCreate(b, projectName, fullSnapshotName, parentVol.Description, drivers.VolumeTypeCustom, true, parentVol.Config, time.Now().UTC(), newExpiryDate, drivers.ContentType(parentVol.ContentType), true, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When creating snapshots, the config keys of the parent are copied to the
snapshot. Should a key be invalid, the snapshot creation fails.

This sets the `removeUnknownKeys` argument to `true` when creating
snapshots. Invalid keys will then be ignored and removed.

Fixes #12325

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
