### PR TITLE
Require destination name when copying an instance on the same server

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -382,11 +382,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -729,12 +729,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1044,10 +1044,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1596,11 +1596,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1983,7 +1983,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1995,11 +1995,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2130,16 +2130,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2527,7 +2523,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2577,7 +2573,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2585,7 +2581,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2604,11 +2600,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2643,7 +2639,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2666,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2726,7 +2722,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2734,7 +2730,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2747,14 +2743,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3096,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3558,9 +3554,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3689,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3926,7 +3922,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3938,11 +3934,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4013,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4230,7 +4226,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4260,7 +4256,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4273,7 +4269,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4367,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,19 +4522,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4586,7 +4582,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4667,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4906,11 +4902,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4919,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4983,7 +4979,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5107,7 +5103,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5115,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5169,11 +5165,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5327,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5823,7 +5819,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5875,7 +5871,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6014,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6026,8 +6022,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6415,7 +6411,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6464,15 +6460,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6492,15 +6488,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6626,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6932,13 +6928,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -631,11 +631,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -645,7 +645,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -670,15 +670,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -716,7 +716,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -976,7 +976,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1009,12 +1009,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1249,7 +1249,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1341,10 +1341,10 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1523,12 +1523,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1557,7 +1557,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1912,8 +1912,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1930,11 +1930,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2264,7 +2264,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2278,8 +2278,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2355,7 +2355,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2370,12 +2370,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2506,17 +2506,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-#, fuzzy
-msgid "Failed to get the new instance name"
-msgstr "kann nicht zum selben Container Namen kopieren"
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2613,7 +2608,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2651,7 +2646,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2667,7 +2662,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2917,7 +2912,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2931,7 +2926,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2983,7 +2978,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2991,7 +2986,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3012,11 +3007,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3052,7 +3047,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3075,7 +3070,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3136,7 +3131,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3145,7 +3140,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3159,14 +3154,14 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3541,7 +3536,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -4054,9 +4049,9 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4196,7 +4191,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4224,7 +4219,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4438,7 +4433,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4451,11 +4446,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4526,11 +4521,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4574,7 +4569,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4752,7 +4747,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4782,7 +4777,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4795,7 +4790,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4895,7 +4890,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4905,13 +4900,13 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -4921,12 +4916,12 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5015,7 +5010,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -5069,21 +5064,21 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5134,7 +5129,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5220,7 +5215,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5261,11 +5256,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5473,12 +5468,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5487,7 +5482,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5558,7 +5553,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5699,7 +5694,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
@@ -5709,7 +5704,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5766,12 +5761,12 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5933,7 +5928,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6205,7 +6200,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6249,7 +6244,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6297,7 +6292,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6457,7 +6452,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6518,7 +6513,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6566,7 +6561,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6669,7 +6664,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6682,9 +6677,9 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:89
+#: lxc/copy.go:100
 #, fuzzy
-msgid "You must specify a destination instance name when using --target"
+msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -7450,7 +7445,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7517,7 +7512,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7544,7 +7539,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7553,7 +7548,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7562,7 +7557,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7604,7 +7599,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -7612,7 +7607,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -7620,7 +7615,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -7877,7 +7872,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -8187,13 +8182,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -8205,7 +8200,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8242,7 +8237,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 
@@ -8250,6 +8245,14 @@ msgstr ""
 #: lxc/image.go:1115
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Failed to get the new instance name"
+#~ msgstr "kann nicht zum selben Container Namen kopieren"
+
+#, fuzzy
+#~ msgid "You must specify a destination instance name when using --target"
+#~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -703,7 +703,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -735,12 +735,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -878,7 +878,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1051,10 +1051,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1225,12 +1225,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1592,8 +1592,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1610,11 +1610,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1924,7 +1924,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1938,8 +1938,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2006,7 +2006,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2018,11 +2018,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2153,16 +2153,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2255,7 +2251,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2293,7 +2289,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2309,7 +2305,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2549,7 +2545,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2563,7 +2559,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2613,7 +2609,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2621,7 +2617,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2640,11 +2636,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2679,7 +2675,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2702,7 +2698,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2762,7 +2758,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2770,7 +2766,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2783,14 +2779,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3134,7 +3130,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3612,9 +3608,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3744,7 +3740,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3772,7 +3768,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3983,7 +3979,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3995,11 +3991,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4070,11 +4066,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4116,7 +4112,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4288,7 +4284,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4318,7 +4314,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4331,7 +4327,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4425,7 +4421,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4435,13 +4431,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4451,12 +4447,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4539,7 +4535,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4589,19 +4585,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4649,7 +4645,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4731,7 +4727,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4772,11 +4768,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4977,11 +4973,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4990,7 +4986,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5060,7 +5056,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5193,7 +5189,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5201,7 +5197,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5256,11 +5252,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5414,7 +5410,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5675,7 +5671,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5719,7 +5715,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5766,7 +5762,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5979,7 +5975,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6024,7 +6020,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6118,7 +6114,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6130,8 +6126,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6519,7 +6515,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6554,7 +6550,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6568,15 +6564,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6596,15 +6592,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6730,7 +6726,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7036,13 +7032,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7054,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7091,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -619,12 +619,12 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -633,7 +633,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -655,15 +655,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -944,7 +944,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -976,12 +976,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1122,7 +1122,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1219,7 +1219,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1297,10 +1297,10 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1475,12 +1475,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1847,8 +1847,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1865,11 +1865,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr "Descripción"
@@ -2179,7 +2179,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2193,8 +2193,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2263,7 +2263,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2277,11 +2277,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2412,17 +2412,12 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-#, fuzzy
-msgid "Failed to get the new instance name"
-msgstr "Perfil para aplicar al nuevo contenedor"
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2516,7 +2511,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2554,7 +2549,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2570,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2813,7 +2808,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2827,7 +2822,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2877,7 +2872,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2885,7 +2880,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2905,11 +2900,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2946,7 +2941,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -2969,7 +2964,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3029,7 +3024,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3038,7 +3033,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3051,14 +3046,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3411,7 +3406,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3897,9 +3892,9 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -4033,7 +4028,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4061,7 +4056,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4270,7 +4265,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4282,11 +4277,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4357,11 +4352,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4403,7 +4398,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4579,7 +4574,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4609,7 +4604,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4622,7 +4617,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4718,7 +4713,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4728,13 +4723,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4744,12 +4739,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4833,7 +4828,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4879,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4947,7 +4942,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5031,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5072,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5277,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5290,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5360,7 +5355,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5493,7 +5488,7 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5501,7 +5496,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5556,11 +5551,11 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5715,7 +5710,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5979,7 +5974,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6023,7 +6018,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6072,7 +6067,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6226,7 +6221,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6285,7 +6280,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6331,7 +6326,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6425,7 +6420,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6437,8 +6432,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6912,7 +6907,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6955,7 +6950,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -6972,17 +6967,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7007,17 +7002,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7174,7 +7169,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7480,13 +7475,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7498,7 +7493,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7535,7 +7530,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 
@@ -7543,6 +7538,10 @@ msgstr ""
 #: lxc/image.go:1115
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Failed to get the new instance name"
+#~ msgstr "Perfil para aplicar al nuevo contenedor"
 
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -626,11 +626,11 @@ msgstr "--empty ne peut être combiné avec le nom d'une image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 
@@ -638,7 +638,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
@@ -661,17 +661,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -865,7 +865,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -980,7 +980,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1013,12 +1013,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1159,7 +1159,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1244,7 +1244,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1258,7 +1258,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1336,10 +1336,10 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1527,12 +1527,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1561,7 +1561,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1937,8 +1937,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1955,11 +1955,11 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2285,7 +2285,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2299,8 +2299,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2386,7 +2386,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2401,12 +2401,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2539,17 +2539,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:414
-#, fuzzy
-msgid "Failed to get the new instance name"
-msgstr "Profil à appliquer au nouveau conteneur"
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2646,7 +2641,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2684,7 +2679,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2700,7 +2695,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -2953,7 +2948,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2970,7 +2965,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3024,7 +3019,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3032,7 +3027,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3054,11 +3049,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3096,7 +3091,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3119,7 +3114,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3179,7 +3174,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3188,7 +3183,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3202,14 +3197,14 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3627,7 +3622,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -4137,9 +4132,9 @@ msgstr "Résumé manquant."
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4282,7 +4277,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4310,7 +4305,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr "NON"
 
