### PR TITLE
Fix idmapped mount layer on intercepted mounts

### DIFF
--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -449,7 +449,7 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -624,7 +624,7 @@ var seccompPath = shared.VarPath("security", "seccomp")
 
 // ProfilePath returns the seccomp path for the instance.
 func ProfilePath(c Instance) string {
-	return path.Join(seccompPath, project.Instance(c.Project().Name, c.Name()))
+	return filepath.Join(seccompPath, project.Instance(c.Project().Name, c.Name()))
 }
 
 // InstanceNeedsPolicy returns whether the instance needs a policy or not.


### PR DESCRIPTION
Ported from https://github.com/lxc/incus/pull/197

This PR fixes an issue of `mount` syscall interception when `security.syscalls.intercept.mount.shift` is `true` and we mount block-device based filesystem inside the container (with a new superblock, not bindmount). Without this PR only bindmount case works properly in combination with enabled `security.syscalls.intercept.mount.shift`.