### PR TITLE
lxd/instance/driver/qemu: replace sha1 by sha256 in blockNodeName()

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
@@ -8308,14 +8308,14 @@ func (d *qemu) deviceDetachUSB(usbDev deviceConfig.USBDeviceItem) error {
 // Block node names may only be up to 31 characters long, so use a hash if longer.
 func (d *qemu) blockNodeName(name string) string {
 	if len(name) > 27 {
-		// If the name is too long, hash it as SHA-1 (20 bytes).
-		// Then encode the SHA-1 binary hash as Base64 Raw URL format (maximum 27 characters).
-		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow,
-		// and keeps the length to 27 characters.
-		hash := sha1.New()
+		// If the name is too long, hash it as SHA-256 (32 bytes).
+		// Then encode the SHA-256 binary hash as Base64 Raw URL format and trim down to 27 chars.
+		// Raw URL avoids the use of "+" character and the padding "=" character which QEMU doesn't allow.
+		hash := sha256.New()
 		hash.Write([]byte(name))
 		binaryHash := hash.Sum(nil)
 		name = base64.RawURLEncoding.EncodeToString(binaryHash)
+		name = name[0:27]
 	}
 
 	// Apply the lxd_ prefix.


### PR DESCRIPTION
While this sha1 usage is perfectly fine as it's not used for its security properties, there is no downside to using sha256 instead. On the other hand, not using sha1 anywhere makes auditing this part trivial.