### PR TITLE
Use HTTP status codes constants instead of literal numerics

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -74,7 +74,7 @@ func restServer(d *Daemon) *http.Server {
 		uiHttpDir := uiHttpDir{http.Dir(uiPath)}
 		mux.PathPrefix("/ui/").Handler(http.StripPrefix("/ui/", http.FileServer(uiHttpDir)))
 		mux.HandleFunc("/ui", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/ui/", 301)
+			http.Redirect(w, r, "/ui/", http.StatusMovedPermanently)
 		})
 	}
 
@@ -85,7 +85,7 @@ func restServer(d *Daemon) *http.Server {
 		documentationHttpDir := documentationHttpDir{http.Dir(documentationPath)}
 		mux.PathPrefix("/documentation/").Handler(http.StripPrefix("/documentation/", http.FileServer(documentationHttpDir)))
 		mux.HandleFunc("/documentation", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/documentation/", 301)
+			http.Redirect(w, r, "/documentation/", http.StatusMovedPermanently)
 		})
 	}
 
@@ -123,7 +123,7 @@ func restServer(d *Daemon) *http.Server {
 		ua := r.Header.Get("User-Agent")
 		if uiEnabled && strings.Contains(ua, "Gecko") {
 			// Web browser handling.
-			http.Redirect(w, r, "/ui/", 301)
+			http.Redirect(w, r, "/ui/", http.StatusMovedPermanently)
 		} else {
 			// Normal client handling.
 			_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -211,7 +211,7 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 
 		// Send to the UI.
 		// NOTE: Once the UI does the redirection on its own, we may be able to use the referer here instead.
-		http.Redirect(w, r, "/ui/", 301)
+		http.Redirect(w, r, "/ui/", http.StatusMovedPermanently)
 	}, provider)
 
 	handler(w, r)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -303,7 +303,7 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 		}
 
 		if rootUID != cred.Uid {
-			http.Error(w, "Access denied for non-root user", 401)
+			http.Error(w, "Access denied for non-root user", http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
Fix one of the low hanging fruit found by `make staticcheck` (see #12422).