### PR TITLE
lxd: Update certificate cache after cluster join.

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -710,9 +710,6 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			}
 		}
 
-		// Update cached trusted certificates.
-		s.UpdateCertificateCache()
-
 		// Update local setup and possibly join the raft dqlite cluster.
 		nodes := make([]db.RaftNode, len(info.RaftNodes))
 		for i, node := range info.RaftNodes {
@@ -725,6 +722,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		if err != nil {
 			return err
 		}
+
+		// Update cached trusted certificates.
+		s.UpdateCertificateCache()
 
 		// Start clustering tasks.
 		d.startClusterTasks()


### PR DESCRIPTION
This method relies on the cluster database and therefore needs to run after we've joined the dqlite cluster in order to properly replicate the cache in the new member.