### PR TITLE
README: Update test status badge so it accurately shows status of tests.yml workflow (stable-5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ See [Getting started](https://documentation.ubuntu.com/lxd/en/stable-5.0/getting
 
 Type                | Service               | Status
 ---                 | ---                   | ---
-CI (client)         | GitHub                | [![Build Status](https://github.com/canonical/lxd/workflows/Client%20build%20and%20unit%20tests/badge.svg?branch=stable-5.0)](https://github.com/canonical/lxd/actions)
-CI (server)         | GitHub                | [![Build Status](https://github.com/canonical/lxd/workflows/Tests/badge.svg?branch=stable-5.0)](https://github.com/canonical/lxd/actions)
+Tests               | GitHub                | [![Build Status](https://github.com/canonical/lxd/actions/workflows/tests.yml/badge.svg?branch=stable-5.0)](https://github.com/canonical/lxd/actions?query=event%3Apush+branch%3Astable-5.0)
 Go documentation    | Godoc                 | [![GoDoc](https://godoc.org/github.com/canonical/lxd/client?status.svg)](https://godoc.org/github.com/canonical/lxd/client)
 Static analysis     | GoReport              | [![Go Report Card](https://goreportcard.com/badge/github.com/canonical/lxd)](https://goreportcard.com/report/github.com/canonical/lxd)
 Translations        | Weblate               | [![Translation status](https://hosted.weblate.org/widgets/linux-containers/-/svg-badge.svg)](https://hosted.weblate.org/projects/linux-containers/lxd/)


### PR DESCRIPTION
And update the link so it shows workflow results filtered by branch and action.

The previous image seemed to be stuck on failure due to a test name change.

The "tests.yml" file covers both client and server tests now.