@@ -4525,7 +4520,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4540,13 +4535,13 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -4624,11 +4619,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4851,7 +4846,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4881,7 +4876,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4894,7 +4889,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +4992,7 @@ msgstr "Copie de l'image : %s"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -5007,13 +5002,13 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -5023,12 +5018,12 @@ msgstr "le serveur distant %s n'existe pas"
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -5117,7 +5112,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -5171,21 +5166,21 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5253,7 +5248,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5339,7 +5334,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5383,11 +5378,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5597,12 +5592,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5611,7 +5606,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5682,7 +5677,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -5828,7 +5823,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
@@ -5838,7 +5833,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5896,12 +5891,12 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -6065,7 +6060,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6342,7 +6337,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6386,7 +6381,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6435,7 +6430,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr "URL"
 
@@ -6598,7 +6593,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6659,7 +6654,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6707,7 +6702,7 @@ msgstr "Création du conteneur"
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6807,7 +6802,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr "OUI"
 
@@ -6820,9 +6815,9 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:89
+#: lxc/copy.go:100
 #, fuzzy
-msgid "You must specify a destination instance name when using --target"
+msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -7663,7 +7658,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7730,7 +7725,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7760,7 +7755,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7772,7 +7767,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7784,7 +7779,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7832,7 +7827,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -7840,7 +7835,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -7848,7 +7843,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8126,7 +8121,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8455,13 +8450,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -8474,7 +8469,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8511,7 +8506,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr "o"
 
@@ -8519,6 +8514,14 @@ msgstr "o"
 #: lxc/image.go:1115
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy
+#~ msgid "Failed to get the new instance name"
+#~ msgstr "Profil à appliquer au nouveau conteneur"
+
+#, fuzzy
+#~ msgid "You must specify a destination instance name when using --target"
+#~ msgstr "vous devez spécifier un nom de conteneur source"
 
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -386,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -733,12 +733,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1048,10 +1048,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1415,7 +1415,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1600,11 +1600,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1905,7 +1905,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1919,8 +1919,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1987,7 +1987,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1999,11 +1999,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2134,16 +2134,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2236,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2274,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2290,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2517,7 +2513,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2531,7 +2527,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2581,7 +2577,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2589,7 +2585,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2608,11 +2604,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2647,7 +2643,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2670,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2730,7 +2726,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2738,7 +2734,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2751,14 +2747,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3100,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3562,9 +3558,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3693,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3721,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3930,7 +3926,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3942,11 +3938,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4017,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4062,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4234,7 +4230,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4264,7 +4260,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4277,7 +4273,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4371,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4381,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4397,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4481,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4530,19 +4526,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4590,7 +4586,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4671,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4712,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4910,11 +4906,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4923,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4987,7 +4983,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5111,7 +5107,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5119,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5173,11 +5169,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5331,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5592,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5636,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5683,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5827,7 +5823,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5879,7 +5875,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5924,7 +5920,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6018,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6030,8 +6026,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6419,7 +6415,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6454,7 +6450,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6468,15 +6464,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6496,15 +6492,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6630,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6936,13 +6932,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6954,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6991,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -620,11 +620,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -654,15 +654,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -943,7 +943,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -975,12 +975,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1118,7 +1118,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1292,10 +1292,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1466,12 +1466,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1500,7 +1500,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1841,8 +1841,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1859,11 +1859,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2189,8 +2189,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2272,11 +2272,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2407,16 +2407,12 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2511,7 +2507,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2549,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2565,7 +2561,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2803,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2817,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2864,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2872,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2896,11 +2892,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -2936,7 +2932,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -2959,7 +2955,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3019,7 +3015,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3028,7 +3024,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3042,14 +3038,14 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3403,7 +3399,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3893,9 +3889,9 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -4028,7 +4024,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4056,7 +4052,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4265,7 +4261,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4278,11 +4274,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4353,11 +4349,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4400,7 +4396,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4574,7 +4570,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4600,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4613,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4714,7 +4710,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
@@ -4724,13 +4720,13 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -4740,12 +4736,12 @@ msgstr "il remote %s non esiste"
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -4830,7 +4826,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4881,19 +4877,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4944,7 +4940,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5028,7 +5024,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5069,11 +5065,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5268,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5281,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5353,7 +5349,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5486,7 +5482,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5494,7 +5490,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5549,11 +5545,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5710,7 +5706,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5974,7 +5970,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6018,7 +6014,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6066,7 +6062,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6219,7 +6215,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6275,7 +6271,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6322,7 +6318,7 @@ msgstr "Creazione del container in corso"
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6416,7 +6412,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6428,9 +6424,9 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
+#: lxc/copy.go:100
 #, fuzzy
