### PR TITLE
Move certificate cache into new package

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/acme"
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	clusterRequest "github.com/canonical/lxd/lxd/cluster/request"
@@ -674,7 +675,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		for _, trustedCert := range trustedCerts {
 			if trustedCert.Type == api.CertificateTypeServer {
-				dbType, err := dbCluster.CertificateAPITypeToDBType(trustedCert.Type)
+				dbType, err := certificate.FromAPIType(trustedCert.Type)
 				if err != nil {
 					return err
 				}

--- a/lxd/certificate/cache.go
+++ b/lxd/certificate/cache.go
@@ -1,0 +1,97 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"sync"
+)
+
+// Cache represents an thread-safe in-memory cache of the certificates in the database.
+type Cache struct {
+	// certificates is a map of certificate Type to map of certificate fingerprint to x509.Certificate.
+	certificates map[Type]map[string]x509.Certificate
+
+	// projects is a map of certificate fingerprint to slice of projects the certificate is restricted to.
+	// If a certificate fingerprint is present in certificates, but not present in projects, it means the certificate is
+	// not restricted.
+	projects map[string][]string
+	mu       sync.RWMutex
+}
+
+// SetCertificatesAndProjects sets both certificates and projects on the Cache.
+func (c *Cache) SetCertificatesAndProjects(certificates map[Type]map[string]x509.Certificate, projects map[string][]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.certificates = certificates
+	c.projects = projects
+}
+
+// SetCertificates sets the certificates on the Cache.
+func (c *Cache) SetCertificates(certificates map[Type]map[string]x509.Certificate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.certificates = certificates
+}
+
+// SetProjects sets the projects on the Cache.
+func (c *Cache) SetProjects(projects map[string][]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.projects = projects
+}
+
+// GetCertificatesAndProjects returns a read-only copy of the certificate and project maps.
+func (c *Cache) GetCertificatesAndProjects() (map[Type]map[string]x509.Certificate, map[string][]string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	certificates := make(map[Type]map[string]x509.Certificate, len(c.certificates))
+	for t, m := range c.certificates {
+		certificates[t] = make(map[string]x509.Certificate, len(m))
+		for f, cert := range m {
+			certificates[t][f] = cert
+		}
+	}
+
+	projects := make(map[string][]string, len(c.projects))
+	for f, projectNames := range c.projects {
+		projectNamesCopy := make([]string, 0, len(projectNames))
+		projectNamesCopy = append(projectNamesCopy, projectNames...)
+		projects[f] = projectNamesCopy
+	}
+
+	return certificates, projects
+}
+
+// GetCertificates returns a read-only copy of the certificate map.
+func (c *Cache) GetCertificates() map[Type]map[string]x509.Certificate {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	certificates := make(map[Type]map[string]x509.Certificate, len(c.certificates))
+	for t, m := range c.certificates {
+		certificates[t] = make(map[string]x509.Certificate, len(m))
+		for f, cert := range m {
+			certificates[t][f] = cert
+		}
+	}
+
+	return certificates
+}
+
+// GetProjects returns a read-only copy of the project map.
+func (c *Cache) GetProjects() map[string][]string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	projects := make(map[string][]string, len(c.projects))
+	for f, projectNames := range c.projects {
+		projectNamesCopy := make([]string, 0, len(projectNames))
+		projectNamesCopy = append(projectNamesCopy, projectNames...)
+		projects[f] = projectNamesCopy
+	}
+
+	return projects
+}

