### PR TITLE
lxd/resources: if `SCSI_IDENT_SERIAL` is available, use it as serial nr before `ID_SERIAL_SHORT`

### DIFF
--- a/lxd/resources/storage.go
+++ b/lxd/resources/storage.go
@@ -83,9 +83,20 @@ func storageAddDriveInfo(devicePath string, disk *api.ResourcesStorageDisk) erro
 		}
 
 		// Serial number
-		if udevProperties["E:ID_SERIAL_SHORT"] != "" {
-			disk.Serial = udevProperties["E:ID_SERIAL_SHORT"]
+		serial := udevProperties["E:SCSI_IDENT_SERIAL"]
+		if serial == "" {
+			serial = udevProperties["E:ID_SCSI_SERIAL"]
 		}
+
+		if serial == "" {
+			serial = udevProperties["E:ID_SERIAL_SHORT"]
+		}
+
+		if serial == "" {
+			serial = udevProperties["E:ID_SERIAL"]
+		}
+
+		disk.Serial = serial
 
 		// Model number (attempt to get original string from encoded value)
 		if udevProperties["E:ID_MODEL_ENC"] != "" {


### PR DESCRIPTION
closes #12209 