-msgid "You must specify a destination instance name when using --target"
+msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6906,7 +6902,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -6949,7 +6945,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -6966,17 +6962,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
@@ -7001,17 +6997,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
@@ -7168,7 +7164,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7474,13 +7470,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -7493,7 +7489,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7530,7 +7526,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 
@@ -7538,6 +7534,10 @@ msgstr ""
 #: lxc/image.go:1115
 msgid "yes"
 msgstr "si"
+
+#, fuzzy
+#~ msgid "You must specify a destination instance name when using --target"
+#~ msgstr "Occorre specificare un nome di container come origine"
 
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -612,11 +612,11 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--no-profiles と --refresh は同時に指定できません"
 
@@ -624,7 +624,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
@@ -645,15 +645,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -688,7 +688,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -841,7 +841,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -954,7 +954,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -986,12 +986,12 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1131,7 +1131,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1219,7 +1219,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1233,7 +1233,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1310,10 +1310,10 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1503,12 +1503,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1537,7 +1537,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1700,7 +1700,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1867,8 +1867,8 @@ msgstr "警告を削除します"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1885,11 +1885,11 @@ msgstr "警告を削除します"
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr "説明"
@@ -2209,7 +2209,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2223,8 +2223,8 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2305,7 +2305,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2317,12 +2317,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2453,16 +2453,12 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr "新しいインスタンス名が取得できません"
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2570,7 +2566,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2608,7 +2604,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2624,7 +2620,7 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2864,7 +2860,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -2880,7 +2876,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -2930,7 +2926,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -2941,7 +2937,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -2964,11 +2960,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3003,7 +2999,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3026,7 +3022,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3090,7 +3086,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3100,7 +3096,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3115,14 +3111,14 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3587,7 +3583,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4084,9 +4080,9 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4233,7 +4229,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4261,7 +4257,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr "NO"
 
@@ -4473,7 +4469,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4485,11 +4481,11 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4560,11 +4556,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4605,7 +4601,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4779,7 +4775,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4812,7 +4808,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4825,7 +4821,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4921,7 +4917,7 @@ msgstr "既存のストレージボリュームのコピーの再読込と更新
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
@@ -4931,13 +4927,13 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -4947,12 +4943,12 @@ msgstr "リモート %s は存在しません"
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -5031,7 +5027,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5080,20 +5076,20 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5147,7 +5143,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -5229,7 +5225,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5271,11 +5267,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5521,11 +5517,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -5539,7 +5535,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5611,7 +5607,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -5737,7 +5733,7 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
@@ -5745,7 +5741,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -5799,11 +5795,11 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
@@ -5957,7 +5953,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6240,7 +6236,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -6286,7 +6282,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6335,7 +6331,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr "URL"
 
@@ -6479,7 +6475,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -6539,7 +6535,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6587,7 +6583,7 @@ msgstr "上位デバイス"
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6687,7 +6683,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr "YES"
 
@@ -6699,10 +6695,10 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
-msgstr ""
-"--target オプションを使うときはコピー先のインスタンス名を指定してください"
+#: lxc/copy.go:100
+#, fuzzy
+msgid "You must specify a destination instance name"
+msgstr "コピー元のインスタンス名を指定してください"
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
 msgid "You must specify a source instance name"
@@ -7103,7 +7099,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7138,7 +7134,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7154,15 +7150,15 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
@@ -7183,17 +7179,17 @@ msgstr "[<remote>:]<pool> [<filter>...]"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
@@ -7266,6 +7262,7 @@ msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
 #: lxc/copy.go:37
+#, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
@@ -7322,7 +7319,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr "現在値"
 
@@ -7766,7 +7763,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7774,7 +7771,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr "n"
 
@@ -7786,7 +7783,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7825,7 +7822,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr "y"
 
@@ -7833,6 +7830,13 @@ msgstr "y"
 #: lxc/image.go:1115
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "Failed to get the new instance name"
+#~ msgstr "新しいインスタンス名が取得できません"
+
+#~ msgid "You must specify a destination instance name when using --target"
+#~ msgstr ""
+#~ "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
 #, fuzzy
 #~ msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>=<value>..."

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -382,11 +382,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -729,12 +729,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1044,10 +1044,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1596,11 +1596,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1983,7 +1983,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1995,11 +1995,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2130,16 +2130,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2527,7 +2523,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2577,7 +2573,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2585,7 +2581,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2604,11 +2600,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2643,7 +2639,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2666,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2726,7 +2722,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2734,7 +2730,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2747,14 +2743,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3096,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3558,9 +3554,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3689,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3926,7 +3922,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3938,11 +3934,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4013,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4230,7 +4226,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4260,7 +4256,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4273,7 +4269,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4367,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,19 +4522,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4586,7 +4582,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4667,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4906,11 +4902,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4919,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4983,7 +4979,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5107,7 +5103,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5115,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5169,11 +5165,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5327,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5823,7 +5819,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5875,7 +5871,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6014,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6026,8 +6022,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6415,7 +6411,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6464,15 +6460,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6492,15 +6488,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6626,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6932,13 +6928,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-10-16 11:52+0100\n"
+        "POT-Creation-Date: 2023-10-24 13:33+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -360,11 +360,11 @@ msgstr  ""
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid   "--instance-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid   "--no-profiles cannot be used with --refresh"
 msgstr  ""
 
@@ -372,7 +372,7 @@ msgstr  ""
 msgid   "--project cannot be used with the query command"
 msgstr  ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
