### PR TITLE
github: build static lxc and lxd-migrate bins for arm64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,18 +306,27 @@ jobs:
         run: |
             mkdir bin
 
-      - name: Build static lxc
+      - name: Build static lxc (x86_64)
         env:
           CGO_ENABLED: 0
+          GOARCH: amd64
         run: |
-          go build -o bin ./lxc
+          go build -o bin/lxc.x86_64 ./lxc
+
+      - name: Build static lxc (aarch64)
+        env:
+          CGO_ENABLED: 0
+          GOARCH: arm64
+        run: |
+          go build -o bin/lxc.aarch64 ./lxc
 
       - name: Build static lxd-migrate
         if: runner.os == 'Linux'
         env:
           CGO_ENABLED: 0
         run: |
-          go build -o bin ./lxd-migrate
+          GOARCH=amd64 go build -o bin/lxd-migrate.x86_64 ./lxd-migrate
+          GOARCH=arm64 go build -o bin/lxd-migrate.aarch64 ./lxd-migrate
 
       - name: Unit tests (client)
         env:


### PR DESCRIPTION
Fixes #12361