### PR TITLE
Fix bulk unfreezing, and add `resume` (or `unfreeze`) command

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -57,6 +57,28 @@ func (c *cmdPause) Command() *cobra.Command {
 	return cmd
 }
 
+// Resume.
+type cmdResume struct {
+	global *cmdGlobal
+	action *cmdAction
+}
+
+// The function Command() returns a cobra.Command object representing the "resume" command.
+// It is used to resume (or unfreeze) one or more instances specified by the user.
+func (c *cmdResume) Command() *cobra.Command {
+	cmdAction := cmdAction{global: c.global}
+	c.action = &cmdAction
+
+	cmd := c.action.Command("resume")
+	cmd.Use = usage("resume", i18n.G("[<remote>:]<instance> [[<remote>:]<instance>...]"))
+	cmd.Short = i18n.G("Resume instances")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Resume instances`))
+	cmd.Aliases = []string{"unfreeze"}
+
+	return cmd
+}
+
 // Restart.
 type cmdRestart struct {
 	global *cmdGlobal
@@ -153,9 +175,11 @@ func (c *cmdAction) doActionAll(action string, resource remoteResource) error {
 		return err
 	}
 
-	// Pause is called freeze.
+	// Pause is called freeze, resume is called unfreeze.
 	if action == "pause" {
 		action = "freeze"
+	} else if action == "resume" {
+		action = "unfreeze"
 	}
 
 	// Only store state if asked to.

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -227,6 +227,10 @@ For help with any of those, simply call them with --help.`))
 	restoreCmd := cmdRestore{global: &globalCmd}
 	app.AddCommand(restoreCmd.Command())
 
+	// resume sub-command
+	resumeCmd := cmdResume{global: &globalCmd}
+	app.AddCommand(resumeCmd.Command())
+
 	// snapshot sub-command
 	snapshotCmd := cmdSnapshot{global: &globalCmd}
 	app.AddCommand(snapshotCmd.Command())

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -136,7 +136,7 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 			}
 
 		case shared.Unfreeze:
-			if inst.IsRunning() {
+			if !inst.IsFrozen() {
 				continue
 			}
 		}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -362,15 +362,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1503,23 +1503,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2579,7 +2579,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4566,11 +4566,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4605,6 +4605,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4630,7 +4634,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5049,7 +5053,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5192,7 +5196,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5228,7 +5232,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5302,7 +5306,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5551,7 +5555,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5567,7 +5571,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5587,7 +5591,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5647,7 +5651,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6236,7 +6240,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6652,7 +6657,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -607,17 +607,17 @@ msgstr "- Partition %d"
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1054,7 +1054,7 @@ msgstr "Ungültige Abbild Eigenschaft: %s\n"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1837,23 +1837,23 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2574,7 +2574,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2926,7 +2926,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2944,7 +2944,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2983,7 +2983,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4192,7 +4192,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4551,7 +4551,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -5110,12 +5110,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5153,6 +5153,11 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/console.go:43
 #, fuzzy
 msgid "Retrieve the instance's console log"
@@ -5181,7 +5186,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5630,7 +5635,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5789,7 +5794,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5827,7 +5832,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 #, fuzzy
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5906,7 +5911,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6165,7 +6170,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6181,7 +6186,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
@@ -6203,7 +6208,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6263,7 +6268,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -7094,7 +7099,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -7902,7 +7908,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -779,7 +779,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1517,23 +1517,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2218,7 +2218,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2559,7 +2559,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2577,7 +2577,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2615,7 +2615,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3742,7 +3742,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4096,7 +4096,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4629,11 +4629,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4668,6 +4668,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4694,7 +4698,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5127,7 +5131,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5279,7 +5283,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5315,7 +5319,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5389,7 +5393,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5638,7 +5642,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5674,7 +5678,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5734,7 +5738,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6340,7 +6344,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6756,7 +6761,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -597,16 +597,16 @@ msgstr "- Partición %d"
 msgid "- Port %d (%s)"
 msgstr "- Puerto %d (%s)"
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1020,7 +1020,7 @@ msgstr "Propiedad mala: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 #, fuzzy
 msgid "Both --all and instance name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