@@ -392,15 +392,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -432,7 +432,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -558,7 +558,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -665,7 +665,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -697,12 +697,12 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -720,7 +720,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -837,7 +837,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -916,7 +916,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -930,7 +930,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -984,7 +984,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734 lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56 lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1696 lxc/storage_volume.go:1823 lxc/storage_volume.go:1969 lxc/storage_volume.go:2073 lxc/storage_volume.go:2113 lxc/storage_volume.go:2206 lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734 lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56 lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1697 lxc/storage_volume.go:1824 lxc/storage_volume.go:1970 lxc/storage_volume.go:2074 lxc/storage_volume.go:2114 lxc/storage_volume.go:2207 lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1139,12 +1139,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1173,7 +1173,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1324,7 +1324,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1416,7 +1416,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1693 lxc/storage_volume.go:1808 lxc/storage_volume.go:1952 lxc/storage_volume.go:2061 lxc/storage_volume.go:2107 lxc/storage_volume.go:2204 lxc/storage_volume.go:2271 lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841 lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1699,7 +1699,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:469 lxc/network_load_balancer.go:470 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:469 lxc/network_load_balancer.go:470 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1709,7 +1709,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461 lxc/network_forward.go:463 lxc/network_load_balancer.go:464 lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997 lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721 lxc/storage_bucket.go:591 lxc/storage_volume.go:1879 lxc/storage_volume.go:1917
+#: lxc/cluster.go:408 lxc/network.go:1188 lxc/network_acl.go:461 lxc/network_forward.go:463 lxc/network_load_balancer.go:464 lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997 lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721 lxc/storage_bucket.go:591 lxc/storage_volume.go:1880 lxc/storage_volume.go:1918
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1772,7 +1772,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1784,11 +1784,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1918,16 +1918,12 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/copy.go:414
-msgid   "Failed to get the new instance name"
-msgstr  ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:360
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -2007,7 +2003,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2043,7 +2039,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2059,7 +2055,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2286,7 +2282,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2298,7 +2294,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2348,7 +2344,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2356,7 +2352,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2374,11 +2370,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2413,7 +2409,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2436,7 +2432,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2495,7 +2491,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2503,7 +2499,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2516,12 +2512,12 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:907 lxc/storage_volume.go:1108 lxc/storage_volume.go:1220 lxc/storage_volume.go:1729 lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1108 lxc/storage_volume.go:1220 lxc/storage_volume.go:1730 lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2849,7 +2845,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3248,7 +3244,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:370 lxc/storage.go:440 lxc/storage.go:695 lxc/storage.go:793 lxc/storage_bucket.go:107 lxc/storage_bucket.go:207 lxc/storage_bucket.go:283 lxc/storage_bucket.go:402 lxc/storage_bucket.go:477 lxc/storage_bucket.go:559 lxc/storage_bucket.go:651 lxc/storage_bucket.go:793 lxc/storage_bucket.go:874 lxc/storage_bucket.go:949 lxc/storage_bucket.go:1028 lxc/storage_bucket.go:1151 lxc/storage_volume.go:189 lxc/storage_volume.go:264 lxc/storage_volume.go:560 lxc/storage_volume.go:637 lxc/storage_volume.go:712 lxc/storage_volume.go:794 lxc/storage_volume.go:896 lxc/storage_volume.go:1097 lxc/storage_volume.go:1445 lxc/storage_volume.go:1718 lxc/storage_volume.go:1845 lxc/storage_volume.go:1991 lxc/storage_volume.go:2133 lxc/storage_volume.go:2228
+#: lxc/storage.go:194 lxc/storage.go:264 lxc/storage.go:370 lxc/storage.go:440 lxc/storage.go:695 lxc/storage.go:793 lxc/storage_bucket.go:107 lxc/storage_bucket.go:207 lxc/storage_bucket.go:283 lxc/storage_bucket.go:402 lxc/storage_bucket.go:477 lxc/storage_bucket.go:559 lxc/storage_bucket.go:651 lxc/storage_bucket.go:793 lxc/storage_bucket.go:874 lxc/storage_bucket.go:949 lxc/storage_bucket.go:1028 lxc/storage_bucket.go:1151 lxc/storage_volume.go:189 lxc/storage_volume.go:264 lxc/storage_volume.go:560 lxc/storage_volume.go:637 lxc/storage_volume.go:712 lxc/storage_volume.go:794 lxc/storage_volume.go:896 lxc/storage_volume.go:1097 lxc/storage_volume.go:1445 lxc/storage_volume.go:1719 lxc/storage_volume.go:1846 lxc/storage_volume.go:1992 lxc/storage_volume.go:2134 lxc/storage_volume.go:2229
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3364,7 +3360,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
+#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
 msgid   "NAME"
 msgstr  ""
 
@@ -3388,7 +3384,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid   "NO"
 msgstr  ""
 
@@ -3595,7 +3591,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3607,11 +3603,11 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -3682,11 +3678,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3727,7 +3723,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -3885,7 +3881,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -3909,7 +3905,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -3920,7 +3916,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4012,7 +4008,7 @@ msgstr  ""
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:382
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
@@ -4022,12 +4018,12 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898 lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916 lxc/remote.go:954
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4037,12 +4033,12 @@ msgstr  ""
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -4121,7 +4117,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4169,19 +4165,19 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4227,7 +4223,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4307,7 +4303,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid   "STATIC"
 msgstr  ""
 
@@ -4348,11 +4344,11 @@ msgstr  ""
 msgid   "Server authentication type (tls, candid, or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4520,18 +4516,18 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4595,7 +4591,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -4719,7 +4715,7 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid   "Show storage volume configurations"
 msgstr  ""
 
@@ -4727,7 +4723,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -4781,11 +4777,11 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
@@ -4939,7 +4935,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5187,7 +5183,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773 lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773 lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5231,7 +5227,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5275,7 +5271,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid   "URL"
 msgstr  ""
 
@@ -5416,7 +5412,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5468,7 +5464,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5511,7 +5507,7 @@ msgstr  ""
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -5597,7 +5593,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid   "YES"
 msgstr  ""
 
@@ -5609,8 +5605,8 @@ msgstr  ""
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: lxc/copy.go:89
-msgid   "You must specify a destination instance name when using --target"
+#: lxc/copy.go:101
+msgid   "You must specify a destination instance name"
 msgstr  ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -5973,7 +5969,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6005,7 +6001,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
@@ -6017,15 +6013,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
@@ -6045,15 +6041,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
@@ -6177,7 +6173,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid   "current"
 msgstr  ""
 
@@ -6436,12 +6432,12 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid   "n"
 msgstr  ""
 
