### PR TITLE
Restrict user.* keys

### DIFF
--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/canonical/lxd/shared"
 )
@@ -203,6 +205,13 @@ func (m *Map) update(values map[string]string) ([]string, error) {
 func (m *Map) set(name string, value string, initial bool) (bool, error) {
 	// Bypass schema for user.* keys
 	if shared.IsUserConfig(name) {
+		for _, r := range strings.TrimPrefix(name, "user.") {
+			// Only allow letters, digits, and punctuation characters.
+			if !unicode.In(r, unicode.Letter, unicode.Digit, unicode.Punct) {
+				return false, fmt.Errorf("Invalid key name")
+			}
+		}
+
 		current, ok := m.values[name]
 		if ok && value == current {
 			// Value is unchanged

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -240,6 +240,11 @@ test_config_profiles() {
   lxc config unset core.metrics_authentication
   [ -z "$(lxc config get core.metrics_authentication)" ]
 
+  # Validate user.* keys
+  ! lxc config set user.⍾ foo || false
+  lxc config set user.foo bar
+  lxc config unset user.foo
+
   testunixdevs
 
   testloopmounts


### PR DESCRIPTION
This restricts `user.*` keys to only include letters, digits, and punctuation characters.

Fixes #12308
