### PR TITLE
Remove shiftfs support

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -326,7 +326,6 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		"unpriv_fscaps":             fmt.Sprintf("%v", s.OS.VFS3Fscaps),
 		"seccomp_listener":          fmt.Sprintf("%v", s.OS.SeccompListener),
 		"seccomp_listener_continue": fmt.Sprintf("%v", s.OS.SeccompListenerContinue),
-		"shiftfs":                   fmt.Sprintf("%v", s.OS.Shiftfs),
 		"idmapped_mounts":           fmt.Sprintf("%v", s.OS.IdmappedMounts),
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -901,18 +901,6 @@ func (d *Daemon) init() error {
 		logger.Warnf(" - %s, %s", warningtype.TypeNames[warningtype.Type(w.TypeCode)], w.LastMessage)
 	}
 
-	// Detect shiftfs support.
-	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
-		logger.Info(" - shiftfs support: disabled")
-	} else {
-		if canUseShiftfs() && (util.SupportsFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil) {
-			d.os.Shiftfs = true
-			logger.Info(" - shiftfs support: yes")
-		} else {
-			logger.Info(" - shiftfs support: no")
-		}
-	}
-
 	// Detect idmapped mounts support.
 	if shared.IsTrue(os.Getenv("LXD_IDMAPPED_MOUNTS_DISABLE")) {
 		logger.Info(" - idmapped mounts kernel support: disabled")

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -640,7 +640,7 @@ func UnshiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet) error {
 	return shiftBtrfsRootfs(path, diskIdmap, false)
 }
 
-// shiftBtrfsRootfs shiftfs a filesystem that main include read-only subvolumes.
+// shiftBtrfsRootfs shifts a filesystem that may include read-only subvolumes.
 func shiftBtrfsRootfs(path string, diskIdmap *idmap.IdmapSet, shift bool) error {
 	var err error
 	roSubvols := []string{}

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -81,7 +81,6 @@ type OS struct {
 	PidFdSetns              bool
 	SeccompListener         bool
 	SeccompListenerContinue bool
-	Shiftfs                 bool
 	UeventInjection         bool
 	VFS3Fscaps              bool
 


### PR DESCRIPTION
This is quite self-explanatory. Only one question remain: should we use idmapped mounts for `MountOwnerShiftDynamic` instead of shiftfs or should we just remove it and only keep the `MountOwnerShiftStatic` mode ?