### PR TITLE
client: Pass a flag into `queryOperation` to skip event listener setup if not required.

### DIFF
--- a/client/lxd_certificates.go
+++ b/client/lxd_certificates.go
@@ -97,7 +97,7 @@ func (r *ProtocolLXD) CreateCertificateToken(certificate api.CertificatesPost) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/certificates", certificate, "")
+	op, _, err := r.queryOperation("POST", "/certificates", certificate, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -35,7 +35,7 @@ func (r *ProtocolLXD) UpdateCluster(cluster api.ClusterPut, ETag string) (Operat
 		}
 	}
 
-	op, _, err := r.queryOperation("PUT", "/cluster", cluster, "")
+	op, _, err := r.queryOperation("PUT", "/cluster", cluster, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (r *ProtocolLXD) CreateClusterMember(member api.ClusterMembersPost) (Operat
 		return nil, fmt.Errorf("The server is missing the required \"clustering_join_token\" API extension")
 	}
 
-	op, _, err := r.queryOperation("POST", "/cluster/members", member, "")
+	op, _, err := r.queryOperation("POST", "/cluster/members", member, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (r *ProtocolLXD) UpdateClusterMemberState(name string, state api.ClusterMem
 		return nil, fmt.Errorf("The server is missing the required \"clustering_evacuation\" API extension")
 	}
 
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/cluster/members/%s/state", name), state, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/cluster/members/%s/state", name), state, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -90,7 +90,7 @@ func (r *ProtocolLXD) CreateContainerFromBackup(args ContainerBackupArgs) (Opera
 
 	if args.PoolName == "" {
 		// Send the request
-		op, _, err := r.queryOperation("POST", "/containers", args.BackupFile, "")
+		op, _, err := r.queryOperation("POST", "/containers", args.BackupFile, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +155,7 @@ func (r *ProtocolLXD) CreateContainer(container api.ContainersPost) (Operation, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/containers", container, "")
+	op, _, err := r.queryOperation("POST", "/containers", container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 // UpdateContainer updates the container definition.
 func (r *ProtocolLXD) UpdateContainer(name string, container api.ContainerPut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -521,7 +521,7 @@ func (r *ProtocolLXD) RenameContainer(name string, container api.ContainerPost) 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 // DeleteContainer requests that LXD deletes the container.
 func (r *ProtocolLXD) DeleteContainer(name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s", url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s", url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +632,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.PathEscape(containerName)), exec, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.PathEscape(containerName)), exec, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -961,7 +961,7 @@ func (r *ProtocolLXD) CreateContainerSnapshot(containerName string, snapshot api
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots", url.PathEscape(containerName)), snapshot, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots", url.PathEscape(containerName)), snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1193,7 +1193,7 @@ func (r *ProtocolLXD) RenameContainerSnapshot(containerName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1266,7 +1266,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1277,7 +1277,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 // DeleteContainerSnapshot requests that LXD deletes the container snapshot.
 func (r *ProtocolLXD) DeleteContainerSnapshot(containerName string, name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1293,7 +1293,7 @@ func (r *ProtocolLXD) UpdateContainerSnapshot(containerName string, name string,
 
 	// Send the request
 	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/snapshots/%s",
-		url.PathEscape(containerName), url.PathEscape(name)), container, ETag)
+		url.PathEscape(containerName), url.PathEscape(name)), container, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1317,7 @@ func (r *ProtocolLXD) GetContainerState(name string) (*api.ContainerState, strin
 // UpdateContainerState updates the container to match the requested state.
 func (r *ProtocolLXD) UpdateContainerState(name string, state api.ContainerStatePut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/state", url.PathEscape(name)), state, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/state", url.PathEscape(name)), state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), console, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), console, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -1698,7 +1698,7 @@ func (r *ProtocolLXD) CreateContainerBackup(containerName string, backup api.Con
 
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/backups",
-		url.PathEscape(containerName)), backup, "")
+		url.PathEscape(containerName)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1714,7 +1714,7 @@ func (r *ProtocolLXD) RenameContainerBackup(containerName string, name string, b
 
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/backups/%s",
-		url.PathEscape(containerName), url.PathEscape(name)), backup, "")
+		url.PathEscape(containerName), url.PathEscape(name)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1730,7 +1730,7 @@ func (r *ProtocolLXD) DeleteContainerBackup(containerName string, name string) (
 
 	// Send the request
 	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/backups/%s",
-		url.PathEscape(containerName), url.PathEscape(name)), nil, "")
+		url.PathEscape(containerName), url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -393,7 +393,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 
 	// Send the JSON based request
 	if args == nil {
-		op, _, err := r.queryOperation("POST", "/images", image, "")
+		op, _, err := r.queryOperation("POST", "/images", image, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -916,7 +916,7 @@ func (r *ProtocolLXD) UpdateImage(fingerprint string, image api.ImagePut, ETag s
 // DeleteImage requests that LXD removes an image from the store.
 func (r *ProtocolLXD) DeleteImage(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -931,7 +931,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.PathEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.PathEscape(fingerprint)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -942,7 +942,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 // CreateImageSecret requests that LXD issues a temporary image secret.
 func (r *ProtocolLXD) CreateImageSecret(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.PathEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.PathEscape(fingerprint)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1001,7 +1001,7 @@ func (r *ProtocolLXD) ExportImage(fingerprint string, image api.ImageExportPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/export", url.PathEscape(fingerprint)), &image, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/export", url.PathEscape(fingerprint)), &image, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -204,7 +204,7 @@ func (r *ProtocolLXD) UpdateInstances(state api.InstancesPut, ETag string) (Oper
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s?%s", path, v.Encode()), state, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s?%s", path, v.Encode()), state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (r *ProtocolLXD) rebuildInstance(instanceName string, instance api.Instance
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild", path, url.PathEscape(instanceName)), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild", path, url.PathEscape(instanceName)), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -534,7 +534,7 @@ func (r *ProtocolLXD) CreateInstanceFromBackup(args InstanceBackupArgs) (Operati
 
 	if args.PoolName == "" && args.Name == "" {
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, args.BackupFile, "")
+		op, _, err := r.queryOperation("POST", path, args.BackupFile, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -615,7 +615,7 @@ func (r *ProtocolLXD) CreateInstance(instance api.InstancesPost) (Operation, err
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, instance, "")
+	op, _, err := r.queryOperation("POST", path, instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +956,7 @@ func (r *ProtocolLXD) UpdateInstance(name string, instance api.InstancePut, ETag
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -977,7 +977,7 @@ func (r *ProtocolLXD) RenameInstance(name string, instance api.InstancePost) (Op
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,7 +1073,7 @@ func (r *ProtocolLXD) MigrateInstance(name string, instance api.InstancePost) (O
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,7 +1089,7 @@ func (r *ProtocolLXD) DeleteInstance(name string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s", path, url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1125,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", uri, exec, "")
+	op, _, err := r.queryOperation("POST", uri, exec, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -1679,7 +1679,7 @@ func (r *ProtocolLXD) CreateInstanceSnapshot(instanceName string, snapshot api.I
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots", path, url.PathEscape(instanceName)), snapshot, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots", path, url.PathEscape(instanceName)), snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1926,7 +1926,7 @@ func (r *ProtocolLXD) RenameInstanceSnapshot(instanceName string, name string, i
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2002,7 +2002,7 @@ func (r *ProtocolLXD) MigrateInstanceSnapshot(instanceName string, name string, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2018,7 +2018,7 @@ func (r *ProtocolLXD) DeleteInstanceSnapshot(instanceName string, name string) (
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2038,7 +2038,7 @@ func (r *ProtocolLXD) UpdateInstanceSnapshot(instanceName string, name string, i
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/snapshots/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), instance, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2080,7 +2080,7 @@ func (r *ProtocolLXD) UpdateInstanceState(name string, state api.InstanceStatePu
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/state", path, url.PathEscape(name)), state, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("%s/%s/state", path, url.PathEscape(name)), state, ETag, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2403,7 +2403,7 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -2491,7 +2491,7 @@ func (r *ProtocolLXD) ConsoleInstanceDynamic(instanceName string, console api.In
 	}
 
 	// Send the request.
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2697,7 +2697,7 @@ func (r *ProtocolLXD) CreateInstanceBackup(instanceName string, backup api.Insta
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups", path, url.PathEscape(instanceName)), backup, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups", path, url.PathEscape(instanceName)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2717,7 +2717,7 @@ func (r *ProtocolLXD) RenameInstanceBackup(instanceName string, name string, bac
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), backup, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -2737,7 +2737,7 @@ func (r *ProtocolLXD) DeleteInstanceBackup(instanceName string, name string) (Op
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("%s/%s/backups/%s", path, url.PathEscape(instanceName), url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -115,7 +115,7 @@ func (r *ProtocolLXD) RenameProject(name string, project api.ProjectPost) (Opera
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -231,7 +231,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeSnapshot(pool string, volumeType st
 		url.PathEscape(pool),
 		url.PathEscape(volumeType),
 		url.PathEscape(volumeName))
-	op, _, err := r.queryOperation("POST", path, snapshot, "")
+	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, snapshot, "")
+	op, _, err := r.queryOperation("POST", path, snapshot, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolumeSnapshot(pool string, volumeType st
 		"/storage-pools/%s/volumes/%s/%s/snapshots/%s",
 		url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 
-	op, _, err := r.queryOperation("DELETE", path, nil, "")
+	op, _, err := r.queryOperation("DELETE", path, nil, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func (r *ProtocolLXD) UpdateStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	// Send the request
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
-	_, _, err := r.queryOperation("PUT", path, volume, ETag)
+	_, _, err := r.queryOperation("PUT", path, volume, ETag, true)
 	if err != nil {
 		return err
 	}
@@ -386,7 +386,7 @@ func (r *ProtocolLXD) MigrateStoragePoolVolume(pool string, volume api.StorageVo
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", path, req, "")
+	op, _, err := r.queryOperation("POST", path, req, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +475,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 
 			// Send the request
 			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(req.Type))
-			top, _, err := r.queryOperation("POST", path, req, "")
+			top, _, err := r.queryOperation("POST", path, req, "", true)
 			if err != nil {
 				errors = append(errors, remoteOperationResult{URL: serverURL, Error: err})
 				continue
@@ -567,7 +567,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		}
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type)), req, "")
+		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type)), req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -616,7 +616,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
-		op, _, err := r.queryOperation("POST", path, req, "")
+		op, _, err := r.queryOperation("POST", path, req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -668,7 +668,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
-		targetOp, _, err := r.queryOperation("POST", path, req, "")
+		targetOp, _, err := r.queryOperation("POST", path, req, "", true)
 		if err != nil {
 			return nil, err
 		}
@@ -736,7 +736,7 @@ func (r *ProtocolLXD) MoveStoragePoolVolume(pool string, source InstanceServer, 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(sourcePool), url.PathEscape(volume.Type), volume.Name), req, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(sourcePool), url.PathEscape(volume.Type), volume.Name), req, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +866,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups", url.PathEscape(pool), url.PathEscape(volName)), backup, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups", url.PathEscape(pool), url.PathEscape(volName)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -881,7 +881,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), backup, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), backup, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -896,7 +896,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolumeBackup(pool string, volName string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/storage-pools/%s/volumes/custom/%s/backups/%s", url.PathEscape(pool), url.PathEscape(volName), url.PathEscape(name)), nil, "", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Is it not always necessary to set up an event listener when interacting with operations via the client. For example, many client methods call `queryOperation` and then call `Wait` on the returned operation. Instead of receiving all events, filtering by operation, then filtering by the ID of the operation, and checking the status code for "success" or "failure", we can just use `/1.0/operations/wait`.