### PR TITLE
Authentication method constants

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -333,7 +333,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 		eventListeners:     make(map[string][]*EventListener),
 	}
 
-	if shared.ValueInSlice(args.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) {
+	if shared.ValueInSlice(args.AuthType, []string{api.AuthenticationMethodCandid, api.AuthenticationMethodOIDC}) {
 		server.RequireAuthenticated(true)
 	}
 
@@ -348,7 +348,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 	}
 
 	server.http = httpClient
-	if args.AuthType == "candid" {
+	if args.AuthType == api.AuthenticationMethodCandid {
 		server.setupBakeryClient()
 	} else if args.AuthType == api.AuthenticationMethodOIDC {
 		server.setupOIDCClient(args.OIDCTokens)

--- a/client/connection.go
+++ b/client/connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/simplestreams"
 )
@@ -332,7 +333,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 		eventListeners:     make(map[string][]*EventListener),
 	}
 
-	if shared.ValueInSlice(args.AuthType, []string{"candid", "oidc"}) {
+	if shared.ValueInSlice(args.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) {
 		server.RequireAuthenticated(true)
 	}
 
@@ -349,7 +350,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 	server.http = httpClient
 	if args.AuthType == "candid" {
 		server.setupBakeryClient()
-	} else if args.AuthType == "oidc" {
+	} else if args.AuthType == api.AuthenticationMethodOIDC {
 		server.setupOIDCClient(args.OIDCTokens)
 	}
 

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -34,7 +34,7 @@ func (r *ProtocolLXD) GetServer() (*api.Server, string, error) {
 
 	if !server.Public && len(server.AuthMethods) == 0 {
 		// TLS is always available for LXD servers
-		server.AuthMethods = []string{"tls"}
+		server.AuthMethods = []string{api.AuthenticationMethodTLS}
 	}
 
 	// Add the value to the cache

--- a/lxc/config/file.go
+++ b/lxc/config/file.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 )
 
 // LoadConfig reads the configuration from the config path; if the path does
@@ -28,7 +29,7 @@ func LoadConfig(path string) (*Config, error) {
 
 	for k, r := range c.Remotes {
 		if !r.Public && r.AuthType == "" {
-			r.AuthType = "tls"
+			r.AuthType = api.AuthenticationMethodTLS
 			c.Remotes[k] = r
 		}
 	}

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -104,7 +104,7 @@ func (c *Config) GetInstanceServer(name string) (lxd.InstanceServer, error) {
 	}
 
 	// HTTPs
-	if !shared.ValueInSlice(remote.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) && (args.TLSClientCert == "" || args.TLSClientKey == "") {
+	if !shared.ValueInSlice(remote.AuthType, []string{api.AuthenticationMethodCandid, api.AuthenticationMethodOIDC}) && (args.TLSClientCert == "" || args.TLSClientKey == "") {
 		return nil, fmt.Errorf("Missing TLS client certificate and key")
 	}
 
@@ -209,7 +209,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 		AuthType:  remote.AuthType,
 	}
 
-	if args.AuthType == "candid" {
+	if args.AuthType == api.AuthenticationMethodCandid {
 		args.AuthInteractor = []httpbakery.Interactor{
 			form.Interactor{Filler: schemaform.IOFiller{}},
 			httpbakery.WebBrowserInteractor{
@@ -304,7 +304,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 	}
 
 	// Stop here if no client certificate involved
-	if remote.Protocol == "simplestreams" || shared.ValueInSlice(remote.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) {
+	if remote.Protocol == "simplestreams" || shared.ValueInSlice(remote.AuthType, []string{api.AuthenticationMethodCandid, api.AuthenticationMethodOIDC}) {
 		return &args, nil
 	}
 

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 )
 
 // Remote holds details for communication with a remote daemon.
@@ -103,7 +104,7 @@ func (c *Config) GetInstanceServer(name string) (lxd.InstanceServer, error) {
 	}
 
 	// HTTPs
-	if !shared.ValueInSlice(remote.AuthType, []string{"candid", "oidc"}) && (args.TLSClientCert == "" || args.TLSClientKey == "") {
+	if !shared.ValueInSlice(remote.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) && (args.TLSClientCert == "" || args.TLSClientKey == "") {
 		return nil, fmt.Errorf("Missing TLS client certificate and key")
 	}
 
@@ -257,7 +258,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 		}
 
 		args.CookieJar = c.cookieJars[name]
-	} else if args.AuthType == "oidc" {
+	} else if args.AuthType == api.AuthenticationMethodOIDC {
 		if c.oidcTokens == nil {
 			c.oidcTokens = map[string]*oidc.Tokens[*oidc.IDTokenClaims]{}
 		}
@@ -303,7 +304,7 @@ func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 	}
 
 	// Stop here if no client certificate involved
-	if remote.Protocol == "simplestreams" || shared.ValueInSlice(remote.AuthType, []string{"candid", "oidc"}) {
+	if remote.Protocol == "simplestreams" || shared.ValueInSlice(remote.AuthType, []string{"candid", api.AuthenticationMethodOIDC}) {
 		return &args, nil
 	}
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -509,15 +509,15 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 
 	// If not specified, the preferred order of authentication is 1) OIDC 2) Candid 3) TLS.
 	if c.flagAuthType == "" {
-		if !srv.Public && shared.ValueInSlice("oidc", srv.AuthMethods) {
-			c.flagAuthType = "oidc"
+		if !srv.Public && shared.ValueInSlice(api.AuthenticationMethodOIDC, srv.AuthMethods) {
+			c.flagAuthType = api.AuthenticationMethodOIDC
 		} else if !srv.Public && shared.ValueInSlice("candid", srv.AuthMethods) {
 			c.flagAuthType = "candid"
 		} else {
 			c.flagAuthType = "tls"
 		}
 
-		if shared.ValueInSlice(c.flagAuthType, []string{"oidc", "candid"}) {
+		if shared.ValueInSlice(c.flagAuthType, []string{api.AuthenticationMethodOIDC, "candid"}) {
 			// Update the remote configuration
 			remote := conf.Remotes[server]
 			remote.AuthType = c.flagAuthType

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -497,7 +497,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		return conf.SaveConfig(c.global.confPath)
 	}
 
-	if c.flagAuthType == "candid" {
+	if c.flagAuthType == api.AuthenticationMethodCandid {
 		d.(lxd.InstanceServer).RequireAuthenticated(false)
 	}
 
@@ -511,13 +511,13 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 	if c.flagAuthType == "" {
 		if !srv.Public && shared.ValueInSlice(api.AuthenticationMethodOIDC, srv.AuthMethods) {
 			c.flagAuthType = api.AuthenticationMethodOIDC
-		} else if !srv.Public && shared.ValueInSlice("candid", srv.AuthMethods) {
-			c.flagAuthType = "candid"
+		} else if !srv.Public && shared.ValueInSlice(api.AuthenticationMethodCandid, srv.AuthMethods) {
+			c.flagAuthType = api.AuthenticationMethodCandid
 		} else {
 			c.flagAuthType = "tls"
 		}
 
-		if shared.ValueInSlice(c.flagAuthType, []string{api.AuthenticationMethodOIDC, "candid"}) {
+		if shared.ValueInSlice(c.flagAuthType, []string{api.AuthenticationMethodOIDC, api.AuthenticationMethodCandid}) {
 			// Update the remote configuration
 			remote := conf.Remotes[server]
 			remote.AuthType = c.flagAuthType
@@ -711,7 +711,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		if rc.AuthType == "candid" && rc.Domain != "" {
+		if rc.AuthType == api.AuthenticationMethodCandid && rc.Domain != "" {
 			rc.AuthType = fmt.Sprintf("%s (%s)", rc.AuthType, rc.Domain)
 		}
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -385,7 +385,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 	// Finally, actually add the remote, almost...  If the remote is a private
 	// HTTPS server then we need to ensure we have a client certificate before
 	// adding the remote server.
-	if rScheme != "unix" && !c.flagPublic && (c.flagAuthType == "tls" || c.flagAuthType == "") {
+	if rScheme != "unix" && !c.flagPublic && (c.flagAuthType == api.AuthenticationMethodTLS || c.flagAuthType == "") {
 		if !conf.HasClientCertificate() {
 			fmt.Fprintf(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
 			err = conf.GenerateClientCertificate()
@@ -412,7 +412,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		remote := conf.Remotes[server]
-		remote.AuthType = "tls"
+		remote.AuthType = api.AuthenticationMethodTLS
 
 		// Handle project.
 		project, err := c.findProject(d.(lxd.InstanceServer), c.flagProject)
@@ -514,7 +514,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		} else if !srv.Public && shared.ValueInSlice(api.AuthenticationMethodCandid, srv.AuthMethods) {
 			c.flagAuthType = api.AuthenticationMethodCandid
 		} else {
-			c.flagAuthType = "tls"
+			c.flagAuthType = api.AuthenticationMethodTLS
 		}
 
 		if shared.ValueInSlice(c.flagAuthType, []string{api.AuthenticationMethodOIDC, api.AuthenticationMethodCandid}) {
@@ -555,7 +555,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 
 	// Check if additional authentication is required.
 	if srv.Auth != "trusted" {
-		if c.flagAuthType == "tls" {
+		if c.flagAuthType == api.AuthenticationMethodTLS {
 			// Prompt for trust password
 			if c.flagPassword == "" {
 				fmt.Printf(i18n.G("Admin password (or token) for %s:")+" ", server)
@@ -597,7 +597,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(i18n.G("Server doesn't trust us after authentication"))
 		}
 
-		if c.flagAuthType == "tls" {
+		if c.flagAuthType == api.AuthenticationMethodTLS {
 			fmt.Println(i18n.G("Client certificate now trusted by server:"), server)
 		}
 	}
@@ -707,7 +707,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 			} else if rc.Protocol == "simplestreams" {
 				rc.AuthType = "none"
 			} else {
-				rc.AuthType = "tls"
+				rc.AuthType = api.AuthenticationMethodTLS
 			}
 		}
 

--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -45,7 +45,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		APIVersion:    version.APIVersion,
 		Public:        false,
 		Auth:          "trusted",
-		AuthMethods:   []string{"tls"},
+		AuthMethods:   []string{api.AuthenticationMethodTLS},
 	}
 
 	uname, err := shared.Uname()

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -172,7 +172,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 
 	i := 1
 
-	if shared.ValueInSlice("candid", apiServer.AuthMethods) {
+	if shared.ValueInSlice(api.AuthenticationMethodCandid, apiServer.AuthMethods) {
 		fmt.Printf("%d) Candid/RBAC based authentication\n", i)
 		availableAuthMethods = append(availableAuthMethods, authMethodCandid)
 		i++
@@ -242,7 +242,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 
 	switch authMethod {
 	case authMethodCandid:
-		authType = "candid"
+		authType = api.AuthenticationMethodCandid
 	case authMethodTLSCertificate, authMethodTLSTemporaryCertificate, authMethodTLSCertificateToken:
 		authType = "tls"
 	}

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -178,7 +178,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 		i++
 	}
 
-	if shared.ValueInSlice("tls", apiServer.AuthMethods) {
+	if shared.ValueInSlice(api.AuthenticationMethodTLS, apiServer.AuthMethods) {
 		fmt.Printf("%d) Use a certificate token\n", i)
 		availableAuthMethods = append(availableAuthMethods, authMethodTLSCertificateToken)
 		i++
@@ -189,7 +189,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 		availableAuthMethods = append(availableAuthMethods, authMethodTLSTemporaryCertificate)
 	}
 
-	if len(apiServer.AuthMethods) > 1 || shared.ValueInSlice("tls", apiServer.AuthMethods) {
+	if len(apiServer.AuthMethods) > 1 || shared.ValueInSlice(api.AuthenticationMethodTLS, apiServer.AuthMethods) {
 		authMethodInt, err := c.global.asker.AskInt("Please pick an authentication mechanism above: ", 1, int64(i), "", nil)
 		if err != nil {
 			return nil, "", err
@@ -244,7 +244,7 @@ func (c *cmdMigrate) askServer() (lxd.InstanceServer, string, error) {
 	case authMethodCandid:
 		authType = api.AuthenticationMethodCandid
 	case authMethodTLSCertificate, authMethodTLSTemporaryCertificate, authMethodTLSCertificateToken:
-		authType = "tls"
+		authType = api.AuthenticationMethodTLS
 	}
 
 	return c.connectTarget(serverURL, certPath, keyPath, authType, token)

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -153,7 +153,7 @@ func (m *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 
 	clientFingerprint := ""
 
-	if authType == "tls" {
+	if authType == api.AuthenticationMethodTLS {
 		var clientCrt []byte
 		var clientKey []byte
 
@@ -258,7 +258,7 @@ func (m *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 		return c, "", nil
 	}
 
-	if authType == "tls" {
+	if authType == api.AuthenticationMethodTLS {
 		if token != "" {
 			req := api.CertificatesPost{
 				Password: token,

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -191,7 +191,7 @@ func (m *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 
 		args.TLSClientCert = string(clientCrt)
 		args.TLSClientKey = string(clientKey)
-	} else if authType == "candid" {
+	} else if authType == api.AuthenticationMethodCandid {
 		args.AuthInteractor = []httpbakery.Interactor{
 			form.Interactor{Filler: schemaform.IOFiller{}},
 			httpbakery.WebBrowserInteractor{
@@ -242,7 +242,7 @@ func (m *cmdMigrate) connectTarget(url string, certPath string, keyPath string, 
 		}
 	}
 
-	if authType == "candid" {
+	if authType == api.AuthenticationMethodCandid {
 		c.RequireAuthenticated(false)
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -210,7 +210,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	// Get the authentication methods.
-	authMethods := []string{"tls"}
+	authMethods := []string{api.AuthenticationMethodTLS}
 	candidURL, _, _, _ := s.GlobalConfig.CandidServer()
 	rbacURL, _, _, _, _, _, _ := s.GlobalConfig.RBACServer()
 	if candidURL != "" || rbacURL != "" {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -219,7 +219,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 	oidcIssuer, oidcClientID, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
-		authMethods = append(authMethods, "oidc")
+		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
 
 	srv := api.ServerUntrusted{

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -214,7 +214,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	candidURL, _, _, _ := s.GlobalConfig.CandidServer()
 	rbacURL, _, _, _, _, _, _ := s.GlobalConfig.RBACServer()
 	if candidURL != "" || rbacURL != "" {
-		authMethods = append(authMethods, "candid")
+		authMethods = append(authMethods, api.AuthenticationMethodCandid)
 	}
 
 	oidcIssuer, oidcClientID, _ := s.GlobalConfig.OIDCServer()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -350,11 +350,11 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 
 		if info != nil && info.Identity != nil {
 			// Valid identity macaroon found.
-			return true, info.Identity.Id(), "candid", nil
+			return true, info.Identity.Id(), api.AuthenticationMethodCandid, nil
 		}
 
 		// Valid macaroon with no identity information.
-		return true, "", "candid", nil
+		return true, "", api.AuthenticationMethodCandid, nil
 	}
 
 	// Validate normal TLS access.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -67,6 +67,7 @@ import (
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/lxd/warnings"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/cancel"
 	"github.com/canonical/lxd/shared/idmap"
 	"github.com/canonical/lxd/shared/logger"
@@ -340,7 +341,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 			return false, "", "", err
 		}
 
-		return true, userName, "oidc", nil
+		return true, userName, api.AuthenticationMethodOIDC, nil
 	} else if d.candidVerifier != nil && d.candidVerifier.IsRequest(r) {
 		info, err := d.candidVerifier.Auth(r)
 		if err != nil {

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -1,0 +1,12 @@
+package api
+
+const (
+	// AuthenticationMethodTLS is the default authentication method for interacting with LXD remotely.
+	AuthenticationMethodTLS = "tls"
+
+	// AuthenticationMethodCandid is a macaroon based authentication method.
+	AuthenticationMethodCandid = "candid"
+
+	// AuthenticationMethodOIDC is a token based authentication method.
+	AuthenticationMethodOIDC = "oidc"
+)


### PR DESCRIPTION
Adds constants for authentication methods and replaces instances of `"tls"`, `"candid"`, and `"oidc"` where appropriate. This was requested for #12252 (https://github.com/canonical/lxd/pull/12252#discussion_r1369846524) but I'd rather not make that PR any larger. 