### PR TITLE
Add staticcheck target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,10 @@
 linters:
   enable:
+    - gci
+    - godot
     - gofmt
     - misspell
-    - godot
     - whitespace
-    - gci
 linters-settings:
   gci:
     sections:

--- a/Makefile
+++ b/Makefile
@@ -287,5 +287,17 @@ endif
 	shellcheck test/extras/*.sh
 	run-parts --exit-on-error --regex '.sh' test/lint
 
+.PHONY: staticcheck
+staticcheck:
+ifeq ($(shell command -v staticcheck),)
+	(cd / ; go install -v -x honnef.co/go/tools/cmd/staticcheck@latest)
+endif
+	# To get advance notice of deprecated function usage, consider running:
+	#   sed -i 's/^go 1\.[0-9]\+$/go 1.18/' go.mod
+	# before 'make staticcheck'.
+
+	# Run staticcheck against all the dirs containing Go files.
+	staticcheck $$(git ls-files *.go | sed 's|^|./|; s|/[^/]\+\.go$$||' | sort -u)
+
 tags: */*.go
 	find . -type f -name '*.go' | gotags -L - -f tags

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,3 @@
+# Checks being ignored:
+# ST1005: error strings should not be capitalized (5585 occurences as of 2023-10-20)
+checks = ["inherit", "-ST1005"]


### PR DESCRIPTION
This flags a bunch of interesting things among which are when deprecated functions are used. It uses the Go version from `go.mod` which is why it wouldn't have caught the `ioutil` bits from #12400 as those are not deprecated in Go 1.18.

I tried different approaches like the `dominikh/staticcheck-action` or the `golangci-lint` integration. I ruled out the GitHub Action as I assumed you wanted something to use locally too. The `golangci-lint` integration is not endorsed by `staticcheck` upstream and isn't really reliable nor intuitive.

So I went for this additional target that isn't run as part of `make static-analysis` because it flags too much (interesting) stuff for me to tackle now.