### PR TITLE
lxc: Check destination target flag on storage volume move.

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1661,8 +1661,8 @@ func (c *cmdStorageVolumeMove) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("No storage pool for target volume specified"))
 	}
 
-	// Rename volume if both remotes and pools of source and target are equal.
-	if srcRemote == dstRemote && srcVolPool == dstVolPool {
+	// Rename volume if both remotes and pools of source and target are equal and there is no destination target.
+	if srcRemote == dstRemote && srcVolPool == dstVolPool && c.storageVolume.flagDestinationTarget != "" {
 		var args []string
 
 		if srcRemote != "" {


### PR DESCRIPTION
When checking whether a storage volume should be renamed or copied, we need to check the --destination-target. If it is set, we need to copy the volume since a rename will not move it to the new cluster member.