### PR TITLE
metrics: Fix label merging in metric sets

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8494,7 +8494,7 @@ func (d *lxc) getFSStats() (*metrics.MetricSet, error) {
 		FSType     string
 	}
 
-	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name})
+	out := metrics.NewMetricSet(nil)
 
 	mounts, err := os.ReadFile("/proc/mounts")
 	if err != nil {

--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -61,14 +61,24 @@ func (m *MetricSet) AddSamples(metricType MetricType, samples ...Sample) {
 	m.set[metricType] = append(m.set[metricType], samples...)
 }
 
-// Merge merges two MetricSets.
+// Merge merges two MetricSets. Missing labels from m's samples are added to all samples in n.
 func (m *MetricSet) Merge(metricSet *MetricSet) {
 	if metricSet == nil {
 		return
 	}
 
-	for k := range metricSet.set {
-		m.set[k] = append(m.set[k], metricSet.set[k]...)
+	for metricType := range metricSet.set {
+		for _, sample := range metricSet.set[metricType] {
+			// Add missing labels from m.
+			for k, v := range m.labels {
+				_, ok := sample.Labels[k]
+				if !ok {
+					sample.Labels[k] = v
+				}
+			}
+
+			m.set[metricType] = append(m.set[metricType], sample)
+		}
 	}
 }
 

--- a/lxd/metrics/metrics_test.go
+++ b/lxd/metrics/metrics_test.go
@@ -37,4 +37,22 @@ func TestMetricSet_FilterSamples(t *testing.T) {
 
 	// Should no longer contain the sample.
 	require.Equal(t, []Sample{}, m.set[CPUSecondsTotal])
+
+	m = NewMetricSet(map[string]string{"project": "default"})
+	m.AddSamples(CPUSecondsTotal, Sample{Value: 10})
+
+	n := NewMetricSet(map[string]string{"name": "jammy"})
+	n.AddSamples(CPUSecondsTotal, Sample{Value: 20})
+
+	m.Merge(n)
+
+	for _, sample := range m.set[CPUSecondsTotal] {
+		hasKeys := []string{}
+
+		for k := range sample.Labels {
+			hasKeys = append(hasKeys, k)
+		}
+
+		require.Contains(t, hasKeys, "project")
+	}
 }

--- a/test/suites/metrics.sh
+++ b/test/suites/metrics.sh
@@ -49,5 +49,8 @@ test_metrics() {
   lxc config set core.metrics_authentication=false
   curl -k -s -X GET "https://${metrics_addr}/1.0/metrics" | grep "name=\"c1\""
 
+  # Filesystem metrics should contain instance type
+  curl -k -s -X GET "https://${metrics_addr}/1.0/metrics" | grep "lxd_filesystem_avail_bytes" | grep "type=\"container\""
+
   lxc delete -f c1 c2
 }


### PR DESCRIPTION
This changes the Merge function to apply any missing labels from the
receiver to all samples from the argument.

This fixes an issue where filesystem stats would be missing certain
labels which were not explicitly set for the filesystem stats metric
set.