@@ -6453,7 +6449,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6490,7 +6486,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -602,11 +602,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -635,15 +635,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -917,7 +917,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -949,12 +949,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1264,10 +1264,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1438,12 +1438,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1631,7 +1631,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1798,8 +1798,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1816,11 +1816,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2350,16 +2350,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2452,7 +2448,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2490,7 +2486,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2506,7 +2502,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2733,7 +2729,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2747,7 +2743,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2797,7 +2793,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2805,7 +2801,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2824,11 +2820,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2863,7 +2859,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2886,7 +2882,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2946,7 +2942,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2954,7 +2950,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2967,14 +2963,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3316,7 +3312,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3778,9 +3774,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3909,7 +3905,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3937,7 +3933,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4146,7 +4142,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4158,11 +4154,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4233,11 +4229,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4278,7 +4274,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4450,7 +4446,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4480,7 +4476,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4493,7 +4489,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4587,7 +4583,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4597,13 +4593,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4613,12 +4609,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4697,7 +4693,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4746,19 +4742,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4806,7 +4802,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4887,7 +4883,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4928,11 +4924,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5126,11 +5122,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5139,7 +5135,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5203,7 +5199,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5327,7 +5323,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5335,7 +5331,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5389,11 +5385,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5547,7 +5543,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5808,7 +5804,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5852,7 +5848,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5899,7 +5895,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6043,7 +6039,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6095,7 +6091,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6140,7 +6136,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6234,7 +6230,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6246,8 +6242,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6635,7 +6631,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6670,7 +6666,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6684,15 +6680,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6712,15 +6708,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6846,7 +6842,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7152,13 +7148,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7170,7 +7166,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7207,7 +7203,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -636,11 +636,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -710,7 +710,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -951,7 +951,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -983,12 +983,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1298,10 +1298,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1472,12 +1472,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1665,7 +1665,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1832,8 +1832,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1850,11 +1850,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2155,7 +2155,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2169,8 +2169,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2249,11 +2249,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2384,16 +2384,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2486,7 +2482,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2524,7 +2520,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2540,7 +2536,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2767,7 +2763,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2781,7 +2777,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2831,7 +2827,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2839,7 +2835,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2858,11 +2854,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2897,7 +2893,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2920,7 +2916,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2980,7 +2976,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2988,7 +2984,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3001,14 +2997,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3350,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3812,9 +3808,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3943,7 +3939,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3971,7 +3967,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4180,7 +4176,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4192,11 +4188,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4267,11 +4263,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4312,7 +4308,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4484,7 +4480,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4514,7 +4510,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4527,7 +4523,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4621,7 +4617,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4631,13 +4627,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4647,12 +4643,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4731,7 +4727,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4780,19 +4776,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4840,7 +4836,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4921,7 +4917,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4962,11 +4958,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5160,11 +5156,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5173,7 +5169,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5237,7 +5233,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5361,7 +5357,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5369,7 +5365,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5423,11 +5419,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5581,7 +5577,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5842,7 +5838,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5886,7 +5882,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5933,7 +5929,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6077,7 +6073,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6129,7 +6125,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6174,7 +6170,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6268,7 +6264,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6280,8 +6276,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6669,7 +6665,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6704,7 +6700,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6718,15 +6714,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6746,15 +6742,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6880,7 +6876,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7186,13 +7182,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7204,7 +7200,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7241,7 +7237,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -382,11 +382,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -729,12 +729,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1044,10 +1044,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1596,11 +1596,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1983,7 +1983,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1995,11 +1995,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2130,16 +2130,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2527,7 +2523,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2577,7 +2573,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2585,7 +2581,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2604,11 +2600,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2643,7 +2639,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2666,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2726,7 +2722,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2734,7 +2730,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2747,14 +2743,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3096,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3558,9 +3554,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3689,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3926,7 +3922,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3938,11 +3934,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4013,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4230,7 +4226,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4260,7 +4256,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4273,7 +4269,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4367,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,19 +4522,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4586,7 +4582,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4667,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4906,11 +4902,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4919,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4983,7 +4979,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5107,7 +5103,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5115,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5169,11 +5165,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5327,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5823,7 +5819,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5875,7 +5871,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6014,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6026,8 +6022,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6415,7 +6411,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6464,15 +6460,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6492,15 +6488,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6626,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6932,13 +6928,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -631,12 +631,12 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 #, fuzzy
 msgid "--no-profiles cannot be used with --refresh"
 msgstr "--refresh só pode ser usado com containers"
@@ -646,7 +646,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -968,7 +968,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1001,12 +1001,12 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -1026,7 +1026,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1144,7 +1144,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1227,7 +1227,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1319,10 +1319,10 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1504,12 +1504,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1538,7 +1538,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1712,7 +1712,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1891,8 +1891,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1909,11 +1909,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr "Descrição"
@@ -2235,7 +2235,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2249,8 +2249,8 @@ msgstr "Editar propriedades da imagem"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2318,7 +2318,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2330,11 +2330,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2465,16 +2465,12 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2568,7 +2564,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2606,7 +2602,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2622,7 +2618,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2868,7 +2864,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2882,7 +2878,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2934,7 +2930,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2942,7 +2938,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2961,11 +2957,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3000,7 +2996,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3023,7 +3019,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3083,7 +3079,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3092,7 +3088,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3105,14 +3101,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3463,7 +3459,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3958,9 +3954,9 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -4092,7 +4088,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4120,7 +4116,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4329,7 +4325,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4341,11 +4337,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4416,11 +4412,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,7 +4458,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4639,7 +4635,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4669,7 +4665,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4682,7 +4678,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4779,7 +4775,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
@@ -4789,13 +4785,13 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4805,12 +4801,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4897,7 +4893,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4950,19 +4946,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5017,7 +5013,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5101,7 +5097,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5142,11 +5138,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5352,11 +5348,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5365,7 +5361,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5435,7 +5431,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -5576,7 +5572,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5585,7 +5581,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5641,11 +5637,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5800,7 +5796,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6067,7 +6063,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6111,7 +6107,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6159,7 +6155,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6320,7 +6316,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6379,7 +6375,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6426,7 +6422,7 @@ msgstr "Editar arquivos no container"
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6520,7 +6516,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6532,8 +6528,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6960,7 +6956,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7000,7 +6996,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7015,16 +7011,16 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -7046,17 +7042,17 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
@@ -7133,8 +7129,9 @@ msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
 #: lxc/copy.go:37
+#, fuzzy
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
-msgstr ""
+msgstr "Criar perfis"
 
 #: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
 #, fuzzy
