### PR TITLE
lxc/network forward: Fix typo `port` to `ports`.

### DIFF
--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -543,7 +543,7 @@ func (c *cmdNetworkForwardEdit) helpTemplate() string {
 ### config:
 ###   target_address: 198.51.100.2
 ### description: test desc
-### port:
+### ports:
 ### - description: port forward
 ###   protocol: tcp
 ###   listen_port: 80,81,8080-8090

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -382,7 +382,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3713,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4009,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4363,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4373,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4389,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4704,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4915,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5111,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5584,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5675,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6010,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6934,7 +6934,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6983,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -282,7 +282,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -670,15 +670,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -716,7 +716,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -976,7 +976,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1249,7 +1249,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1523,12 +1523,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1557,7 +1557,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1912,8 +1912,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2608,7 +2608,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2646,7 +2646,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -3070,7 +3070,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3154,7 +3154,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3536,7 +3536,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4191,7 +4191,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4219,7 +4219,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4521,11 +4521,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4569,7 +4569,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4890,7 +4890,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4900,13 +4900,13 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -4916,12 +4916,12 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -5010,7 +5010,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5215,7 +5215,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -5256,11 +5256,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5482,7 +5482,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5704,7 +5704,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5928,7 +5928,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6200,7 +6200,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6244,7 +6244,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6292,7 +6292,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6664,7 +6664,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6677,7 +6677,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7872,7 +7872,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -8188,7 +8188,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -8200,7 +8200,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8237,7 +8237,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -703,7 +703,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -878,7 +878,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1225,12 +1225,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1592,8 +1592,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2158,7 +2158,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2251,7 +2251,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2305,7 +2305,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2698,7 +2698,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2779,7 +2779,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3130,7 +3130,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3740,7 +3740,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3768,7 +3768,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4066,11 +4066,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4112,7 +4112,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4421,7 +4421,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4431,13 +4431,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4447,12 +4447,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4535,7 +4535,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4585,7 +4585,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4768,11 +4768,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4986,7 +4986,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5197,7 +5197,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5410,7 +5410,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5671,7 +5671,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5762,7 +5762,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6114,7 +6114,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6126,7 +6126,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6726,7 +6726,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7038,7 +7038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7050,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7087,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -286,7 +286,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -619,7 +619,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
@@ -633,7 +633,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -655,15 +655,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -944,7 +944,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1122,7 +1122,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1219,7 +1219,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1475,12 +1475,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1847,8 +1847,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2511,7 +2511,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2964,7 +2964,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3046,7 +3046,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3406,7 +3406,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4028,7 +4028,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4056,7 +4056,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4352,11 +4352,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4398,7 +4398,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -4723,13 +4723,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4739,12 +4739,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4828,7 +4828,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4879,7 +4879,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5710,7 +5710,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5974,7 +5974,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6018,7 +6018,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6420,7 +6420,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6432,7 +6432,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7481,7 +7481,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7493,7 +7493,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7530,7 +7530,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -293,7 +293,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -626,7 +626,7 @@ msgstr "--empty ne peut être combiné avec le nom d'une image"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only ne peut être utilisé lorsque la source est un snapshot"
 
@@ -638,7 +638,7 @@ msgstr "--no-profiles ne peut pas être utilisé avec --refresh"
 msgid "--project cannot be used with the query command"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
@@ -661,17 +661,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -714,7 +714,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -865,7 +865,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -980,7 +980,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1159,7 +1159,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1244,7 +1244,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1258,7 +1258,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1527,12 +1527,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1561,7 +1561,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1937,8 +1937,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2544,7 +2544,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2641,7 +2641,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3114,7 +3114,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3197,7 +3197,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3622,7 +3622,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4277,7 +4277,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4305,7 +4305,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr "NON"
 
@@ -4619,11 +4619,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4668,7 +4668,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4992,7 +4992,7 @@ msgstr "Copie de l'image : %s"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -5002,13 +5002,13 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -5018,12 +5018,12 @@ msgstr "le serveur distant %s n'existe pas"
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -5112,7 +5112,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -5166,7 +5166,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5334,7 +5334,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5378,11 +5378,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5606,7 +5606,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5833,7 +5833,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6060,7 +6060,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6337,7 +6337,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6381,7 +6381,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6430,7 +6430,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr "URL"
 
@@ -6802,7 +6802,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr "OUI"
 
@@ -6815,7 +6815,7 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -8121,7 +8121,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8456,7 +8456,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -8469,7 +8469,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8506,7 +8506,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -174,7 +174,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -386,7 +386,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3689,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4013,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4667,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6014,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6026,7 +6026,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6626,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6938,7 +6938,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -288,7 +288,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -620,7 +620,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -654,15 +654,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -696,7 +696,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -943,7 +943,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1118,7 +1118,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1466,12 +1466,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1500,7 +1500,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1841,8 +1841,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2412,7 +2412,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2507,7 +2507,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2561,7 +2561,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2955,7 +2955,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3038,7 +3038,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3399,7 +3399,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4024,7 +4024,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4052,7 +4052,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4349,11 +4349,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4396,7 +4396,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4710,7 +4710,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
@@ -4720,13 +4720,13 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -4736,12 +4736,12 @@ msgstr "il remote %s non esiste"
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -4826,7 +4826,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4877,7 +4877,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5024,7 +5024,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -5065,11 +5065,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5281,7 +5281,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5970,7 +5970,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6014,7 +6014,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6062,7 +6062,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6412,7 +6412,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6424,7 +6424,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7164,7 +7164,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7476,7 +7476,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -7489,7 +7489,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7526,7 +7526,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -266,6 +266,7 @@ msgstr ""
 "configuration keys can be changed."
 
 #: lxc/network_forward.go:535
+#, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -278,7 +279,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -612,7 +613,7 @@ msgstr "--empty はイメージ名と同時に指定できません"
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--instance-only はコピー元がスナップショットの場合は指定できません"
 
@@ -624,7 +625,7 @@ msgstr "--no-profiles と --refresh は同時に指定できません"
 msgid "--project cannot be used with the query command"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
@@ -645,15 +646,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -688,7 +689,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -841,7 +842,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -954,7 +955,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1013,7 +1014,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1131,7 +1132,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1219,7 +1220,7 @@ msgid ""
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1233,7 +1234,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1503,12 +1504,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1537,7 +1538,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1867,8 +1868,8 @@ msgstr "警告を削除します"
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2458,7 +2459,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2566,7 +2567,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2604,7 +2605,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2620,7 +2621,7 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -3022,7 +3023,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3111,7 +3112,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3583,7 +3584,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4229,7 +4230,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4257,7 +4258,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr "NO"
 
@@ -4556,11 +4557,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4601,7 +4602,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4917,7 +4918,7 @@ msgstr "既存のストレージボリュームのコピーの再読込と更新
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
@@ -4927,13 +4928,13 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -4943,12 +4944,12 @@ msgstr "リモート %s は存在しません"
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -5027,7 +5028,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5076,7 +5077,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5225,7 +5226,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5267,11 +5268,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5535,7 +5536,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5741,7 +5742,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -5953,7 +5954,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6236,7 +6237,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -6282,7 +6283,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6331,7 +6332,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr "URL"
 
@@ -6683,7 +6684,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr "YES"
 
@@ -6695,7 +6696,7 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 #, fuzzy
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
@@ -7319,7 +7320,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr "現在値"
 
@@ -7771,7 +7772,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr "n"
 
@@ -7783,7 +7784,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7822,7 +7823,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr "y"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -382,7 +382,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3713,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4009,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4363,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4373,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4389,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4704,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4915,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5111,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5584,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5675,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6010,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6934,7 +6934,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6983,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-10-24 13:33+0200\n"
+        "POT-Creation-Date: 2023-10-27 23:30+0800\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -158,7 +158,7 @@ msgid   "### This is a YAML representation of the network forward.\n"
         "### config:\n"
         "###   target_address: 198.51.100.2\n"
         "### description: test desc\n"
-        "### port:\n"
+        "### ports:\n"
         "### - description: port forward\n"
         "###   protocol: tcp\n"
         "###   listen_port: 80,81,8080-8090\n"
@@ -392,15 +392,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -432,7 +432,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -558,7 +558,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -665,7 +665,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -837,7 +837,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -916,7 +916,7 @@ msgstr  ""
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -930,7 +930,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1139,12 +1139,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1173,7 +1173,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1416,7 +1416,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841 lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -2003,7 +2003,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2039,7 +2039,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2055,7 +2055,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2432,7 +2432,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2512,7 +2512,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2845,7 +2845,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3360,7 +3360,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
+#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
 msgid   "NAME"
 msgstr  ""
 
@@ -3384,7 +3384,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid   "NO"
 msgstr  ""
 
@@ -3678,11 +3678,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3723,7 +3723,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -4018,12 +4018,12 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916 lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898 lxc/remote.go:936
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4033,12 +4033,12 @@ msgstr  ""
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -4117,7 +4117,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4165,7 +4165,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4303,7 +4303,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid   "STATIC"
 msgstr  ""
 
@@ -4344,11 +4344,11 @@ msgstr  ""
 msgid   "Server authentication type (tls, candid, or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4527,7 +4527,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4723,7 +4723,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -4935,7 +4935,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5271,7 +5271,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid   "URL"
 msgstr  ""
 
@@ -5593,7 +5593,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid   "YES"
 msgstr  ""
 
@@ -6173,7 +6173,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid   "current"
 msgstr  ""
 
@@ -6437,7 +6437,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid   "n"
 msgstr  ""
 
@@ -6449,7 +6449,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6486,7 +6486,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -281,7 +281,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -602,7 +602,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -635,15 +635,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -917,7 +917,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1438,12 +1438,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1798,8 +1798,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2355,7 +2355,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2448,7 +2448,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2882,7 +2882,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2963,7 +2963,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3312,7 +3312,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3905,7 +3905,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3933,7 +3933,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4229,11 +4229,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4274,7 +4274,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4583,7 +4583,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4593,13 +4593,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4609,12 +4609,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4693,7 +4693,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4883,7 +4883,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4924,11 +4924,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5135,7 +5135,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5543,7 +5543,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5804,7 +5804,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5848,7 +5848,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5895,7 +5895,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6230,7 +6230,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6242,7 +6242,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6842,7 +6842,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7154,7 +7154,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7203,7 +7203,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -295,7 +295,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -636,7 +636,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -710,7 +710,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -951,7 +951,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1221,7 +1221,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1472,12 +1472,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1506,7 +1506,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1832,8 +1832,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2482,7 +2482,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2536,7 +2536,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2916,7 +2916,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3346,7 +3346,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3939,7 +3939,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3967,7 +3967,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4263,11 +4263,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4308,7 +4308,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4617,7 +4617,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4627,13 +4627,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4643,12 +4643,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4727,7 +4727,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4958,11 +4958,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5169,7 +5169,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5577,7 +5577,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5838,7 +5838,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5882,7 +5882,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5929,7 +5929,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6264,7 +6264,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6276,7 +6276,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6876,7 +6876,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7188,7 +7188,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7200,7 +7200,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7237,7 +7237,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -382,7 +382,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3713,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4009,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4363,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4373,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4389,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4704,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4915,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5111,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5584,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5675,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6010,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6934,7 +6934,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6983,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -290,7 +290,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -631,7 +631,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 #, fuzzy
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
@@ -646,7 +646,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--project cannot be used with the query command"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 #, fuzzy
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -968,7 +968,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1026,7 +1026,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1144,7 +1144,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1227,7 +1227,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1241,7 +1241,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1504,12 +1504,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1538,7 +1538,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1891,8 +1891,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2470,7 +2470,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2564,7 +2564,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2602,7 +2602,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2618,7 +2618,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3019,7 +3019,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3101,7 +3101,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3459,7 +3459,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4088,7 +4088,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4116,7 +4116,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4412,11 +4412,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4458,7 +4458,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4775,7 +4775,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
@@ -4785,13 +4785,13 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4801,12 +4801,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4893,7 +4893,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4946,7 +4946,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5097,7 +5097,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -5138,11 +5138,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5581,7 +5581,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5796,7 +5796,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6063,7 +6063,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6155,7 +6155,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6528,7 +6528,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7506,7 +7506,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7518,7 +7518,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7555,7 +7555,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -291,7 +291,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -635,7 +635,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -647,7 +647,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -669,15 +669,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -715,7 +715,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -965,7 +965,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1224,7 +1224,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1238,7 +1238,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1492,12 +1492,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1526,7 +1526,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1877,8 +1877,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2456,7 +2456,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2550,7 +2550,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2604,7 +2604,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3452,7 +3452,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -4088,7 +4088,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4116,7 +4116,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4416,11 +4416,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4462,7 +4462,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4775,7 +4775,7 @@ msgstr "Копирование образа: %s"
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4785,13 +4785,13 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4801,12 +4801,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4891,7 +4891,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -5092,7 +5092,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -5133,11 +5133,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5568,7 +5568,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6048,7 +6048,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6092,7 +6092,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6140,7 +6140,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6496,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6508,7 +6508,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7972,7 +7972,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7984,7 +7984,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8021,7 +8021,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -174,7 +174,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -386,7 +386,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3689,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4013,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4667,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6014,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6026,7 +6026,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6626,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6938,7 +6938,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -174,7 +174,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -386,7 +386,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3689,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4013,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4667,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6014,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6026,7 +6026,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6626,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6938,7 +6938,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -382,7 +382,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -394,7 +394,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -589,7 +589,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -697,7 +697,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1218,12 +1218,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1578,8 +1578,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2228,7 +2228,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2266,7 +2266,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3092,7 +3092,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3685,7 +3685,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3713,7 +3713,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4009,11 +4009,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4054,7 +4054,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4363,7 +4363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4373,13 +4373,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4389,12 +4389,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4473,7 +4473,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4663,7 +4663,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4704,11 +4704,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4915,7 +4915,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5111,7 +5111,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5584,7 +5584,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5675,7 +5675,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6010,7 +6010,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6022,7 +6022,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6622,7 +6622,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6934,7 +6934,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6983,7 +6983,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -174,7 +174,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -386,7 +386,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -419,15 +419,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -701,7 +701,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1222,12 +1222,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1582,8 +1582,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2232,7 +2232,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2666,7 +2666,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3689,7 +3689,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3717,7 +3717,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4013,11 +4013,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4367,7 +4367,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4377,13 +4377,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4393,12 +4393,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4477,7 +4477,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4667,7 +4667,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4708,11 +4708,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4919,7 +4919,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5632,7 +5632,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6014,7 +6014,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6026,7 +6026,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6626,7 +6626,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6938,7 +6938,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6950,7 +6950,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6987,7 +6987,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -247,7 +247,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -517,7 +517,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -550,15 +550,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -591,7 +591,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -832,7 +832,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1353,12 +1353,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1387,7 +1387,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1713,8 +1713,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2363,7 +2363,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2797,7 +2797,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3227,7 +3227,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3820,7 +3820,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3848,7 +3848,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4144,11 +4144,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4189,7 +4189,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4498,7 +4498,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4508,13 +4508,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4524,12 +4524,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4608,7 +4608,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4657,7 +4657,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4798,7 +4798,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4839,11 +4839,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5050,7 +5050,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5246,7 +5246,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5458,7 +5458,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5719,7 +5719,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5763,7 +5763,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5810,7 +5810,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6157,7 +6157,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6757,7 +6757,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -7069,7 +7069,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7118,7 +7118,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-10-24 11:31+0200\n"
+"POT-Creation-Date: 2023-10-27 23:30+0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -173,7 +173,7 @@ msgid ""
 "### config:\n"
 "###   target_address: 198.51.100.2\n"
 "### description: test desc\n"
-"### port:\n"
+"### ports:\n"
 "### - description: port forward\n"
 "###   protocol: tcp\n"
 "###   listen_port: 80,81,8080-8090\n"
@@ -385,7 +385,7 @@ msgstr ""
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
-#: lxc/copy.go:154
+#: lxc/copy.go:155
 msgid "--instance-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "--project cannot be used with the query command"
 msgstr ""
 
-#: lxc/copy.go:168
+#: lxc/copy.go:166
 msgid "--refresh can only be used with instances"
 msgstr ""
 
@@ -418,15 +418,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:894
+#: lxc/remote.go:820 lxc/remote.go:876
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:932
+#: lxc/remote.go:914
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:767
+#: lxc/remote.go:749
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:732
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -592,7 +592,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:579
+#: lxc/remote.go:561
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -700,7 +700,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:565
+#: lxc/remote.go:547
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:137 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:873
+#: lxc/remote.go:855
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:444
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:619
+#: lxc/remote.go:601
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1221,12 +1221,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:497
+#: lxc/remote.go:479
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:222 lxc/remote.go:481
+#: lxc/remote.go:222 lxc/remote.go:463
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:492
+#: lxc/remote.go:474
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1581,8 +1581,8 @@ msgstr ""
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
 #: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:646 lxc/remote.go:682 lxc/remote.go:770 lxc/remote.go:841
-#: lxc/remote.go:896 lxc/remote.go:934 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
+#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:362
+#: lxc/copy.go:360
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2231,7 +2231,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:686
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:668
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:735
 msgid "GLOBAL"
 msgstr ""
 
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:157 lxc/remote.go:408
+#: lxc/remote.go:157 lxc/remote.go:390
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:342
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:331
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:681 lxc/remote.go:682
+#: lxc/remote.go:663 lxc/remote.go:664
 msgid "List the available remotes"
 msgstr ""
 
@@ -3688,7 +3688,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:747 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:729 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3716,7 +3716,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:703 lxc/remote.go:708 lxc/remote.go:713
+#: lxc/project.go:481 lxc/remote.go:685 lxc/remote.go:690 lxc/remote.go:695
 msgid "NO"
 msgstr ""
 
@@ -4012,11 +4012,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:749
+#: lxc/remote.go:731
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:751
+#: lxc/image.go:1057 lxc/remote.go:733
 msgid "PUBLIC"
 msgstr ""
 
@@ -4057,7 +4057,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:473
+#: lxc/remote.go:455
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:384
+#: lxc/copy.go:382
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
@@ -4376,13 +4376,13 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:799
+#: lxc/remote.go:781
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:790 lxc/remote.go:861 lxc/remote.go:916
-#: lxc/remote.go:954
+#: lxc/project.go:769 lxc/remote.go:772 lxc/remote.go:843 lxc/remote.go:898
+#: lxc/remote.go:936
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -4392,12 +4392,12 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:869
+#: lxc/remote.go:851
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:794 lxc/remote.go:865 lxc/remote.go:958
+#: lxc/remote.go:776 lxc/remote.go:847 lxc/remote.go:940
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -4476,7 +4476,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:840 lxc/remote.go:841
+#: lxc/remote.go:822 lxc/remote.go:823
 msgid "Remove remotes"
 msgstr ""
 
@@ -4525,7 +4525,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:769 lxc/remote.go:770
+#: lxc/remote.go:751 lxc/remote.go:752
 msgid "Rename remotes"
 msgstr ""
 
@@ -4666,7 +4666,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:752
+#: lxc/remote.go:734
 msgid "STATIC"
 msgstr ""
 
@@ -4707,11 +4707,11 @@ msgstr ""
 msgid "Server authentication type (tls, candid, or oidc)"
 msgstr ""
 
-#: lxc/remote.go:471
+#: lxc/remote.go:453
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:615
+#: lxc/remote.go:597
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4918,7 +4918,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:933 lxc/remote.go:934
+#: lxc/remote.go:915 lxc/remote.go:916
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5114,7 +5114,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:627 lxc/remote.go:628
 msgid "Show the default remote"
 msgstr ""
 
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:895 lxc/remote.go:896
+#: lxc/remote.go:877 lxc/remote.go:878
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:129 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:130 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5631,7 +5631,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:340 lxc/move.go:307
+#: lxc/copy.go:338 lxc/move.go:307
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5678,7 +5678,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:748
+#: lxc/cluster.go:184 lxc/remote.go:730
 msgid "URL"
 msgstr ""
 
@@ -6013,7 +6013,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:705 lxc/remote.go:710 lxc/remote.go:715
+#: lxc/project.go:483 lxc/remote.go:687 lxc/remote.go:692 lxc/remote.go:697
 msgid "YES"
 msgstr ""
 
@@ -6025,7 +6025,7 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:100
+#: lxc/copy.go:101
 msgid "You must specify a destination instance name"
 msgstr ""
 
@@ -6625,7 +6625,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:738
+#: lxc/project.go:488 lxc/remote.go:720
 msgid "current"
 msgstr ""
 
@@ -6937,7 +6937,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:470
+#: lxc/remote.go:452
 msgid "n"
 msgstr ""
 
@@ -6949,7 +6949,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:445
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6986,7 +6986,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:454
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
Related documentation:  
https://documentation.ubuntu.com/lxd/en/latest/howto/network_forwards/
