### PR TITLE
[Stable-4.0] doc: fix symbolic link to rest-api.yaml after moving the directory

### DIFF
--- a/doc/.sphinx/_extra/rest-api.yaml
+++ b/doc/.sphinx/_extra/rest-api.yaml
@@ -1,1 +1,1 @@
-../../doc/rest-api.yaml
+../../rest-api.yaml

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5567,9 +5567,9 @@ definitions:
     x-go-package: github.com/lxc/lxd/shared/api
 info:
   contact:
-        email: lxd@lists.canonical.com
+    email: lxd@lists.canonical.com
     name: LXD upstream
-        url: https://github.com/canonical/lxd
+    url: https://github.com/canonical/lxd
   description: |-
     This is the REST API used by all LXD clients.
     Internal endpoints aren't included in this documentation.


### PR DESCRIPTION
Cherry-pick this fix to 4.0 as well.