### PR TITLE
github: Skip edge snap build for pushes on branches from dependabot (stable-5.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -368,7 +368,7 @@ jobs:
     name: Trigger snap edge build
     runs-on: ubuntu-22.04
     needs: [code-tests, system-tests, client, documentation]
-    if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push'}}
+    if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The edge snap build failed anyway because of the inaccessible secret. But its clearer to see it skipped.