### PR TITLE
client: Remove project from format string API path.

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -220,7 +220,7 @@ func (r *ProtocolLXD) rebuildInstance(instanceName string, instance api.Instance
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild?project=%s", path, url.PathEscape(instanceName), r.project), instance, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/rebuild", path, url.PathEscape(instanceName)), instance, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`(*ProtocolLXD).queryOperation` calls `(*ProtocolLXD).query` which will set the project query parameter if necessary. Including it here as part of a formatted string can lead to urls like
`/1.0/instances/c1/rebuild?project=`. This isn't necessarily a problem but would be unexpected on the API side.