### PR TITLE
lxd/firewall: Fix nftables ACL template

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -136,7 +136,7 @@ table {{.family}} {{.namespace}} {
 		# Allow core ICMPv6 to LXD host.
 		iifname "{{$.networkName}}" icmpv6 type {1, 2, 3, 4, 133, 135, 136, 143} accept
 
-		iifname {{.networkName}} jump acl{{.chainSeparator}}{{.networkName}}
+		iifname "{{.networkName}}" jump acl{{.chainSeparator}}{{.networkName}}
 	}
 
 	chain aclout{{.chainSeparator}}{{.networkName}} {
@@ -150,12 +150,12 @@ table {{.family}} {{.namespace}} {
 		# Allow ICMPv6 ping from host into network as dnsmasq uses this to probe IP allocations.
 		oifname "{{$.networkName}}" icmpv6 type {1, 2, 3, 4, 128, 134, 135, 136, 143}  accept
 
-		oifname {{.networkName}} jump acl{{.chainSeparator}}{{.networkName}}
+		oifname "{{.networkName}}" jump acl{{.chainSeparator}}{{.networkName}}
 	}
 
 	chain aclfwd{{.chainSeparator}}{{.networkName}} {
-		iifname {{.networkName}} jump acl{{.chainSeparator}}{{.networkName}}
-		oifname {{.networkName}} jump acl{{.chainSeparator}}{{.networkName}}
+		iifname "{{.networkName}}" jump acl{{.chainSeparator}}{{.networkName}}
+		oifname "{{.networkName}}" jump acl{{.chainSeparator}}{{.networkName}}
 	}
 }
 `))


### PR DESCRIPTION
Network interface name must be double-quoted to avoid collisions with the nftables syntax.

For example a bridge network called `rt` will cause the following error prior to this commit:
```
Error: syntax error, unexpected rt
           iifname rt jump acl.rt
                   ^^
```
when trying to set ACL:
`lxc network set rt security.acls="rt-acl"`
because `rt` is a restricted token in the nftables syntax: https://wiki.nftables.org/wiki-nftables/index.php/Quick_reference-nftables_in_10_minutes#Rt