### PR TITLE
doc: add page title for related links

### DIFF
--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -1,6 +1,6 @@
 ---
 discourse: 8767,7519,9281
-relatedlinks: https://ubuntu.com/blog/lxd-virtual-machines-an-overview
+relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)'
 ---
 
 (expl-instances)=

--- a/doc/howto/images_create.md
+++ b/doc/howto/images_create.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd
+relatedlinks: '[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)'
 ---
 
 (images-create)=

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://ubuntu.com/lxd, https://ubuntu.com/blog/open-source-for-beginners-dev-environment-with-lxd
+relatedlinks: '[Run&#32;system&#32;containers&#32;with&#32;LXD](https://ubuntu.com/lxd), [Open&#32;source&#32;for&#32;beginners:&#32;setting&#32;up&#32;your&#32;dev&#32;environment&#32;with&#32;LXD](https://ubuntu.com/blog/open-source-for-beginners-dev-environment-with-lxd)'
 ---
 
 # LXD

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd
+relatedlinks: '[How&#32;to&#32;install&#32;a&#32;Windows&#32;11&#32;VM&#32;using&#32;LXD](https://ubuntu.com/tutorials/how-to-install-a-windows-11-vm-using-lxd)'
 ---
 
 (instances)=

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://ubuntu.com/tutorials/introduction-to-lxd-projects
+relatedlinks: '[Introduction&#32;to&#32;LXD&#32;projects](https://ubuntu.com/tutorials/introduction-to-lxd-projects)'
 ---
 
 (projects)=

--- a/doc/restapi_landing.md
+++ b/doc/restapi_landing.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://ubuntu.com/blog/directly-interacting-with-the-lxd-api
+relatedlinks: '[Directly&#32;interacting&#32;with&#32;the&#32;LXD&#32;API](https://ubuntu.com/blog/directly-interacting-with-the-lxd-api)'
 ---
 
 (restapi)=


### PR DESCRIPTION
Some ubuntu.com pages recently started returning errors when trying to retrieve the page title.
Until this is fixed, work around this problem by explicitly specifying the title for related links.