### PR TITLE
Operation wait extension

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1125,7 +1125,8 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", uri, exec, "", false)
+	useEventListener := r.CheckExtension("operation_wait") != nil
+	op, _, err := r.queryOperation("POST", uri, exec, "", useEventListener)
 	if err != nil {
 		return nil, err
 	}
@@ -2403,7 +2404,8 @@ func (r *ProtocolLXD) ConsoleInstance(instanceName string, console api.InstanceC
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", false)
+	useEventListener := r.CheckExtension("operation_wait") != nil
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("%s/%s/console", path, url.PathEscape(instanceName)), console, "", useEventListener)
 	if err != nil {
 		return nil, err
 	}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2306,3 +2306,9 @@ during instance initialization using the `--device` flag.
 
 Note that these configuration are applied only at the time of instance creation and subsequent modifications have
 no effect on existing devices.
+
+## `operation_wait`
+
+This API extension indicates that the `/1.0/operations/{id}/wait` endpoint exists on the server. This indicates to the client
+that the endpoint can be used to wait for an operation to complete rather than waiting for an operation event via the
+`/1.0/events` endpoint.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -386,6 +386,7 @@ var APIExtensions = []string{
 	"event_lifecycle_name_and_project",
 	"instances_nic_limits_priority",
 	"disk_initial_volume_configuration",
+	"operation_wait",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
#12349 introduced to the client the concept of waiting for an operation to complete via the operation wait endpoint rather than using the events websocket. This is used for `InstanceExec` and `InstanceConsole`.

Unfortunately this did not work for VMs as the lxd-agent did not contain the operation wait endpoint. This was fixed in #12372, but this fix will not work for older versions of the lxd-agent. This change introduces an API extension for the change so that we can check if the operation wait endpoint exists before choosing how to handle waiting for the operation.