### PR TITLE
client: Use io.Writer for Stdout/Stderr in InstanceExecArgs

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -643,10 +643,10 @@ type InstanceExecArgs struct {
 	Stdin io.ReadCloser
 
 	// Standard output
-	Stdout io.WriteCloser
+	Stdout io.Writer
 
 	// Standard error
-	Stderr io.WriteCloser
+	Stderr io.Writer
 
 	// Control message handler (window resize, signals, ...)
 	Control func(conn *websocket.Conn)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -640,7 +640,7 @@ type InstanceConsoleLogArgs struct {
 // The InstanceExecArgs struct is used to pass additional options during instance exec.
 type InstanceExecArgs struct {
 	// Standard input
-	Stdin io.ReadCloser
+	Stdin io.Reader
 
 	// Standard output
 	Stdout io.Writer

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1287,10 +1287,6 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 				}
 
 				if fds["0"] != "" {
-					if args.Stdin != nil {
-						_ = args.Stdin.Close()
-					}
-
 					// Empty the stdin channel but don't block on it as
 					// stdin may be stuck in Read()
 					go func() {

--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -45,8 +45,8 @@ func MirrorRead(conn *websocket.Conn, rc io.ReadCloser) chan error {
 	return chDone
 }
 
-// MirrorWrite is a uni-directional mirror which replicates a websocket to an io.WriteCloser.
-func MirrorWrite(conn *websocket.Conn, wc io.WriteCloser) chan error {
+// MirrorWrite is a uni-directional mirror which replicates a websocket to an io.Writer.
+func MirrorWrite(conn *websocket.Conn, wc io.Writer) chan error {
 	chDone := make(chan error, 1)
 	if wc == nil {
 		close(chDone)

--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -17,8 +17,8 @@ func Mirror(conn *websocket.Conn, rwc io.ReadWriteCloser) (chan error, chan erro
 	return chRead, chWrite
 }
 
-// MirrorRead is a uni-directional mirror which replicates an io.ReadCloser to a websocket.
-func MirrorRead(conn *websocket.Conn, rc io.ReadCloser) chan error {
+// MirrorRead is a uni-directional mirror which replicates an io.Reader to a websocket.
+func MirrorRead(conn *websocket.Conn, rc io.Reader) chan error {
 	chDone := make(chan error, 1)
 	if rc == nil {
 		close(chDone)


### PR DESCRIPTION
This changes the Stdout and Stderr fields to be of type io.Writer
instead of io.WriteCloser since `Close()` is never called on these
fields.

Fixes #12197
