### PR TITLE
lxc: Handle volume rename in `lxc storage volume move` command

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -97,13 +97,13 @@ Unless specified through a prefix, all volume operations affect "custom" (user c
 	storageVolumeListCmd := cmdStorageVolumeList{global: c.global, storage: c.storage, storageVolume: c}
 	cmd.AddCommand(storageVolumeListCmd.Command())
 
-	// Move
-	storageVolumeMoveCmd := cmdStorageVolumeMove{global: c.global, storage: c.storage, storageVolume: c, storageVolumeCopy: &storageVolumeCopyCmd}
-	cmd.AddCommand(storageVolumeMoveCmd.Command())
-
 	// Rename
 	storageVolumeRenameCmd := cmdStorageVolumeRename{global: c.global, storage: c.storage, storageVolume: c}
 	cmd.AddCommand(storageVolumeRenameCmd.Command())
+
+	// Move
+	storageVolumeMoveCmd := cmdStorageVolumeMove{global: c.global, storage: c.storage, storageVolume: c, storageVolumeCopy: &storageVolumeCopyCmd, storageVolumeRename: &storageVolumeRenameCmd}
+	cmd.AddCommand(storageVolumeMoveCmd.Command())
 
 	// Set
 	storageVolumeSetCmd := cmdStorageVolumeSet{global: c.global, storage: c.storage, storageVolume: c}
@@ -1598,10 +1598,11 @@ func (c *cmdStorageVolumeList) projectColumnData(vol api.StorageVolume, state ap
 
 // Move.
 type cmdStorageVolumeMove struct {
-	global            *cmdGlobal
-	storage           *cmdStorage
-	storageVolume     *cmdStorageVolume
-	storageVolumeCopy *cmdStorageVolumeCopy
+	global              *cmdGlobal
+	storage             *cmdStorage
+	storageVolume       *cmdStorageVolume
+	storageVolumeCopy   *cmdStorageVolumeCopy
+	storageVolumeRename *cmdStorageVolumeRename
 }
 
 func (c *cmdStorageVolumeMove) Command() *cobra.Command {
@@ -1626,6 +1627,53 @@ func (c *cmdStorageVolumeMove) Run(cmd *cobra.Command, args []string) error {
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
 		return err
+	}
+
+	// Parse remote
+	resources, err := c.global.ParseServers(args[0], args[1])
+	if err != nil {
+		return err
+	}
+
+	// Source
+	srcResource := resources[0]
+	if srcResource.name == "" {
+		return fmt.Errorf(i18n.G("Missing source volume name"))
+	}
+
+	srcRemote := srcResource.remote
+	srcPath := srcResource.name
+
+	// Get source pool and volume name
+	srcVolName, srcVolPool := c.storageVolume.parseVolumeWithPool(srcPath)
+	if srcVolPool == "" {
+		return fmt.Errorf(i18n.G("No storage pool for source volume specified"))
+	}
+
+	// Destination
+	dstResource := resources[1]
+	dstRemote := dstResource.remote
+	dstPath := dstResource.name
+
+	// Get target pool and volume name
+	dstVolName, dstVolPool := c.storageVolume.parseVolumeWithPool(dstPath)
+	if dstVolPool == "" {
+		return fmt.Errorf(i18n.G("No storage pool for target volume specified"))
+	}
+
+	// Rename volume if both remotes and pools of source and target are equal.
+	if srcRemote == dstRemote && srcVolPool == dstVolPool {
+		var args []string
+
+		if srcRemote != "" {
+			args = append(args, fmt.Sprintf("%s:%s", srcRemote, srcVolPool))
+		} else {
+			args = append(args, srcVolPool)
+		}
+
+		args = append(args, srcVolName, dstVolName)
+
+		return c.storageVolumeRename.Run(cmd, args)
 	}
 
 	return c.storageVolumeCopy.Run(cmd, args)

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -114,6 +114,10 @@ test_storage_local_volume_handling() {
     lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")-${driver}1" vol3
     lxc storage volume get "lxdtest-$(basename "${LXD_DIR}")-${driver}1" vol3 user.foo | grep -Fx "snap0"
 
+    # Rename custom volume using `lxc storage volume move`
+    lxc storage volume move "lxdtest-$(basename "${LXD_DIR}")-${driver}1"/vol1 "lxdtest-$(basename "${LXD_DIR}")-${driver}1"/vol4
+    lxc storage volume move "lxdtest-$(basename "${LXD_DIR}")-${driver}1"/vol4 "lxdtest-$(basename "${LXD_DIR}")-${driver}1"/vol1
+
     lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-${driver}1" vol1
     lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-${driver}1" vol2
     lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-${driver}1" vol3


### PR DESCRIPTION
When calling `lxc storage volume move` it internally always calls `lxc
storage volume copy`. This in itself is not a problem. However, the
`copy` handler expects LXD to always return an `OperationResponse`. This
doesn't happen though as LXD will return a `SyncResponse` if it detects
a move request.

This changes the `move` handler to call `lxc storage volume rename` if
it detects a rename request, instead of passing it to the `copy`
handler.

Fixes #12344

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
