### PR TITLE
doc: temporarily ignore MAAS links

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -121,7 +121,8 @@ linkcheck_ignore = [
     'https://web.libera.chat/#lxd',
     'http://localhost:8001',
     r'/lxd/en/latest/api/.*',
-    r'/api/.*'
+    r'/api/.*',
+    r'https://maas\.io/docs/.*'
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
There are currently some issues with the MAAS documentation. To prevent the link checker from complaining, temporarily exclude those links from the checks.