### PR TITLE
config: Ensure config key values are reset to their default

### DIFF
--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -223,6 +223,12 @@ func (m *Map) set(name string, value string, initial bool) (bool, error) {
 		return false, fmt.Errorf("unknown key")
 	}
 
+	// When unsetting a config key, the value argument will be empty.
+	// This ensures that the default value is set if the provided value is empty.
+	if value == "" {
+		value = key.Default
+	}
+
 	err := key.validate(value)
 	if err != nil {
 		return false, err

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -233,6 +233,13 @@ test_config_profiles() {
     false
   fi
 
+  # Test unsetting config keys
+  lxc config set core.metrics_authentication false
+  [ "$(lxc config get core.metrics_authentication)" = "false" ]
+
+  lxc config unset core.metrics_authentication
+  [ -z "$(lxc config get core.metrics_authentication)" ]
+
   testunixdevs
 
   testloopmounts


### PR DESCRIPTION
When unsetting a config key, the value should be reset correctly to
the default value.

Fixes #12478
