### PR TITLE
github: Run push actions on main and release branches only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,10 @@
 name: Tests
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+      - stable-*
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
If dependabot creates new PRs, those are not originating from a fork. Instead a new branch is created in the same repository which triggers on both `push` and `pull_request`.

Limiting the push trigger to the main and release branches doesn't anymore duplicate the jobs for dependabot PRs.

Check here for reference: https://github.com/canonical/lxd/pull/12376