### PR TITLE
shared/api/url: Fix double path encoding issue

### DIFF
--- a/shared/api/url.go
+++ b/shared/api/url.go
@@ -32,14 +32,20 @@ func (u *URL) Host(host string) *URL {
 // Path sets the path of the URL from one or more path parts.
 // It appends each of the pathParts (escaped using url.PathEscape) prefixed with "/" to the URL path.
 func (u *URL) Path(pathParts ...string) *URL {
-	var b strings.Builder
+	var path, rawPath strings.Builder
 
 	for _, pathPart := range pathParts {
-		b.WriteString("/") // Build an absolute URL.
-		b.WriteString(url.PathEscape(pathPart))
+		// Generate unencoded path.
+		path.WriteString("/") // Build an absolute URL.
+		path.WriteString(pathPart)
+
+		// Generate encoded path hint (this will be used by u.URL.EncodedPath() to decide its methodology).
+		rawPath.WriteString("/") // Build an absolute URL.
+		rawPath.WriteString(url.PathEscape(pathPart))
 	}
 
-	u.URL.Path = b.String()
+	u.URL.Path = path.String()
+	u.URL.RawPath = rawPath.String()
 
 	return u
 }

--- a/shared/api/url_test.go
+++ b/shared/api/url_test.go
@@ -14,11 +14,11 @@ func ExampleURL() {
 	fmt.Println(u.Host("example.com"))
 	fmt.Println(u.Scheme("https"))
 
-	// Output: /1.0/networks/name-with-%252F-in-it
-	// /1.0/networks/name-with-%252F-in-it
-	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
-	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it
-	// /1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
-	// //example.com/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
-	// https://example.com/1.0/networks/name-with-%252F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// Output: /1.0/networks/name-with-%2F-in-it
+	// /1.0/networks/name-with-%2F-in-it
+	// /1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it
+	// /1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it
+	// /1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// //example.com/1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
+	// https://example.com/1.0/networks/name-with-%2F-in-it?project=project-with-%25-in-it&target=member-with-%25-in-it
 }


### PR DESCRIPTION
Go's net.URL requires Path to be populated with unencoded path and RawPath to be populated with the hint on how we want Path to be encoded.

This avoids double path encoding when calling url.EscapedPath(), which is used in url.String().

Fixes #12398

Before:

```
lxc storage volume create default tüdeldü
lxc storage show default
config:
  source: /var/lib/lxd/storage-pools/default
description: ""
name: default
driver: dir
used_by:
- /1.0/storage-pools/default/volumes/custom/t%25C3%25BCdeld%25C3%25BC
```

After:

```
lxc storage show default
config:
  source: /var/lib/lxd/storage-pools/default
description: ""
name: default
driver: dir
used_by:
- /1.0/storage-pools/default/volumes/custom/t%C3%BCdeld%C3%BC
```

Closes #12406