### PR TITLE
Revert "Ensure the remote connection using simplestreams is valid before adding it"

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -326,24 +326,6 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		conf.Remotes[server] = config.Remote{Addr: addr, Public: true, Protocol: c.flagProtocol}
-
-		// Check that the server is reachable (test that the server URL path is valid)
-		var d lxd.ImageServer
-		if c.flagPublic {
-			d, err = conf.GetImageServer(server)
-		} else {
-			d, err = conf.GetInstanceServer(server)
-		}
-
-		if err != nil {
-			return err
-		}
-
-		_, err = d.GetImages()
-		if err != nil {
-			return err
-		}
-
 		return conf.SaveConfig(c.global.confPath)
 	} else if c.flagProtocol != "lxd" {
 		return fmt.Errorf(i18n.G("Invalid protocol: %s"), c.flagProtocol)

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -26,11 +26,6 @@ test_remote_url() {
     lxc_remote remote add ubuntu2 https://cloud-images.ubuntu.com:443/releases --protocol=simplestreams
     lxc_remote remote remove ubuntu1
     lxc_remote remote remove ubuntu2
-
-    # a connectivity issue returns an error
-    ! lxc_remote remote add ubuntu1 https://cloud-images.ubuntu.com:1234/releases --protocol=simplestreams
-    # a malformed url path returns an error
-    ! lxc_remote remote add ubuntu2 https://cloud-images.ubuntu.com/buildd/releases/ --protocol=simplestreams --public
   fi
 }
 


### PR DESCRIPTION
Reverts #12442 as it prevented adding simplestreams remotes.