### PR TITLE
network: Don't consider an IP parse failure of a proxy listen address an error

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2581,7 +2581,7 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 
 			proxySubnet, err := ParseIPToNet(proxyListenAddr.Address)
 			if err != nil {
-				return err
+				continue // If proxy listen isn't a valid IP it can't conflict.
 			}
 
 			externalSubnets = append(externalSubnets, externalSubnetUsage{


### PR DESCRIPTION


Fixes #12368