### PR TITLE
github: use ppa:ubuntu-lxc/daily instead of ppa:ubuntu-lxc/lxc-git-master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
+          sudo add-apt-repository ppa:ubuntu-lxc/daily -y --no-update
           sudo apt-get update
 
           sudo apt-get install --no-install-recommends -y \
@@ -186,7 +186,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -x
-          sudo add-apt-repository ppa:ubuntu-lxc/lxc-git-master -y --no-update
+          sudo add-apt-repository ppa:ubuntu-lxc/daily -y --no-update
           sudo add-apt-repository ppa:dqlite/dev -y --no-update
           sudo apt-get update
 


### PR DESCRIPTION
Let's be consistent with go-lxc [1] and use ppa:ubuntu-lxc/daily to fetch and install development build of liblxc.

I have checked that builds in ppa:ubuntu-lxc/daily and ppa:ubuntu-lxc/lxc-git-master right now are equal. Likely we need to get rid of ubuntu-lxc/lxc-git-master at some point, but as a first step let's just start using ubuntu-lxc/daily for LXD CI builds.

[1] https://github.com/lxc/go-lxc/blob/ccae595aa49e779f7ecc9250329967aa546acd31/.github/workflows/test.yml#L29