### PR TITLE
btrfs: Handle pools whose source is a subvolume outside of the pool mount path

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -195,13 +195,13 @@ func (d *btrfs) Create() error {
 		hostPath := shared.HostPath(d.config["source"])
 		if d.isSubvolume(hostPath) {
 			// Existing btrfs subvolume.
-			subvols, err := d.getSubvolumes(hostPath)
+			hasSubvolumes, err := d.hasSubvolumes(hostPath)
 			if err != nil {
 				return fmt.Errorf("Could not determine if existing btrfs subvolume is empty: %w", err)
 			}
 
 			// Check that the provided subvolume is empty.
-			if len(subvols) > 0 {
+			if hasSubvolumes {
 				return fmt.Errorf("Requested btrfs subvolume exists but is not empty")
 			}
 		} else {

--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -95,6 +95,17 @@ func (d *btrfs) isSubvolume(path string) bool {
 	return true
 }
 
+func (d *btrfs) hasSubvolumes(path string) (bool, error) {
+	var stdout strings.Builder
+
+	err := shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", "-o", path)
+	if err != nil {
+		return false, err
+	}
+
+	return stdout.Len() > 0, nil
+}
+
 func (d *btrfs) getSubvolumes(path string) ([]string, error) {
 	poolMountPath := GetPoolMountPath(d.name)
 	if !strings.HasPrefix(path, poolMountPath+"/") {

--- a/test/suites/storage_driver_btrfs.sh
+++ b/test/suites/storage_driver_btrfs.sh
@@ -156,6 +156,29 @@ test_storage_driver_btrfs() {
     lxc profile device remove default root
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool1"
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool2"
+
+    # Test creating storage pool from exiting btrfs subvolume
+    truncate -s 200M testpool.img
+    mkfs.btrfs -f testpool.img
+    basepath="$(pwd)/mnt"
+    mkdir -p "${basepath}"
+    mount testpool.img "${basepath}"
+    btrfs subvolume create "${basepath}/foo"
+    btrfs subvolume create "${basepath}/foo/bar"
+
+    # This should fail as the source itself has subvolumes.
+    ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" btrfs source="${basepath}/foo" || false
+
+    # This should work as the provided subvolume is empty.
+    btrfs subvolume delete "${basepath}/foo/bar"
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" btrfs source="${basepath}/foo"
+    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool1"
+
+    sleep 1
+
+    umount "${basepath}"
+    rmdir "${basepath}"
+    rm -f testpool.img
   )
 
   # shellcheck disable=SC2031


### PR DESCRIPTION
This fixes an issue where btrfs pools whose source is a subvolume outside of the pool mount path would fail being created.
However, as this scenario is totally valid, it should be handled correctly.

Fixes #12496

Fixes regression from https://github.com/canonical/lxd/pull/12258/commits/7ebca54656208a4d24f7fd488271d677b8882c16
