### PR TITLE
Drop `GetTLSConfig()` unused args

### DIFF
--- a/lxd/migration_connection.go
+++ b/lxd/migration_connection.go
@@ -37,7 +37,7 @@ func setupWebsocketDialer(certificate string) (*websocket.Dialer, error) {
 		}
 	}
 
-	config, err := shared.GetTLSConfig("", "", "", cert)
+	config, err := shared.GetTLSConfig(cert)
 	if err != nil {
 		return nil, fmt.Errorf("Failed configuring TLS: %w", err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -866,7 +866,7 @@ func doVolumeMigration(s *state.State, r *http.Request, requestProjectName strin
 		}
 	}
 
-	config, err := shared.GetTLSConfig("", "", "", cert)
+	config, err := shared.GetTLSConfig(cert)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -113,7 +113,7 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 		}
 	}
 
-	tlsConfig, err := shared.GetTLSConfig("", "", "", cert)
+	tlsConfig, err := shared.GetTLSConfig(cert)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -427,7 +427,7 @@ func CertFingerprintStr(c string) (string, error) {
 
 func GetRemoteCertificate(address string, useragent string) (*x509.Certificate, error) {
 	// Setup a permissive TLS config
-	tlsConfig, err := GetTLSConfig("", "", "", nil)
+	tlsConfig, err := GetTLSConfig(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/network.go
+++ b/shared/network.go
@@ -97,32 +97,11 @@ func finalizeTLSConfig(tlsConfig *tls.Config, tlsRemoteCert *x509.Certificate) {
 	}
 }
 
-func GetTLSConfig(tlsClientCertFile string, tlsClientKeyFile string, tlsClientCAFile string, tlsRemoteCert *x509.Certificate) (*tls.Config, error) {
+func GetTLSConfig(tlsRemoteCert *x509.Certificate) (*tls.Config, error) {
 	tlsConfig := InitTLSConfig()
 
-	// Client authentication
-	if tlsClientCertFile != "" && tlsClientKeyFile != "" {
-		cert, err := tls.LoadX509KeyPair(tlsClientCertFile, tlsClientKeyFile)
-		if err != nil {
-			return nil, err
-		}
-
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	}
-
-	if tlsClientCAFile != "" {
-		caCertificates, err := os.ReadFile(tlsClientCAFile)
-		if err != nil {
-			return nil, err
-		}
-
-		caPool := x509.NewCertPool()
-		caPool.AppendCertsFromPEM(caCertificates)
-
-		tlsConfig.RootCAs = caPool
-	}
-
 	finalizeTLSConfig(tlsConfig, tlsRemoteCert)
+
 	return tlsConfig, nil
 }
 


### PR DESCRIPTION
None of the callers of `GetTLSConfig()` provide any client cert, key or CA files, so drop those args.