@@ -1772,23 +1772,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creando el contenedor"
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4923,12 +4923,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "Aliases:"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4965,6 +4965,11 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "Aliases:"
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5426,7 +5431,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5578,7 +5583,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
@@ -5615,7 +5620,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5689,7 +5694,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5941,7 +5946,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5957,7 +5962,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5977,7 +5982,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6037,7 +6042,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6692,7 +6697,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7199,7 +7205,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,16 +605,16 @@ msgstr "- Partition %d"
 msgid "- Port %d (%s)"
 msgstr "- Port %d (%s)"
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 "--console ne peut être pas utilisée tant que l'arrêt de l'instance est forcé"
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr "--console ne peut être utilisé avec --all"
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
@@ -1058,7 +1058,7 @@ msgstr "Mauvaise propriété : %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1862,23 +1862,23 @@ msgstr "Copie de l'image : %s"
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2606,7 +2606,7 @@ msgstr "Forcer l'allocation d'un pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -2983,7 +2983,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3024,7 +3024,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -3197,7 +3197,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -4278,7 +4278,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 #, fuzzy
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4650,7 +4650,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5212,12 +5212,12 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "Création du conteneur"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 #, fuzzy
 msgid ""
 "Restart instances\n"
@@ -5272,6 +5272,11 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/console.go:43
 #, fuzzy
 msgid "Retrieve the instance's console log"
@@ -5300,7 +5305,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5754,7 +5759,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -5919,7 +5924,7 @@ msgstr "Instantanés :"
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5958,7 +5963,7 @@ msgstr "à suivi d'état"
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 #, fuzzy
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6037,7 +6042,7 @@ msgstr "Image copiée avec succès !"
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -6300,7 +6305,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6316,7 +6321,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 #, fuzzy
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
@@ -6338,7 +6343,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
@@ -6400,7 +6405,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -7274,7 +7279,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -8152,7 +8158,7 @@ msgstr ""
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1507,23 +1507,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2583,7 +2583,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4570,11 +4570,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4609,6 +4609,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4634,7 +4638,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5196,7 +5200,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5232,7 +5236,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5306,7 +5310,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5555,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5571,7 +5575,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5591,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6240,7 +6244,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6656,7 +6661,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -599,15 +599,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -1019,7 +1019,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1766,23 +1766,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Creazione del container in corso"
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2831,7 +2831,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -4026,7 +4026,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4921,12 +4921,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4963,6 +4963,11 @@ msgstr "Il nome del container è: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "Creazione del container in corso"
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4990,7 +4995,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5420,7 +5425,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5572,7 +5577,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -5610,7 +5615,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5684,7 +5689,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
@@ -5937,7 +5942,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5953,7 +5958,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5973,7 +5978,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6033,7 +6038,7 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6687,7 +6692,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "Creazione del container in corso"
@@ -7194,7 +7200,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -594,15 +594,15 @@ msgstr "- パーティション %d"
 msgid "- Port %d (%s)"
 msgstr "- ポート %d (%s)"
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "インスタンスの強制シャットダウンの際は --console は使えません"
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr "--console と --all は同時に指定できません"
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
@@ -1034,7 +1034,7 @@ msgstr "不正なイメージプロパティ形式: %s"
 msgid "Bond:"
 msgstr "ボンディング:"
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr "--all とインスタンス名を両方同時に指定することはできません"
 
@@ -1794,23 +1794,23 @@ msgstr "ストレージボリュームを削除します"
 msgid "Delete warning"
 msgstr "警告を削除します"
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2520,7 +2520,7 @@ msgstr "強制的に擬似端末を割り当てます"
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr "インスタンスを強制停止します"
 