--- a/lxd/certificate/type.go
+++ b/lxd/certificate/type.go
@@ -1,0 +1,33 @@
+package certificate
+
+import (
+	"fmt"
+
+	"github.com/canonical/lxd/shared/api"
+)
+
+// Type indicates the type of the certificate.
+type Type int
+
+// TypeClient indicates a client certificate type.
+const TypeClient = Type(1)
+
+// TypeServer indicates a server certificate type.
+const TypeServer = Type(2)
+
+// TypeMetrics indicates a metrics certificate type.
+const TypeMetrics = Type(3)
+
+// FromAPIType converts an API type to the equivalent Type.
+func FromAPIType(apiType string) (Type, error) {
+	switch apiType {
+	case api.CertificateTypeClient:
+		return TypeClient, nil
+	case api.CertificateTypeServer:
+		return TypeServer, nil
+	case api.CertificateTypeMetrics:
+		return TypeMetrics, nil
+	}
+
+	return -1, fmt.Errorf("Invalid certificate type")
+}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	clusterRequest "github.com/canonical/lxd/lxd/cluster/request"
@@ -37,7 +38,7 @@ import (
 )
 
 type certificateCache struct {
-	Certificates map[dbCluster.CertificateType]map[string]x509.Certificate
+	Certificates map[certificate.Type]map[string]x509.Certificate
 	Projects     map[string][]string
 	Lock         sync.Mutex
 }
