### PR TITLE
Fix volume rename if cluster desination target is set

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1661,8 +1661,9 @@ func (c *cmdStorageVolumeMove) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("No storage pool for target volume specified"))
 	}
 
-	// Rename volume if both remotes and pools of source and target are equal.
-	if srcRemote == dstRemote && srcVolPool == dstVolPool {
+	// Rename volume if both remotes and pools of source and target are equal
+	// and no destination cluster member name is set.
+	if srcRemote == dstRemote && srcVolPool == dstVolPool && c.storageVolume.flagDestinationTarget == "" {
 		var args []string
 
 		if srcRemote != "" {

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -663,9 +663,19 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2 --refresh
 
+    # Check renaming storage volume works.
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume create pool1 vol2 --target=node1
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume move pool1/vol2 pool1/vol3 --target=node1
+    LXD_DIR="${LXD_TWO_DIR}" lxc storage volume show pool1 vol3 | grep -q node1
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume move pool1/vol3 pool1/vol2 --target=node1 --destination-target=node2
+    LXD_DIR="${LXD_TWO_DIR}" lxc storage volume show pool1 vol2 | grep -q node2
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume rename pool1 vol2 vol3 --target=node2
+    LXD_DIR="${LXD_TWO_DIR}" lxc storage volume show pool1 vol3 | grep -q node2
+
     # Delete pool and check cleaned up.
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol1 --target=node1
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol1 --target=node2
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol3 --target=node2
     LXD_DIR="${LXD_TWO_DIR}" lxc storage delete pool1
     ! stat "${LXD_ONE_SOURCE}/containers" || false
     ! stat "${LXD_TWO_SOURCE}/containers" || false


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/canonical/lxd/pull/12348
which causes the `--destination-target` flag to be ignored.

When renaming a volume using `lxc storage volume move`, the args were
passed to the handler behind `lxc storage volume rename` which does not
support the `--destination-target` flag.

Instead if the destination flag is set when renaming a volume, use the handler for volume movements.