@@ -2878,7 +2878,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2896,7 +2896,7 @@ msgstr "設定されている自動でのストレージボリュームの有効
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
@@ -2934,7 +2934,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
@@ -3114,7 +3114,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -4233,7 +4233,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
@@ -4588,7 +4588,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5123,11 +5123,11 @@ msgstr "ユーザの確認を要求する"
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr "インスタンスを再起動します"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5168,6 +5168,11 @@ msgstr "クラスターメンバーをリストアしています: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "インスタンスを一覧表示します"
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr "インスタンスのコンソールログを取得します"
@@ -5193,7 +5198,7 @@ msgstr "ロール（admin または read-only）"
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
@@ -5681,7 +5686,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -5824,7 +5829,7 @@ msgstr "スナップショット:"
 msgid "Socket %d:"
 msgstr "ソケット %d:"
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
@@ -5860,7 +5865,7 @@ msgstr "ステートフル"
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
@@ -5934,7 +5939,7 @@ msgstr "ストレージボリュームのコピーが成功しました!"
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
@@ -6190,7 +6195,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6215,7 +6220,7 @@ msgstr ""
 msgid "Threads:"
 msgstr "スレッド:"
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
@@ -6238,7 +6243,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6303,7 +6308,7 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -6915,7 +6920,8 @@ msgstr "[<remote>:]<instance> <template>"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr "[<remote>:]<instance> [<snapshot name>]"
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 
@@ -7351,7 +7357,7 @@ msgstr "ドライバ"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -362,15 +362,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1503,23 +1503,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2579,7 +2579,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4566,11 +4566,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4605,6 +4605,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4630,7 +4634,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5049,7 +5053,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5192,7 +5196,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5228,7 +5232,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5302,7 +5306,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5551,7 +5555,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5567,7 +5571,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5587,7 +5591,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5647,7 +5651,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6236,7 +6240,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6652,7 +6657,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-11-07 10:34+0100\n"
+        "POT-Creation-Date: 2023-11-08 11:11+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -340,15 +340,15 @@ msgstr  ""
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid   "--console can't be used while forcing instance shutdown"
 msgstr  ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid   "--console can't be used with --all"
 msgstr  ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid   "--console only works with a single instance"
 msgstr  ""
 
@@ -739,7 +739,7 @@ msgstr  ""
 msgid   "Bond:"
 msgstr  ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid   "Both --all and instance name given"
 msgstr  ""
 
@@ -1416,7 +1416,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97 lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1982,7 +1982,7 @@ msgstr  ""
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid   "Force the instance to stop"
 msgstr  ""
 
@@ -2296,7 +2296,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2312,7 +2312,7 @@ msgstr  ""
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid   "Ignore the instance state"
 msgstr  ""
 
@@ -2350,7 +2350,7 @@ msgstr  ""
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid   "Immediately attach to the console"
 msgstr  ""
 
@@ -2513,7 +2513,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -3366,7 +3366,7 @@ msgstr  ""
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid   "Must supply instance name for: "
 msgstr  ""
 
@@ -3708,7 +3708,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -4209,11 +4209,11 @@ msgstr  ""
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid   "Restart instances"
 msgstr  ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid   "Restart instances\n"
         "\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
@@ -4246,6 +4246,10 @@ msgstr  ""
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid   "Resume instances"
+msgstr  ""
+
 #: lxc/console.go:43
 msgid   "Retrieve the instance's console log"
 msgstr  ""
@@ -4271,7 +4275,7 @@ msgstr  ""
 msgid   "Run again a specific project"
 msgstr  ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid   "Run against all instances"
 msgstr  ""
 
@@ -4661,7 +4665,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -4804,7 +4808,7 @@ msgstr  ""
 msgid   "Socket %d:"
 msgstr  ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid   "Some instances failed to %s"
 msgstr  ""
@@ -4840,7 +4844,7 @@ msgstr  ""
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid   "Stop instances"
 msgstr  ""
 
@@ -4914,7 +4918,7 @@ msgstr  ""
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid   "Store the instance state"
 msgstr  ""
 
@@ -5156,7 +5160,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5168,7 +5172,7 @@ msgstr  ""
 msgid   "Threads:"
 msgstr  ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
@@ -5188,7 +5192,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
@@ -5246,7 +5250,7 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -5811,7 +5815,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [<snapshot name>]"
 msgstr  ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95 lxc/action.go:118
 msgid   "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr  ""
 