@@ -188,7 +189,7 @@ func updateCertificateCache(d *Daemon) {
 
 	logger.Debug("Refreshing trusted certificate cache")
 
-	newCerts := map[dbCluster.CertificateType]map[string]x509.Certificate{}
+	newCerts := map[certificate.Type]map[string]x509.Certificate{}
 	newProjects := map[string][]string{}
 
 	var certs []*api.Certificate
@@ -240,7 +241,7 @@ func updateCertificateCache(d *Daemon) {
 		}
 
 		// Add server certs to list of certificates to store in local database to allow cluster restart.
-		if dbCert.Type == dbCluster.CertificateTypeServer {
+		if dbCert.Type == certificate.TypeServer {
 			localCerts = append(localCerts, dbCert)
 		}
 	}
@@ -265,7 +266,7 @@ func updateCertificateCache(d *Daemon) {
 func updateCertificateCacheFromLocal(d *Daemon) error {
 	logger.Debug("Refreshing local trusted certificate cache")
 
-	newCerts := map[dbCluster.CertificateType]map[string]x509.Certificate{}
+	newCerts := map[certificate.Type]map[string]x509.Certificate{}
 
 	var dbCerts []dbCluster.Certificate
 	var err error
@@ -601,7 +602,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	dbReqType, err := dbCluster.CertificateAPITypeToDBType(req.Type)
+	dbReqType, err := certificate.FromAPIType(req.Type)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -964,7 +965,7 @@ func doCertificateUpdate(d *Daemon, dbInfo api.Certificate, req api.CertificateP
 	s := d.State()
 
 	if clientType == clusterRequest.ClientTypeNormal {
-		reqDBType, err := dbCluster.CertificateAPITypeToDBType(req.Type)
+		reqDBType, err := certificate.FromAPIType(req.Type)
 		if err != nil {
 			return response.BadRequest(err)
 		}

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -20,8 +20,8 @@ import (
 	dqlite "github.com/canonical/go-dqlite"
 	client "github.com/canonical/go-dqlite/client"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db"
-	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/revert"
 	"github.com/canonical/lxd/lxd/state"
@@ -154,7 +154,7 @@ func setDqliteVersionHeader(request *http.Request) {
 // These handlers might return 404, either because this LXD node is a
 // non-clustered node not available over the network or because it is not a
 // database node part of the dqlite cluster.
-func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts func() map[cluster.CertificateType]map[string]x509.Certificate) map[string]http.HandlerFunc {
+func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts func() map[certificate.Type]map[string]x509.Certificate) map[string]http.HandlerFunc {
 	database := func(w http.ResponseWriter, r *http.Request) {
 		g.lock.RLock()
 		if !tlsCheckCert(r, g.networkCert, g.state().ServerCert(), trustedCerts()) {

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
-	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
 )
@@ -37,7 +37,7 @@ func TestGateway_Single(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func TestGateway_SingleWithNetworkAddress(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -146,7 +146,7 @@ func TestGateway_NetworkAuth(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	"github.com/canonical/lxd/lxd/db"
-	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
@@ -214,7 +214,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	mux := http.NewServeMux()
 	server := newServer(serverCert, mux)
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	"github.com/canonical/lxd/lxd/db"
@@ -130,7 +131,7 @@ func TestBootstrap(t *testing.T) {
 	// The cluster certificate is in place.
 	assert.True(t, shared.PathExists(filepath.Join(state.OS.VarDir, "cluster.crt")))
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -288,9 +289,9 @@ func TestJoin(t *testing.T) {
 	altServerCert := shared.TestingAltKeyPair()
 	trustedAltServerCert, _ := x509.ParseCertificate(altServerCert.KeyPair().Certificate[0])
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
-		return map[dbCluster.CertificateType]map[string]x509.Certificate{
-			dbCluster.CertificateTypeServer: {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
+		return map[certificate.Type]map[string]x509.Certificate{
+			certificate.TypeServer: {
 				altServerCert.Fingerprint(): *trustedAltServerCert,
 			},
 		}

--- a/lxd/cluster/tls.go
+++ b/lxd/cluster/tls.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
@@ -53,7 +53,7 @@ func tlsClientConfig(networkCert *shared.CertInfo, serverCert *shared.CertInfo) 
 }
 
 // tlsCheckCert checks certificate access, returns true if certificate is trusted.
-func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[cluster.CertificateType]map[string]x509.Certificate) bool {
+func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *shared.CertInfo, trustedCerts map[certificate.Type]map[string]x509.Certificate) bool {
 	_, err := x509.ParseCertificate(networkCert.KeyPair().Certificate[0])
 	if err != nil {
 		// Since we have already loaded this certificate, typically
@@ -77,7 +77,7 @@ func tlsCheckCert(r *http.Request, networkCert *shared.CertInfo, serverCert *sha
 		}
 
 		// Check the trusted server certficates list provided.
-		trusted, _ = util.CheckTrustState(*i, trustedCerts[cluster.CertificateTypeServer], networkCert, false)
+		trusted, _ = util.CheckTrustState(*i, trustedCerts[certificate.TypeServer], networkCert, false)
 		if trusted {
 			return true
 		}

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
-	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
@@ -158,7 +158,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[certificate.Type]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/db/certificates.go
+++ b/lxd/db/certificates.go
@@ -5,6 +5,7 @@ package db
 import (
 	"context"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/query"
 )
@@ -32,7 +33,7 @@ func (db *DB) UpdateCertificate(ctx context.Context, fingerprint string, cert cl
 func (n *NodeTx) GetCertificates(ctx context.Context) ([]cluster.Certificate, error) {
 	type cert struct {
 		fingerprint string
-		certType    cluster.CertificateType
+		certType    certificate.Type
 		name        string
 		certificate string
 	}

--- a/lxd/db/cluster/certificates.go
+++ b/lxd/db/cluster/certificates.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -39,7 +40,7 @@ import (
 type Certificate struct {
 	ID          int
 	Fingerprint string `db:"primary=yes"`
-	Type        CertificateType
+	Type        certificate.Type
 	Name        string
 	Certificate string
 	Restricted  bool
@@ -50,43 +51,17 @@ type CertificateFilter struct {
 	ID          *int
 	Fingerprint *string
 	Name        *string
-	Type        *CertificateType
-}
-
-// CertificateType indicates the type of the certificate.
-type CertificateType int
-
-// CertificateTypeClient indicates a client certificate type.
-const CertificateTypeClient = CertificateType(1)
-
-// CertificateTypeServer indicates a server certificate type.
-const CertificateTypeServer = CertificateType(2)
-
-// CertificateTypeMetrics indicates a metrics certificate type.
-const CertificateTypeMetrics = CertificateType(3)
-
-// CertificateAPITypeToDBType converts an API type to the equivalent DB type.
-func CertificateAPITypeToDBType(apiType string) (CertificateType, error) {
-	switch apiType {
-	case api.CertificateTypeClient:
-		return CertificateTypeClient, nil
-	case api.CertificateTypeServer:
-		return CertificateTypeServer, nil
-	case api.CertificateTypeMetrics:
-		return CertificateTypeMetrics, nil
-	}
-
-	return -1, fmt.Errorf("Invalid certificate type")
+	Type        *certificate.Type
 }
 
 // ToAPIType returns the API equivalent type.
 func (cert *Certificate) ToAPIType() string {
 	switch cert.Type {
-	case CertificateTypeClient:
+	case certificate.TypeClient:
 		return api.CertificateTypeClient
-	case CertificateTypeServer:
+	case certificate.TypeServer:
 		return api.CertificateTypeServer
-	case CertificateTypeMetrics:
+	case certificate.TypeMetrics:
 		return api.CertificateTypeMetrics
 	}
 

--- a/lxd/db/cluster/certificates.interface.mapper.go
+++ b/lxd/db/cluster/certificates.interface.mapper.go
@@ -5,6 +5,8 @@ package cluster
 import (
 	"context"
 	"database/sql"
+
+	"github.com/canonical/lxd/lxd/certificate"
 )
 
 // CertificateGenerated is an interface of generated methods for Certificate.
@@ -35,7 +37,7 @@ type CertificateGenerated interface {
 
 	// DeleteCertificates deletes the certificate matching the given key parameters.
 	// generator: certificate DeleteMany-by-Name-and-Type
-	DeleteCertificates(ctx context.Context, tx *sql.Tx, name string, certificateType CertificateType) error
+	DeleteCertificates(ctx context.Context, tx *sql.Tx, name string, certificateType certificate.Type) error
 
 	// UpdateCertificate updates the certificate matching the given key parameters.
 	// generator: certificate Update

--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
 )
@@ -336,7 +337,7 @@ func DeleteCertificate(ctx context.Context, tx *sql.Tx, fingerprint string) erro
 
 // DeleteCertificates deletes the certificate matching the given key parameters.
 // generator: certificate DeleteMany-by-Name-and-Type
-func DeleteCertificates(ctx context.Context, tx *sql.Tx, name string, certificateType CertificateType) error {
+func DeleteCertificates(ctx context.Context, tx *sql.Tx, name string, certificateType certificate.Type) error {
 	stmt, err := Stmt(tx, certificateDeleteByNameAndType)
 	if err != nil {
 		return fmt.Errorf("Failed to get \"certificateDeleteByNameAndType\" prepared statement: %w", err)

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/query"
@@ -69,7 +70,7 @@ func TestImportPreClusteringData(t *testing.T) {
 		cert := certs[0]
 		assert.Equal(t, 1, cert.ID)
 		assert.Equal(t, "abcd:efgh", cert.Fingerprint)
-		assert.Equal(t, cluster.CertificateTypeClient, cert.Type)
+		assert.Equal(t, certificate.TypeClient, cert.Type)
 		assert.Equal(t, "foo", cert.Name)
 		assert.Equal(t, "FOO", cert.Certificate)
 		return nil

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/canonical/lxd/lxd/backup"
+	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/cluster"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
@@ -227,7 +228,7 @@ func patchClusteringServerCertTrust(name string, d *Daemon) error {
 		trustedServerCerts := make(map[string]*dbCluster.Certificate)
 
 		for _, c := range dbCerts {
-			if c.Type == dbCluster.CertificateTypeServer {
+			if c.Type == certificate.TypeServer {
 				trustedServerCerts[c.Name] = &c
 			}
 		}


### PR DESCRIPTION
For #12313 we need to access the certificate cache from the `auth` package for the TLS driver. While making this change I also noticed that the certificate cache is not strictly thread safe since the certificates and projects are stored in maps. E.g. It would be possible to get the certificate map within a lock, unlock it, then read/write from/to the map and cause a panic. Additionally, [here](https://github.com/canonical/lxd/blob/d2067ea5407311d90fecd29430343a98a838275f/lxd/daemon.go#L1040) the length of the certificate map is read without a lock which is may be thread safe but could also be a race condition.

This PR moves the certificate cache logic into a new package and adds methods for writing/reading from it safely. The returns maps are copies.