### PR TITLE
lxd-agent: Adds an operation wait endpoint to fix VM exec operations

### DIFF
--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -33,6 +33,7 @@ var api10 = []APIEndpoint{
 	operationsCmd,
 	operationCmd,
 	operationWebsocket,
+	operationWait,
 	sftpCmd,
 	stateCmd,
 }

--- a/lxd-agent/operations.go
+++ b/lxd-agent/operations.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -33,6 +35,11 @@ var operationWebsocket = APIEndpoint{
 	Path: "operations/{id}/websocket",
 
 	Get: APIEndpointAction{Handler: operationWebsocketGet},
+}
+
+var operationWait = APIEndpoint{
+	Path: "operations/{id}/wait",
+	Get:  APIEndpointAction{Handler: operationWaitGet},
 }
 
 func operationDelete(d *Daemon, r *http.Request) response.Response {
@@ -157,4 +164,43 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	return operations.OperationWebSocket(r, op)
+}
+
+func operationWaitGet(d *Daemon, r *http.Request) response.Response {
+	id, err := url.PathUnescape(mux.Vars(r)["id"])
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to extract operation ID from URL: %w", err))
+	}
+
+	timeoutSecs, err := shared.AtoiEmptyDefault(r.FormValue("timeout"), -1)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to extract operation wait timeout from URL: %w", err))
+	}
+
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeoutSecs > -1 {
+		ctx, cancel = context.WithDeadline(r.Context(), time.Now().Add(time.Second*time.Duration(timeoutSecs)))
+	} else {
+		ctx, cancel = context.WithCancel(r.Context())
+	}
+
+	defer cancel()
+
+	op, err := operations.OperationGetInternal(id)
+	if err != nil {
+		return response.NotFound(err)
+	}
+
+	err = op.Wait(ctx)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	_, opAPI, err := op.Render()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponse(true, opAPI)
 }


### PR DESCRIPTION
After recent changes to the client in #12349, when calling ExecInstance we wait for the operation to complete by directly calling the operation wait endpoint instead of listening for the event.

When calling exec on a VM, the client is used to connect with the LXD agent via vsock. This was failing with a 404 because the endpoint didn't exist.