### PR TITLE
lxd-agent: Fixes intermittent exec EOF closure when vsock listener is restarted just after boot

### DIFF
--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/mdlayher/vsock"
 
@@ -193,41 +191,19 @@ func getClient(CID uint32, port int, serverCertificate string) (*http.Client, er
 	return client, nil
 }
 
-// waitVsockContextID checks for valid local context ID and returns it.
-// If no valid context ID has been ascertained when the context is cancelled, the last error is returned.
-func waitVsockContextID(ctx context.Context) (uint32, error) {
+func startHTTPServer(d *Daemon, debug bool) error {
 	const CIDAny uint32 = 4294967295 // Equivalent to VMADDR_CID_ANY.
 
-	for {
-		cid, err := vsock.ContextID()
-		if cid == CIDAny {
-			// Ignore VMADDR_CID_ANY as this seems to indicate the vsock module is still initialising.
-			err = fmt.Errorf("Invalid context ID %d", cid)
-		} else if err == nil {
-			return cid, nil
-		}
-
-		ctxErr := ctx.Err()
-		if ctxErr != nil {
-			if err != nil {
-				return 0, err
-			}
-
-			return 0, ctxErr
-		}
-
-		time.Sleep(time.Second)
-	}
-}
-
-func startHTTPServer(d *Daemon, debug bool) error {
-	// Setup the listener on VM's context ID for inbound connections from LXD.
-	l, err := vsock.ListenContextID(d.localCID, shared.HTTPSDefaultPort, nil)
+	// Setup the listener on wildcard CID for inbound connections from LXD.
+	// We use the VMADDR_CID_ANY CID so that if the VM's CID changes in the future the listener still works.
+	// A CID change can occur when restoring a stateful VM that was previously using one CID but is
+	// subsequently restored using a different one.
+	l, err := vsock.ListenContextID(CIDAny, shared.HTTPSDefaultPort, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to listen on vsock: %w", err)
 	}
 
-	logger.Info("Started vsock listener", logger.Ctx{"contextID": d.localCID})
+	logger.Info("Started vsock listener")
 
 	// Load the expected server certificate.
 	cert, err := shared.ReadCert("server.crt")

--- a/lxd-agent/daemon.go
+++ b/lxd-agent/daemon.go
@@ -16,8 +16,6 @@ type Daemon struct {
 	serverPort        uint32
 	serverCertificate string
 
-	localCID uint32
-
 	// The channel which is used to indicate that the lxd-agent was able to connect to LXD.
 	chConnected chan struct{}
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -12,11 +12,6 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
-// ContextID returns the local VM sockets context ID.
-func ContextID() (uint32, error) {
-	return vsock.ContextID()
-}
-
 // Dial connects to a remote vsock.
 func Dial(cid, port uint32) (net.Conn, error) {
 	return vsock.Dial(cid, port, nil)


### PR DESCRIPTION
This PR switches the lxd-agent vsock listener to use the VMADDR_CID_ANY (4294967295) CID, rather than trying to ascertain the VM's local CID and listening only on that.

The reason is two-fold:

 1. We were seeing that sometimes the vsock.ContextID() call was returning 4294967295 just after the vsock module was loaded, but shortly afterward then started returning the correct CID assigned in QEMU. This would trigger the vsock CID change detector up to 30s later and cause the vsock listener to be restarted. Any ongoing exec operations that had started before that would be prematurely terminated. The vsock VID change detector was originally added to detect when a VM was statefully restored/migrated in such a way that its QEMU assigned CID was changed whilst the VM was running. This prevented LXD from using the lxd-agent until such time as the lxd-agent noticed its local CID had changed and restarted its listener on the new CID.

 2. However it was observed during investigating this issue that if we bound the lxd-agent listener to the VMADDR_CID_ANY (4294967295) CID then this continue to work even if the VM was statefully restored using a different CID. This is because the VMADDR_CID_ANY seems to be used as a kind of wildcard CID. The vsock manpage says:

     Consider using VMADDR_CID_ANY when binding instead of getting the local CID with
     IOCTL_VM_SOCKETS_GET_LOCAL_CID.

     There are several special addresses: VMADDR_CID_ANY (-1U) means any address for binding;

By binding to the VMADDR_CID_ANY address it also allows us to simplify the vsock listener logic and remove the vsock CID change detector entirely, neatly sidestepping the original problem.