### PR TITLE
Respect storage pool configuration when moving instance between projects

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -194,13 +194,17 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 	// Support for server-side move. Currently, such migration can only move an instance to different project
 	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
-	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") && (len(c.flagConfig) == 0 && len(c.flagDevice) == 0 && len(c.flagProfile) == 0 && !c.flagNoProfiles) {
+	if sourceRemote == destRemote && c.flagStorage != "" || c.flagTargetProject != "" {
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
 			return err
 		}
 
 		if source.HasExtension("instance_pool_move") && source.HasExtension("instance_project_move") {
+			if len(c.flagConfig) != 0 || len(c.flagDevice) != 0 || len(c.flagProfile) != 0 || c.flagNoProfiles {
+				return fmt.Errorf("The move command does not support flags --config, --device, --profile, and --no-profiles. Please use copy instead")
+			}
+
 			if c.flagMode != moveDefaultMode {
 				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage or --target-project"))
 			}

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -192,35 +192,20 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Support for server-side pool move.
-	if c.flagStorage != "" && sourceRemote == destRemote {
+	// Support for server-side move. Currently, such migration can only move an instance to different project
+	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
+	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") && (len(c.flagConfig) == 0 && len(c.flagDevice) == 0 && len(c.flagProfile) == 0 && !c.flagNoProfiles) {
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
 			return err
 		}
 
-		if source.HasExtension("instance_pool_move") {
+		if source.HasExtension("instance_pool_move") && source.HasExtension("instance_project_move") {
 			if c.flagMode != moveDefaultMode {
-				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage"))
+				return fmt.Errorf(i18n.G("The --mode flag can't be used with --storage or --target-project"))
 			}
 
-			return moveInstancePool(conf, sourceResource, destResource, c.flagInstanceOnly, c.flagStorage, stateful)
-		}
-	}
-
-	// Support for server-side project move.
-	if c.flagTargetProject != "" && sourceRemote == destRemote {
-		source, err := conf.GetInstanceServer(sourceRemote)
-		if err != nil {
-			return err
-		}
-
-		if source.HasExtension("instance_project_move") {
-			if c.flagMode != moveDefaultMode {
-				return fmt.Errorf(i18n.G("The --mode flag can't be used with --target-project"))
-			}
-
-			return moveInstanceProject(conf, sourceResource, destResource, c.flagTargetProject, c.flagInstanceOnly, stateful)
+			return moveInstance(conf, sourceResource, destResource, c.flagStorage, c.flagTargetProject, c.flagInstanceOnly, stateful)
 		}
 	}
 
@@ -330,8 +315,8 @@ func moveClusterInstance(conf *config.Config, sourceResource string, destResourc
 	return nil
 }
 
-// Move an instance between pools using special POST /instances/<name> API.
-func moveInstancePool(conf *config.Config, sourceResource string, destResource string, instanceOnly bool, storage string, stateful bool) error {
+// Move an instance between pools and projects using special POST /instances/<name> API.
+func moveInstance(conf *config.Config, sourceResource string, destResource string, storage string, targetProject string, instanceOnly bool, stateful bool) error {
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {
@@ -364,60 +349,9 @@ func moveInstancePool(conf *config.Config, sourceResource string, destResource s
 	req := api.InstancePost{
 		Name:         destName,
 		Migration:    true,
+		InstanceOnly: instanceOnly,
 		Pool:         storage,
-		InstanceOnly: instanceOnly,
-		Live:         stateful,
-	}
-
-	op, err := source.MigrateInstance(sourceName, req)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration API failure: %w"), err)
-	}
-
-	err = op.Wait()
-	if err != nil {
-		return fmt.Errorf(i18n.G("Migration operation failure: %w"), err)
-	}
-
-	return nil
-}
-
-// Move an instance between projects using special POST /instances/<name> API.
-func moveInstanceProject(conf *config.Config, sourceResource string, destResource string, targetProject string, instanceOnly bool, stateful bool) error {
-	// Parse the source.
-	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
-	if err != nil {
-		return err
-	}
-
-	// Parse the destination.
-	_, destName, err := conf.ParseRemote(destResource)
-	if err != nil {
-		return err
-	}
-
-	// Make sure we have an instance or snapshot name.
-	if sourceName == "" {
-		return fmt.Errorf(i18n.G("You must specify a source instance name"))
-	}
-
-	// The destination name is optional.
-	if destName == "" {
-		destName = sourceName
-	}
-
-	// Connect to the source host.
-	source, err := conf.GetInstanceServer(sourceRemote)
-	if err != nil {
-		return fmt.Errorf(i18n.G("Failed to connect to cluster member: %w"), err)
-	}
-
-	// Pass the new project to the migration API.
-	req := api.InstancePost{
-		Name:         destName,
-		Migration:    true,
 		Project:      targetProject,
-		InstanceOnly: instanceOnly,
 		Live:         stateful,
 	}
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5368,16 +5368,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5638,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6036,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3922,12 +3922,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5974,19 +5974,14 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
+#: lxc/move.go:209
 #, fuzzy
-msgid "The --mode flag can't be used with --storage"
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
-
-#: lxc/move.go:220
-#, fuzzy
-msgid "The --mode flag can't be used with --target-project"
-msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/console.go:125
 msgid "The --show-log flag is only supported for by 'console' output type"
@@ -6138,7 +6133,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6254,7 +6249,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6692,7 +6687,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -8255,6 +8250,10 @@ msgstr ""
 #: lxc/image.go:1115
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage"
+#~ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #, fuzzy
 #~ msgid "Failed to get the new instance name"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -3489,12 +3489,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5455,16 +5455,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5613,7 +5609,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5725,7 +5721,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6140,7 +6136,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2397,7 +2397,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -3766,12 +3766,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5755,18 +5755,14 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
-msgstr ""
+#: lxc/move.go:209
+#, fuzzy
+msgid "The --mode flag can't be used with --storage or --target-project"
+msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
-
-#: lxc/move.go:220
-#, fuzzy
-msgid "The --mode flag can't be used with --target-project"
-msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
 #: lxc/console.go:125
 msgid "The --show-log flag is only supported for by 'console' output type"
@@ -5915,7 +5911,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6028,7 +6024,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6446,7 +6442,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -2524,7 +2524,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -4004,12 +4004,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -6107,16 +6107,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -6274,7 +6270,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6391,7 +6387,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6830,7 +6826,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5372,16 +5372,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5530,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5642,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6040,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2392,7 +2392,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -3764,12 +3764,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5752,16 +5752,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5911,7 +5907,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6024,7 +6020,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6439,7 +6435,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -2440,7 +2440,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -3967,12 +3967,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -6000,17 +6000,14 @@ msgstr "ターゲットのパスはディレクトリでなければなりませ
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
-msgstr "--mode と --storage は同時に指定できません"
+#: lxc/move.go:209
+#, fuzzy
+msgid "The --mode flag can't be used with --storage or --target-project"
+msgstr "--mode と --target-project は同時に指定できません"
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
-msgstr "--mode と --target-project は同時に指定できません"
 
 #: lxc/console.go:125
 msgid "The --show-log flag is only supported for by 'console' output type"
@@ -6163,7 +6160,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
@@ -6294,7 +6291,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6712,7 +6709,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7842,6 +7839,9 @@ msgstr "y"
 #: lxc/image.go:1115
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "The --mode flag can't be used with --storage"
+#~ msgstr "--mode と --storage は同時に指定できません"
 
 #~ msgid "Failed to get the new instance name"
 #~ msgstr "新しいインスタンス名が取得できません"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5368,16 +5368,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5638,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6036,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-11-07 10:34+0100\n"
+        "POT-Creation-Date: 2023-11-27 13:02+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1903,7 +1903,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -3188,12 +3188,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -4977,16 +4977,12 @@ msgstr  ""
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:204
-msgid   "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid   "The --mode flag can't be used with --storage or --target-project"
 msgstr  ""
 
 #: lxc/move.go:179
 msgid   "The --mode flag can't be used with --target"
-msgstr  ""
-
-#: lxc/move.go:220
-msgid   "The --mode flag can't be used with --target-project"
 msgstr  ""
 
 #: lxc/console.go:125
@@ -5132,7 +5128,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
@@ -5237,7 +5233,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5619,7 +5615,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid   "You must specify a source instance name"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3659,12 +3659,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5588,16 +5588,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5746,7 +5742,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5858,7 +5854,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6256,7 +6252,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3693,12 +3693,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5622,16 +5622,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5780,7 +5776,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5892,7 +5888,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6290,7 +6286,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5368,16 +5368,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5638,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6036,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -3829,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5842,19 +5842,14 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
+#: lxc/move.go:209
 #, fuzzy
-msgid "The --mode flag can't be used with --storage"
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
 msgstr ""
-
-#: lxc/move.go:220
-#, fuzzy
-msgid "The --mode flag can't be used with --target-project"
-msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/console.go:125
 msgid "The --show-log flag is only supported for by 'console' output type"
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6117,7 +6112,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6542,7 +6537,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7573,6 +7568,10 @@ msgstr ""
 #: lxc/image.go:1115
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "The --mode flag can't be used with --storage"
+#~ msgstr "--refresh só pode ser usado com containers"
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr "%v (interrompa mais duas vezes para forçar)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -3826,12 +3826,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5832,16 +5832,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5990,7 +5986,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6102,7 +6098,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6522,7 +6518,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5372,16 +5372,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5530,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5642,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6040,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5372,16 +5372,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5530,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5642,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6040,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5368,16 +5368,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5526,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5638,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6036,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5372,16 +5372,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5530,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5642,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6040,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3592,12 +3592,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5521,16 +5521,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5679,7 +5675,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5791,7 +5787,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6189,7 +6185,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 07:19+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:284 lxc/move.go:360 lxc/move.go:412
+#: lxc/move.go:273 lxc/move.go:349
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:302 lxc/move.go:374 lxc/move.go:426
+#: lxc/move.go:291 lxc/move.go:364
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:379 lxc/move.go:431
+#: lxc/move.go:316 lxc/move.go:369
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -5371,16 +5371,12 @@ msgstr ""
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:204
-msgid "The --mode flag can't be used with --storage"
+#: lxc/move.go:209
+msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
 #: lxc/move.go:179
 msgid "The --mode flag can't be used with --target"
-msgstr ""
-
-#: lxc/move.go:220
-msgid "The --mode flag can't be used with --target-project"
 msgstr ""
 
 #: lxc/console.go:125
@@ -5529,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:289
+#: lxc/move.go:278
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5641,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:296
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6039,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
+#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
 msgid "You must specify a source instance name"
 msgstr ""
 


### PR DESCRIPTION
If `--storage` flag is used along `--target-project` flag in move command, ensure the instance is migrated to another project as well.

In addition, when migrating to another project, determine root disk device in the following order:
1. Check if local devices already contain root disk device
2. Check if any of the profiles that will be applied to the instance in the target project contain configuration for root disk device
3. Lastly, set the current root disk device to the instance's configuration (found from expended devices).

---

When using server-side move, flags `--profile`, `--no-profiles`, `--device` are not respected. Therefore, step `2.` only works for profiles that are already applied to the instance in source project and exist in the target project.

A very simple solution would be to skip server-side project move if any of the above flags is set. This way, LXD would copy the instance (ensuring profiles and devices are applied).

If we are willing to support server-side move of the instance while respecting other flags, then we would most likely need to expand `moveInstanceProject()`.

---

There is also a small inconsistency between "server-side" move and "move using copy". When moving an instance whose root disk device is configured in the profile, a root disk device configuration is moved to the instance's config. On the other side, copy ("move using copy") will not do that.
