### PR TITLE
client: Unset response header timeout when waiting for operations.

### DIFF
--- a/client/lxd_operations.go
+++ b/client/lxd_operations.go
@@ -89,6 +89,14 @@ func (r *ProtocolLXD) GetOperation(uuid string) (*api.Operation, string, error) 
 func (r *ProtocolLXD) GetOperationWait(uuid string, timeout int) (*api.Operation, string, error) {
 	op := api.Operation{}
 
+	// Unset the response header timeout so that the request does not time out.
+	transport, err := r.getUnderlyingHTTPTransport()
+	if err != nil {
+		return nil, "", err
+	}
+
+	transport.ResponseHeaderTimeout = 0
+
 	// Fetch the raw value
 	etag, err := r.queryStruct("GET", fmt.Sprintf("/operations/%s/wait?timeout=%d", url.PathEscape(uuid), timeout), nil, "", &op)
 	if err != nil {


### PR DESCRIPTION
The `ResponseHeaderTimeout` in the `http.Transport` for the client was, in most cases, set to 1 hour. This change unsets the timeout, allowing us to wait for an operation to complete indefinitely.