@@ -7197,7 +7194,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7503,13 +7500,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7521,7 +7518,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7558,7 +7555,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,11 +635,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -647,7 +647,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -965,7 +965,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -998,12 +998,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1316,10 +1316,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1526,7 +1526,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1701,7 +1701,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1877,8 +1877,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1895,11 +1895,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2213,7 +2213,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2227,8 +2227,8 @@ msgstr "Копирование образа: %s"
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2300,7 +2300,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2315,12 +2315,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2451,16 +2451,12 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2554,7 +2550,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2592,7 +2588,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2608,7 +2604,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2851,7 +2847,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2865,7 +2861,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2916,7 +2912,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2924,7 +2920,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -2946,11 +2942,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2987,7 +2983,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3010,7 +3006,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3070,7 +3066,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3079,7 +3075,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3092,14 +3088,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3456,7 +3452,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3955,9 +3951,9 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -4092,7 +4088,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4120,7 +4116,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4332,7 +4328,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4345,11 +4341,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4420,11 +4416,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4466,7 +4462,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4638,7 +4634,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4668,7 +4664,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4681,7 +4677,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4779,7 +4775,7 @@ msgstr "Копирование образа: %s"
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4789,13 +4785,13 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4805,12 +4801,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4895,7 +4891,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4946,21 +4942,21 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5011,7 +5007,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5096,7 +5092,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -5137,11 +5133,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5342,11 +5338,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5355,7 +5351,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5426,7 +5422,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -5563,7 +5559,7 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5572,7 +5568,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5628,12 +5624,12 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5791,7 +5787,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6052,7 +6048,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6096,7 +6092,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6144,7 +6140,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -6298,7 +6294,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6358,7 +6354,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6406,7 +6402,7 @@ msgstr "Копирование образа: %s"
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6500,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6512,8 +6508,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -7249,7 +7245,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7316,7 +7312,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7342,7 +7338,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7350,7 +7346,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7358,7 +7354,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7398,7 +7394,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -7406,7 +7402,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -7414,7 +7410,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -7664,7 +7660,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7970,13 +7966,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7988,7 +7984,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8025,7 +8021,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -386,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -733,12 +733,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1048,10 +1048,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1415,7 +1415,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1600,11 +1600,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1905,7 +1905,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1919,8 +1919,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1987,7 +1987,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1999,11 +1999,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2134,16 +2134,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2236,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2274,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2290,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2517,7 +2513,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2531,7 +2527,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2581,7 +2577,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2589,7 +2585,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2608,11 +2604,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2647,7 +2643,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2670,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2730,7 +2726,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2738,7 +2734,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2751,14 +2747,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3100,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3562,9 +3558,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3693,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3721,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3930,7 +3926,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3942,11 +3938,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4017,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4062,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4234,7 +4230,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4264,7 +4260,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4277,7 +4273,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4371,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4381,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4397,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4481,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4530,19 +4526,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4590,7 +4586,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4671,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4712,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4910,11 +4906,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4923,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4987,7 +4983,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5111,7 +5107,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5119,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5173,11 +5169,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5331,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5592,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5636,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5683,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5827,7 +5823,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5879,7 +5875,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5924,7 +5920,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6018,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6030,8 +6026,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6419,7 +6415,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6454,7 +6450,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6468,15 +6464,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6496,15 +6492,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6630,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6936,13 +6932,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6954,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6991,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -386,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -733,12 +733,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1048,10 +1048,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1415,7 +1415,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1600,11 +1600,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1905,7 +1905,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1919,8 +1919,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1987,7 +1987,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1999,11 +1999,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2134,16 +2134,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2236,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2274,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2290,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2517,7 +2513,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2531,7 +2527,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2581,7 +2577,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2589,7 +2585,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2608,11 +2604,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2647,7 +2643,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2670,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2730,7 +2726,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2738,7 +2734,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2751,14 +2747,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3100,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3562,9 +3558,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3693,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3721,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3930,7 +3926,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3942,11 +3938,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4017,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4062,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4234,7 +4230,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4264,7 +4260,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4277,7 +4273,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4371,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4381,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4397,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4481,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4530,19 +4526,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4590,7 +4586,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4671,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4712,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4910,11 +4906,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4923,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4987,7 +4983,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5111,7 +5107,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5119,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5173,11 +5169,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5331,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5592,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5636,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5683,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5827,7 +5823,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5879,7 +5875,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5924,7 +5920,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6018,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6030,8 +6026,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6419,7 +6415,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6454,7 +6450,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6468,15 +6464,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6496,15 +6492,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6630,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6936,13 +6932,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6954,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6991,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -382,11 +382,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -729,12 +729,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1044,10 +1044,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1411,7 +1411,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1596,11 +1596,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1901,7 +1901,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1915,8 +1915,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1983,7 +1983,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1995,11 +1995,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2130,16 +2130,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2527,7 +2523,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2577,7 +2573,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2585,7 +2581,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2604,11 +2600,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2643,7 +2639,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2666,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2726,7 +2722,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2734,7 +2730,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2747,14 +2743,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3096,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3558,9 +3554,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3689,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3926,7 +3922,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3938,11 +3934,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4013,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4230,7 +4226,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4260,7 +4256,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4273,7 +4269,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4367,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,19 +4522,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4586,7 +4582,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4667,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4906,11 +4902,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4919,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4983,7 +4979,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5107,7 +5103,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5115,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5169,11 +5165,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5327,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5823,7 +5819,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5875,7 +5871,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5920,7 +5916,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6014,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6026,8 +6022,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6415,7 +6411,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6450,7 +6446,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6464,15 +6460,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6492,15 +6488,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6626,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6932,13 +6928,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -386,11 +386,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -733,12 +733,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1048,10 +1048,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1415,7 +1415,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1600,11 +1600,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1905,7 +1905,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1919,8 +1919,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1987,7 +1987,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1999,11 +1999,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2134,16 +2134,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2236,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2274,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2290,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2517,7 +2513,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2531,7 +2527,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2581,7 +2577,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2589,7 +2585,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2608,11 +2604,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2647,7 +2643,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2670,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2730,7 +2726,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2738,7 +2734,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2751,14 +2747,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3100,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3562,9 +3558,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3693,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3721,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3930,7 +3926,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3942,11 +3938,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4017,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4062,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4234,7 +4230,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4264,7 +4260,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4277,7 +4273,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4371,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4381,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4397,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4481,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4530,19 +4526,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4590,7 +4586,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4671,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4712,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4910,11 +4906,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4923,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4987,7 +4983,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5111,7 +5107,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5119,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5173,11 +5169,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5331,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5592,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5636,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5683,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5827,7 +5823,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5879,7 +5875,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5924,7 +5920,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6018,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6030,8 +6026,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6419,7 +6415,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6454,7 +6450,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6468,15 +6464,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6496,15 +6492,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6630,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6936,13 +6932,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6954,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6991,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -517,11 +517,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -550,15 +550,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -832,7 +832,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -864,12 +864,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1179,10 +1179,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1353,12 +1353,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1713,8 +1713,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1731,11 +1731,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -2036,7 +2036,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2050,8 +2050,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2130,11 +2130,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2265,16 +2265,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2367,7 +2363,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2405,7 +2401,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2421,7 +2417,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2648,7 +2644,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2662,7 +2658,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2712,7 +2708,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2720,7 +2716,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2739,11 +2735,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2778,7 +2774,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2801,7 +2797,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2861,7 +2857,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2882,14 +2878,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3231,7 +3227,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3693,9 +3689,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3824,7 +3820,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3852,7 +3848,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4073,11 +4069,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4148,11 +4144,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4193,7 +4189,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4365,7 +4361,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4395,7 +4391,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4408,7 +4404,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4502,7 +4498,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4512,13 +4508,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4528,12 +4524,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4612,7 +4608,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4661,19 +4657,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4721,7 +4717,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4802,7 +4798,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4843,11 +4839,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5041,11 +5037,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5054,7 +5050,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5242,7 +5238,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5250,7 +5246,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5304,11 +5300,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5462,7 +5458,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5723,7 +5719,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5767,7 +5763,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5814,7 +5810,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5958,7 +5954,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6010,7 +6006,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6055,7 +6051,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6149,7 +6145,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6161,8 +6157,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6550,7 +6546,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6585,7 +6581,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6599,15 +6595,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6627,15 +6623,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6761,7 +6757,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -7067,13 +7063,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -7085,7 +7081,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7122,7 +7118,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-16 11:52+0100\n"
+"POT-Creation-Date: 2023-10-24 11:31+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -385,11 +385,11 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:154
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/copy.go:94
+#: lxc/copy.go:89
 msgid "--no-profiles cannot be used with --refresh"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:168
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:820 lxc/remote.go:876
+#: lxc/remote.go:838 lxc/remote.go:894
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:914
+#: lxc/remote.go:932
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:767
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:732
+#: lxc/remote.go:750
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:561
+#: lxc/remote.go:579
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:547
+#: lxc/remote.go:565
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -732,12 +732,12 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2331
+#: lxc/storage_volume.go:2332
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2408
+#: lxc/export.go:192 lxc/storage_volume.go:2409
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:855
+#: lxc/remote.go:873
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:444
+#: lxc/remote.go:462
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:601
+#: lxc/remote.go:619
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1047,10 +1047,10 @@ msgstr ""
 #: lxc/storage_volume.go:537 lxc/storage_volume.go:616
 #: lxc/storage_volume.go:860 lxc/storage_volume.go:1074
 #: lxc/storage_volume.go:1187 lxc/storage_volume.go:1617
