### PR TITLE
storage: Keep storage pool mounted after call to `Create`

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -218,16 +218,9 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 
 	revert.Add(func() { _ = b.driver.Delete(op) })
 
-	// Mount the storage pool.
-	ourMount, err := b.driver.Mount()
+	_, err = b.driver.Mount()
 	if err != nil {
 		return err
-	}
-
-	// We expect the caller of create to mount the pool if needed, so we should unmount after
-	// storage struct has been created.
-	if ourMount {
-		defer func() { _, _ = b.driver.Unmount() }()
 	}
 
 	// Create the directory structure.

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -113,12 +113,6 @@ func storagePoolCreateLocal(state *state.State, poolID int64, req api.StoragePoo
 
 	revert.Add(func() { _ = pool.Delete(clientType, nil) })
 
-	// Mount the pool.
-	_, err = pool.Mount()
-	if err != nil {
-		return nil, err
-	}
-
 	// In case the storage pool config was changed during the pool creation, we need to update the database to
 	// reflect this change. This can e.g. happen, when we create a loop file image. This means we append ".img"
 	// to the path the user gave us and update the config in the storage callback. So diff the config here to


### PR DESCRIPTION
This changes the behaviour of the backend's `Create` function to not
unmount the storage pool after creation. This reduces calls to the
driver's `Mount` function, and therefore any driver specific calls.

Fixes #12278