@@ -6203,7 +6207,7 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid   "error: %v"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -582,15 +582,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1723,23 +1723,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2415,7 +2415,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2799,7 +2799,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2964,7 +2964,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3907,7 +3907,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4259,7 +4259,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4786,11 +4786,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4825,6 +4825,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4850,7 +4854,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5269,7 +5273,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5412,7 +5416,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5448,7 +5452,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5522,7 +5526,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5771,7 +5775,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5787,7 +5791,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5807,7 +5811,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5867,7 +5871,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6456,7 +6460,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6872,7 +6877,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -616,15 +616,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1757,23 +1757,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2777,7 +2777,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2833,7 +2833,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4820,11 +4820,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4859,6 +4859,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4884,7 +4888,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5446,7 +5450,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5482,7 +5486,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5556,7 +5560,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5805,7 +5809,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5821,7 +5825,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5841,7 +5845,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5901,7 +5905,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6490,7 +6494,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6906,7 +6911,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -362,15 +362,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1503,23 +1503,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2579,7 +2579,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4566,11 +4566,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4605,6 +4605,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4630,7 +4634,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5049,7 +5053,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5192,7 +5196,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5228,7 +5232,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5302,7 +5306,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5551,7 +5555,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5567,7 +5571,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5587,7 +5591,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5647,7 +5651,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6236,7 +6240,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6652,7 +6657,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -606,17 +606,17 @@ msgstr "- Partição %d"
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 #, fuzzy
 msgid "--console can't be used while forcing instance shutdown"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 #, fuzzy
 msgid "--console can't be used with --all"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 #, fuzzy
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1045,7 +1045,7 @@ msgstr "Propriedade ruim: %s"
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1816,23 +1816,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2530,7 +2530,7 @@ msgstr "Forçar alocação de pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Ignorar o estado do container"
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2896,7 +2896,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
@@ -2935,7 +2935,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 #, fuzzy
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
@@ -3102,7 +3102,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4090,7 +4090,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4442,7 +4442,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4990,12 +4990,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5036,6 +5036,11 @@ msgstr "Nome de membro do cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "Editar arquivos no container"
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -5063,7 +5068,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5508,7 +5513,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5664,7 +5669,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -5700,7 +5705,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5774,7 +5779,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
@@ -6030,7 +6035,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6046,7 +6051,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -6066,7 +6071,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6126,7 +6131,7 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6764,7 +6769,8 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -7224,7 +7230,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -615,15 +615,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr "- Порт %d (%s)"
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1802,23 +1802,23 @@ msgstr "Копирование образа: %s"
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2516,7 +2516,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 #, fuzzy
 msgid "Force the instance to stop"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2861,7 +2861,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 #, fuzzy
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2918,7 +2918,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4090,7 +4090,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4446,7 +4446,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4988,12 +4988,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 #, fuzzy
 msgid "Restart instances"
 msgstr "Псевдонимы:"
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -5031,6 +5031,11 @@ msgstr "Копирование образа: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+#, fuzzy
+msgid "Resume instances"
+msgstr "Псевдонимы:"
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -5058,7 +5063,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5496,7 +5501,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5652,7 +5657,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, fuzzy, c-format
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5689,7 +5694,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 #, fuzzy
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5765,7 +5770,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 #, fuzzy
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6015,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6031,7 +6036,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -6051,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6111,7 +6116,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6906,7 +6911,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 #, fuzzy
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
@@ -7690,7 +7696,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1507,23 +1507,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2583,7 +2583,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4570,11 +4570,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4609,6 +4609,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4634,7 +4638,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5196,7 +5200,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5232,7 +5236,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5306,7 +5310,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5555,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5571,7 +5575,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5591,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6240,7 +6244,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6656,7 +6661,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1507,23 +1507,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2583,7 +2583,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4570,11 +4570,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4609,6 +4609,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4634,7 +4638,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5196,7 +5200,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5232,7 +5236,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5306,7 +5310,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5555,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5571,7 +5575,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5591,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6240,7 +6244,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6656,7 +6661,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -362,15 +362,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -773,7 +773,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1503,23 +1503,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2195,7 +2195,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2523,7 +2523,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2579,7 +2579,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2744,7 +2744,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3687,7 +3687,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4566,11 +4566,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4605,6 +4605,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4630,7 +4634,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5049,7 +5053,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5192,7 +5196,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5228,7 +5232,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5302,7 +5306,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5551,7 +5555,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5567,7 +5571,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5587,7 +5591,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5647,7 +5651,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6236,7 +6240,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6652,7 +6657,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -366,15 +366,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1507,23 +1507,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2199,7 +2199,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2583,7 +2583,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3691,7 +3691,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4570,11 +4570,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4609,6 +4609,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4634,7 +4638,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5196,7 +5200,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5232,7 +5236,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5306,7 +5310,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5555,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5571,7 +5575,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5591,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5651,7 +5655,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6240,7 +6244,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6656,7 +6661,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1656,23 +1656,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2348,7 +2348,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2694,7 +2694,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2732,7 +2732,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2897,7 +2897,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3840,7 +3840,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4192,7 +4192,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4719,11 +4719,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4758,6 +4758,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4783,7 +4787,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5202,7 +5206,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5345,7 +5349,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5381,7 +5385,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5455,7 +5459,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5704,7 +5708,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5720,7 +5724,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5740,7 +5744,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5800,7 +5804,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6389,7 +6393,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6805,7 +6810,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-08 11:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -365,15 +365,15 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/action.go:219
+#: lxc/action.go:243
 msgid "--console can't be used while forcing instance shutdown"
 msgstr ""
 