-#: lxc/storage_volume.go:1696 lxc/storage_volume.go:1823
-#: lxc/storage_volume.go:1969 lxc/storage_volume.go:2073
-#: lxc/storage_volume.go:2113 lxc/storage_volume.go:2206
-#: lxc/storage_volume.go:2278 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:1697 lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1970 lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2114 lxc/storage_volume.go:2207
+#: lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid "Cluster member name"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:479
+#: lxc/remote.go:497
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:463
+#: lxc/remote.go:222 lxc/remote.go:481
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:474
+#: lxc/remote.go:492
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2277
+#: lxc/storage_volume.go:2278
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
+#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1599,11 +1599,11 @@ msgstr ""
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
 #: lxc/storage_volume.go:1060 lxc/storage_volume.go:1175
 #: lxc/storage_volume.go:1322 lxc/storage_volume.go:1406
-#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1693
-#: lxc/storage_volume.go:1808 lxc/storage_volume.go:1952
-#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2107
-#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2271
-#: lxc/storage_volume.go:2425 lxc/version.go:22 lxc/warning.go:29
+#: lxc/storage_volume.go:1613 lxc/storage_volume.go:1694
+#: lxc/storage_volume.go:1809 lxc/storage_volume.go:1953
+#: lxc/storage_volume.go:2062 lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2205 lxc/storage_volume.go:2272
+#: lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29
 #: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid "Description"
 msgstr ""
@@ -1904,7 +1904,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
 #: lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597
-#: lxc/storage_volume.go:1885 lxc/storage_volume.go:1923
+#: lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/network_forward.go:463 lxc/network_load_balancer.go:464
 #: lxc/network_peer.go:457 lxc/network_zone.go:403 lxc/network_zone.go:997
 #: lxc/profile.go:850 lxc/project.go:628 lxc/storage.go:721
-#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1879
-#: lxc/storage_volume.go:1917
+#: lxc/storage_bucket.go:591 lxc/storage_volume.go:1880
+#: lxc/storage_volume.go:1918
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2270 lxc/storage_volume.go:2271
+#: lxc/storage_volume.go:2271 lxc/storage_volume.go:2272
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1998,11 +1998,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2274
+#: lxc/storage_volume.go:2275
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2391
+#: lxc/export.go:152 lxc/storage_volume.go:2392
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2133,16 +2133,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/copy.go:414
-msgid "Failed to get the new instance name"
-msgstr ""
-
 #: lxc/file.go:1191
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:358
+#: lxc/copy.go:362
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2235,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2273,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:735
+#: lxc/remote.go:753
 msgid "GLOBAL"
 msgstr ""
 
