### PR TITLE
doc: update link to tool downloads

### DIFF
--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -60,7 +60,7 @@ The tool can create both containers and virtual machines:
 
 Complete the following steps to migrate an existing machine to a LXD instance:
 
-1. Download the [`bin.linux.lxd-migrate`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate) tool from the **Assets** section of the latest [LXD release](https://github.com/canonical/lxd/releases).
+1. Download the `bin.linux.lxd-migrate` tool ([`bin.linux.lxd-migrate.aarch64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.aarch64) or [`bin.linux.lxd-migrate.x86_64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.x86_64)) from the **Assets** section of the latest [LXD release](https://github.com/canonical/lxd/releases).
 1. Place the tool on the machine that you want to use to create the instance.
    Make it executable (usually by running `chmod u+x bin.linux.lxd-migrate`).
 1. Make sure that the machine has `rsync` installed.

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -26,7 +26,7 @@ Clustering (see {ref}`exp-clustering` and {ref}`cluster-form`)
   The default answer is `no`, which means clustering is not enabled.
   If you answer `yes`, you can either connect to an existing cluster or create one.
 
-MAAS support (see [`maas.io`](https://maas.io/) and [MAAS - How to manage VM hosts](https://maas.io/docs/install-with-lxd))
+MAAS support (see [`maas.io`](https://maas.io/) and [MAAS - Setting up LXD for VMs](https://maas.io/docs/setting-up-lxd-for-vms))
 : MAAS is an open-source tool that lets you build a data center from bare-metal servers.
 
   The default answer is `no`, which means MAAS support is not enabled.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -141,9 +141,9 @@ To install it:
 
 You can also find native builds of the LXD client on [GitHub](https://github.com/canonical/lxd/actions):
 
-- [LXD client for Linux](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxc)
-- [LXD client for Windows](https://github.com/canonical/lxd/releases/latest/download/bin.windows.lxc.exe)
-- [LXD client for macOS](https://github.com/canonical/lxd/releases/latest/download/bin.macos.lxc)
+- LXD client for Linux: [`bin.linux.lxc.aarch64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxc.aarch64), [`bin.linux.lxc.x86_64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxc.x86_64)
+- LXD client for Windows: [`bin.windows.lxc.aarch64.exe`](https://github.com/canonical/lxd/releases/latest/download/bin.windows.lxc.aarch64.exe), [`bin.windows.lxc.x86_64.exe`](https://github.com/canonical/lxd/releases/latest/download/bin.windows.lxc.x86_64.exe)
+- LXD client for macOS: [`bin.macos.lxc.aarch64`](https://github.com/canonical/lxd/releases/latest/download/bin.macos.lxc.aarch64), [`bin.macos.lxc.x86_64`](https://github.com/canonical/lxd/releases/latest/download/bin.macos.lxc.x86_64)
 
 To download a specific build:
 


### PR DESCRIPTION
Our binaries are now available for different architectures. Update the download links to the new links.