### PR TITLE
lxd: Update certificate cache again after cluster join.

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -710,7 +710,8 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			}
 		}
 
-		// Update cached trusted certificates.
+		// Update cached trusted certificates (this adds the server certificates we collected above) so that we are able to join.
+		// Client and metric type certificates from the cluster we are joining will not be added until later.
 		s.UpdateCertificateCache()
 
 		// Update local setup and possibly join the raft dqlite cluster.
@@ -811,6 +812,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		if err != nil {
 			logger.Warn("Failed to sync images")
 		}
+
+		// Update the cert cache again to add client and metric certs to the cache.
+		s.UpdateCertificateCache()
 
 		s.Events.SendLifecycle(projectParam(r), lifecycle.ClusterMemberAdded.Event(req.ServerName, op.Requestor(), nil))
 


### PR DESCRIPTION
A change that will be introduced by #12313 is that requests originating from other cluster members will no longer be implicitly trusted, since these requests can originate from a client. For example, if the request context contains `request.CtxProtocol` equal to `cluster`, but the `request.ForwardedProtocol` is `tls`, the forwarded request currently has admin privilege. In contrast, #12313 will extract the `request.ForwardedUsername` and authenticate with that. This is not only much safer, it is also necessary in order to perform filtering of resources where these need to be collected from other cluster members (operations).

This leads to a problem with this test: https://github.com/canonical/lxd/blob/6ab06f9dc9f73b458ab8acd6843ea91d089d6f5d/test/suites/clustering.sh#L1878-L1954

Specifically on this line https://github.com/canonical/lxd/blob/main/test/suites/clustering.sh#L1932 we have just joined `node2` to the cluster, and we perform a request targeting `node2`. This has previously worked because the `cluster` remote is still `node1` whose certificate cache contains the client certificate of the user, and when the request is forwarded `node2` treats the request from `node1` with admin privileges. However, in #12313 when `node2` receives the request from `node1`, it extracts the `request.ForwardedUsername` (client certificate fingerprint) and returns a 403 Forbidden because it's certificate cache does not contain the client certificates from `node1` yet.

This can be fixed in a number of ways. In this case, I have opted to simply refresh the certificate cache again once all of the cluster join logic is completed.