@@ -2289,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:390
+#: lxc/remote.go:157 lxc/remote.go:408
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2516,7 +2512,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:2112
+#: lxc/snapshot.go:40 lxc/storage_volume.go:2113
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2530,7 +2526,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2111
+#: lxc/storage_volume.go:2112
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2580,7 +2576,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2425
+#: lxc/storage_volume.go:2426
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2588,7 +2584,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2424
+#: lxc/storage_volume.go:2425
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2607,11 +2603,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2433
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2498
+#: lxc/storage_volume.go:2499
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2646,7 +2642,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:417
+#: lxc/init.go:417
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2669,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:360
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2729,7 +2725,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1744
+#: lxc/move.go:134 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2737,7 +2733,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1740
+#: lxc/storage_volume.go:1741
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2750,14 +2746,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:331
+#: lxc/remote.go:349
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/storage_volume.go:907 lxc/storage_volume.go:1108
-#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1729
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:2002
+#: lxc/storage_volume.go:1220 lxc/storage_volume.go:1730
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:2003
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:663 lxc/remote.go:664
+#: lxc/remote.go:681 lxc/remote.go:682
 msgid "List the available remotes"
 msgstr ""
 
@@ -3561,9 +3557,9 @@ msgstr ""
 #: lxc/storage_volume.go:637 lxc/storage_volume.go:712
 #: lxc/storage_volume.go:794 lxc/storage_volume.go:896
 #: lxc/storage_volume.go:1097 lxc/storage_volume.go:1445
-#: lxc/storage_volume.go:1718 lxc/storage_volume.go:1845
-#: lxc/storage_volume.go:1991 lxc/storage_volume.go:2133
-#: lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:1719 lxc/storage_volume.go:1846
+#: lxc/storage_volume.go:1992 lxc/storage_volume.go:2134
+#: lxc/storage_volume.go:2229
 msgid "Missing pool name"
 msgstr ""
 
@@ -3692,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3720,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
+#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
 msgid "NO"
 msgstr ""
 
@@ -3929,7 +3925,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1757
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3941,11 +3937,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2313
+#: lxc/storage_volume.go:2314
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2146
+#: lxc/storage_volume.go:2147
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4016,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:731
+#: lxc/remote.go:749
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:733
+#: lxc/image.go:1057 lxc/remote.go:751
 msgid "PUBLIC"
 msgstr ""
 
@@ -4061,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:473
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4233,7 +4229,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1954
+#: lxc/storage_volume.go:1955
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4263,7 +4259,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:1813
+#: lxc/storage_volume.go:1814
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4276,7 +4272,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2064
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4370,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:380
+#: lxc/copy.go:384
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4380,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:781
+#: lxc/remote.go:799
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
-#: lxc/remote.go:936
+#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
+#: lxc/remote.go:954
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4396,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:851
+#: lxc/remote.go:869
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
+#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4480,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:822 lxc/remote.go:823
+#: lxc/remote.go:840 lxc/remote.go:841
 msgid "Remove remotes"
 msgstr ""
 
@@ -4529,19 +4525,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:751 lxc/remote.go:752
+#: lxc/remote.go:769 lxc/remote.go:770
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1693
+#: lxc/storage_volume.go:1694
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1692
+#: lxc/storage_volume.go:1693
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1769 lxc/storage_volume.go:1789
+#: lxc/storage_volume.go:1770 lxc/storage_volume.go:1790
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4589,7 +4585,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2203 lxc/storage_volume.go:2204
+#: lxc/storage_volume.go:2204 lxc/storage_volume.go:2205
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4670,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:734
+#: lxc/remote.go:752
 msgid "STATIC"
 msgstr ""
 
@@ -4711,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:471
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:597
+#: lxc/remote.go:615
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4909,11 +4905,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1808
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1808
+#: lxc/storage_volume.go:1809
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4922,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:915 lxc/remote.go:916
+#: lxc/remote.go:933 lxc/remote.go:934
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4986,7 +4982,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1824
+#: lxc/storage_volume.go:1825
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5110,7 +5106,7 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1951 lxc/storage_volume.go:1952
+#: lxc/storage_volume.go:1952 lxc/storage_volume.go:1953
 msgid "Show storage volume configurations"
 msgstr ""
 
@@ -5118,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:627 lxc/remote.go:628
+#: lxc/remote.go:645 lxc/remote.go:646
 msgid "Show the default remote"
 msgstr ""
 
@@ -5172,11 +5168,11 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2106 lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2107 lxc/storage_volume.go:2108
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1897
+#: lxc/storage_volume.go:1898
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
@@ -5330,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:877 lxc/remote.go:878
+#: lxc/remote.go:895 lxc/remote.go:896
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5591,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:128 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5635,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:336 lxc/move.go:307
+#: lxc/copy.go:340 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5682,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:730
+#: lxc/cluster.go:184 lxc/remote.go:748
 msgid "URL"
 msgstr ""
 
@@ -5826,7 +5822,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2060 lxc/storage_volume.go:2061
+#: lxc/storage_volume.go:2061 lxc/storage_volume.go:2062
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5878,7 +5874,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2075
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -5923,7 +5919,7 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2276
+#: lxc/export.go:42 lxc/storage_volume.go:2277
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6017,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
+#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
 msgid "YES"
 msgstr ""
 
@@ -6029,8 +6025,8 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:89
-msgid "You must specify a destination instance name when using --target"
+#: lxc/copy.go:100
+msgid "You must specify a destination instance name"
 msgstr ""
 
 #: lxc/copy.go:84 lxc/move.go:273 lxc/move.go:349 lxc/move.go:401
@@ -6418,7 +6414,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2423
+#: lxc/storage_volume.go:2424
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6453,7 +6449,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1691
+#: lxc/storage_volume.go:1692
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6467,15 +6463,15 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2202
+#: lxc/storage_volume.go:2203
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2269
+#: lxc/storage_volume.go:2270
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
@@ -6495,15 +6491,15 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2059
+#: lxc/storage_volume.go:2060
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1806
+#: lxc/storage_volume.go:1807
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1950
+#: lxc/storage_volume.go:1951
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
@@ -6629,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:720
+#: lxc/project.go:488 lxc/remote.go:738
 msgid "current"
 msgstr ""
 
@@ -6935,13 +6931,13 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2427
+#: lxc/storage_volume.go:2428
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "n"
 msgstr ""
 
@@ -6953,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:445
+#: lxc/remote.go:463
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6990,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:454
+#: lxc/remote.go:472
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
Removes unused code that determines generated name on copy or move (using copy).
It requires destination name to be provided, with only exception being when moving an instance to another remote (for example: `lxc move c1 remote2:`). In such case, the destination name is set to the source name.

Fixes #12338