### PR TITLE
lxc/storage: Initialise writable storage pool config map if nil.

### DIFF
--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -728,6 +728,10 @@ func (c *cmdStorageSet) Run(cmd *cobra.Command, args []string) error {
 			}
 		}
 	} else {
+		if writable.Config == nil {
+			writable.Config = make(map[string]string)
+		}
+
 		// Update the volume config keys.
 		for k, v := range keys {
 			writable.Config[k] = v


### PR DESCRIPTION
After creating an empty pool with e.g. `lxc storage create test dir`, the following command panics `lxc storage set test rsync.compression true` and the config key is not set.

This commit initialises the writable config map if it is nil and fixes the command.