### PR TITLE
Improve ceph test reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -271,6 +271,15 @@ jobs:
           sudo microceph.ceph fs ls
           sleep 30
           sudo microceph.ceph status
+          # Wait until there are no more "unkowns" pgs
+          for _ in $(seq 60); do
+            if sudo microceph.ceph pg stat | grep -wF unknown; then
+              sleep 1
+            else
+              break
+            fi
+          done
+          sudo microceph.ceph status
           sudo rm -f /snap/bin/rbd
 
       - name: "Run system tests (${{ matrix.go }}, ${{ matrix.suite }}, ${{ matrix.backend }})"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,9 +245,8 @@ jobs:
             exit 1
           fi
 
-          sudo apt-get install --no-install-recommends -y ceph-common
           sudo snap install microceph --edge
-          sleep 5
+          sudo apt-get install --no-install-recommends -y ceph-common
           sudo microceph cluster bootstrap
           sudo microceph.ceph config set global osd_pool_default_size 1
           sudo microceph.ceph config set global mon_allow_pool_delete true


### PR DESCRIPTION
Tests failing at:

```
  lxc storage create lxdtest-5zO ceph volume.size=25MiB ceph.osd.pg_num=8
```

All seem to have `microceph.ceph status` show as:

```
 + sudo microceph.ceph status
  cluster:
    id:     7e42c215-815d-477f-afa9-5f218fcc3081
    health: HEALTH_WARN
            mon fv-az1234-656 is low on available space
            nobackfill,norebalance,norecover,noscrub,nodeep-scrub,nosnaptrim flag(s) set
            3 pool(s) have no replicas configured
            OSD count 0 < osd_pool_default_size 1

  services:
    mon: 1 daemons, quorum fv-az1234-656 (age 63s)
    mgr: fv-az1234-656(active, since 55s)
    mds: 1/1 daemons up
    osd: 0 osds: 0 up, 0 in
         flags nobackfill,norebalance,norecover,noscrub,nodeep-scrub,nosnaptrim

  data:
    volumes: 1/1 healthy
    pools:   3 pools, 65 pgs
    objects: 0 objects, 0 B
    usage:   0 B used, 0 B / 0 B avail
    pgs:     100.000% pgs unknown
             65 unknown
```

Poll `ceph pg stat` for up to a minute to stabilize and no longer have unknown pgs.