-#: lxc/action.go:368
+#: lxc/action.go:392
 msgid "--console can't be used with --all"
 msgstr ""
 
-#: lxc/action.go:372
+#: lxc/action.go:396
 msgid "--console only works with a single instance"
 msgstr ""
 
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Bond:"
 msgstr ""
 
-#: lxc/action.go:147 lxc/action.go:324
+#: lxc/action.go:169 lxc/action.go:348
 msgid "Both --all and instance name given"
 msgstr ""
 
@@ -1506,23 +1506,23 @@ msgstr ""
 msgid "Delete warning"
 msgstr ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98
-#: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206
-#: lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439
-#: lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689
-#: lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
-#: lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30
-#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
-#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
-#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
-#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:97
+#: lxc/action.go:120 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110
+#: lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122
+#: lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367
+#: lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604
+#: lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982
+#: lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189
+#: lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157
+#: lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382
+#: lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577
+#: lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50
+#: lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380
+#: lxc/config.go:513 lxc/config.go:730 lxc/config.go:854
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -2198,7 +2198,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/action.go:135
+#: lxc/action.go:157
 msgid "Force the instance to stop"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:394
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
-#: lxc/action.go:126
+#: lxc/action.go:148
 msgid "Ignore the instance state"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/action.go:130 lxc/launch.go:41
+#: lxc/action.go:152 lxc/launch.go:41
 msgid "Immediately attach to the console"
 msgstr ""
 
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:491
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3690,7 +3690,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:233
+#: lxc/action.go:257
 msgid "Must supply instance name for: "
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:357
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/action.go:74
+#: lxc/action.go:96
 msgid "Restart instances"
 msgstr ""
 
-#: lxc/action.go:75
+#: lxc/action.go:97
 msgid ""
 "Restart instances\n"
 "\n"
@@ -4608,6 +4608,10 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
+#: lxc/action.go:74 lxc/action.go:75
+msgid "Resume instances"
+msgstr ""
+
 #: lxc/console.go:43
 msgid "Retrieve the instance's console log"
 msgstr ""
@@ -4633,7 +4637,7 @@ msgstr ""
 msgid "Run again a specific project"
 msgstr ""
 
-#: lxc/action.go:121
+#: lxc/action.go:143
 msgid "Run against all instances"
 msgstr ""
 
@@ -5052,7 +5056,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:269 lxc/main.go:270
 msgid "Show less common commands"
 msgstr ""
 
@@ -5195,7 +5199,7 @@ msgstr ""
 msgid "Socket %d:"
 msgstr ""
 
-#: lxc/action.go:401
+#: lxc/action.go:425
 #, c-format
 msgid "Some instances failed to %s"
 msgstr ""
@@ -5231,7 +5235,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/action.go:97 lxc/action.go:98
+#: lxc/action.go:119 lxc/action.go:120
 msgid "Stop instances"
 msgstr ""
 
@@ -5305,7 +5309,7 @@ msgstr ""
 msgid "Storage volume moved successfully!"
 msgstr ""
 
-#: lxc/action.go:124
+#: lxc/action.go:146
 msgid "Store the instance state"
 msgstr ""
 
@@ -5554,7 +5558,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:291
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5570,7 +5574,7 @@ msgstr ""
 msgid "Threads:"
 msgstr ""
 
-#: lxc/action.go:136
+#: lxc/action.go:158
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
@@ -5590,7 +5594,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:399
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/action.go:287 lxc/launch.go:110
+#: lxc/action.go:311 lxc/launch.go:110
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6239,7 +6243,8 @@ msgstr ""
 msgid "[<remote>:]<instance> [<snapshot name>]"
 msgstr ""
 
-#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:96
+#: lxc/action.go:30 lxc/action.go:51 lxc/action.go:73 lxc/action.go:95
+#: lxc/action.go:118
 msgid "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgstr ""
 
@@ -6655,7 +6660,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:393
+#: lxc/action.go:417
 #, c-format
 msgid "error: %v"
 msgstr ""


### PR DESCRIPTION
This fixes bulk unfreezing instances, and adds a new command `resume` (or `unfreeze`) to the CLI.

Fixes #12491
