### PR TITLE
test/suites: Fixes wait_no_operations helper.

### DIFF
--- a/test/suites/operations.sh
+++ b/test/suites/operations.sh
@@ -5,7 +5,7 @@ wait_no_operations() {
   while [ "${retries}" -gt 0 ]; do
     echo "Waiting operations to complete (${retries} retries left) ..."
     count=$(lxc query "/1.0/operations?all-projects=true" | jq '.success | length')
-    if [ "${count}" -eq 0 ]; then
+    if [ -z "${count}" ] || [ "${count}" -eq 0 ]; then
       return 0
     fi
 


### PR DESCRIPTION
The `get_operations` test is failing for me on main because the result of `lxc query /1.0/operations?all-projects=true` is empty when there are no operations. If this is a problem with LXD and not just the test please let me know!