### PR TITLE
lxc/delete: Include instance name in error message

### DIFF
--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -92,6 +92,11 @@ func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
 
 	// Process with deletion.
 	for _, resource := range resources {
+		connInfo, err := resource.server.GetConnectionInfo()
+		if err != nil {
+			return err
+		}
+
 		if c.flagInteractive {
 			err := c.promptDelete(resource.name)
 			if err != nil {
@@ -102,7 +107,7 @@ func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
 		if shared.IsSnapshot(resource.name) {
 			err := c.doDelete(resource.server, resource.name)
 			if err != nil {
-				return err
+				return fmt.Errorf(i18n.G("Failed deleting instance snapshot %q in project %q: %w"), resource.name, connInfo.Project, err)
 			}
 
 			continue
@@ -160,7 +165,7 @@ func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
 
 		err = c.doDelete(resource.server, resource.name)
 		if err != nil {
-			return err
+			return fmt.Errorf(i18n.G("Failed deleting instance %q in project %q: %w"), resource.name, connInfo.Project, err)
 		}
 	}
 	return nil

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2059,6 +2059,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5230,7 +5240,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5394,7 +5404,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -2436,6 +2436,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5831,7 +5841,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6005,7 +6015,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -2083,6 +2083,16 @@ msgstr "  Χρήση δικτύου:"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "  Χρήση δικτύου:"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/file.go:1174
 #, c-format
@@ -5317,7 +5327,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5481,7 +5491,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2342,6 +2342,16 @@ msgstr "Nombre del Miembro del Cluster"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "Nombre del Miembro del Cluster"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5617,7 +5627,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiando la imagen: %s"
@@ -5783,7 +5793,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -2468,6 +2468,16 @@ msgstr "Profil à appliquer au nouveau conteneur"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5963,7 +5973,7 @@ msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 msgid "Stopping instance failed!"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6134,7 +6144,7 @@ msgstr "Le périphérique n'existe pas"
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 #, fuzzy
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -2063,6 +2063,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5234,7 +5244,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5398,7 +5408,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2337,6 +2337,16 @@ msgstr "Il nome del container è: %s"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "Il nome del container è: %s"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "Il nome del container è: %s"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5612,7 +5622,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "errore di processamento degli alias %s\n"
@@ -5778,7 +5788,7 @@ msgstr "La periferica esiste già"
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -2385,6 +2385,16 @@ msgstr "インスタンスの SFTP への接続に失敗しました: %w"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr "証明書追加トークンのトークン変換操作に失敗しました: %w"
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
 #: lxc/file.go:1174
 #, c-format
@@ -5862,7 +5872,7 @@ msgstr "実行中の場合、インスタンスを停止します"
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "インスタンスの停止に失敗しました: %s"
@@ -6026,7 +6036,7 @@ msgstr "デバイスはすでに存在します"
 msgid "The direction argument must be one of: ingress, egress"
 msgstr "direction 引数は次のいずれかでなければなりません: ingress, egress"
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2059,6 +2059,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5230,7 +5240,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5394,7 +5404,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-11-05 22:14+0000\n"
+        "POT-Creation-Date: 2023-11-07 10:34+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1847,6 +1847,16 @@ msgstr  ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid   "Failed converting token operation to certificate add token: %w"
+msgstr  ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid   "Failed deleting instance %q in project %q: %w"
+msgstr  ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid   "Failed deleting instance snapshot %q in project %q: %w"
 msgstr  ""
 
 #: lxc/file.go:1174
@@ -4842,7 +4852,7 @@ msgstr  ""
 msgid   "Stopping instance failed!"
 msgstr  ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid   "Stopping the instance failed: %s"
 msgstr  ""
@@ -5003,7 +5013,7 @@ msgstr  ""
 msgid   "The direction argument must be one of: ingress, egress"
 msgstr  ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid   "The instance is currently running, stop it first or pass --force"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -2279,6 +2279,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5450,7 +5460,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5614,7 +5624,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2313,6 +2313,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5484,7 +5494,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5648,7 +5658,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2059,6 +2059,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5230,7 +5240,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5394,7 +5404,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2395,6 +2395,16 @@ msgstr "Nome de membro do cluster"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "Nome de membro do cluster"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "Nome de membro do cluster"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5702,7 +5712,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Copiar a imagem: %s"
@@ -5872,7 +5882,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2381,6 +2381,16 @@ msgstr "Копирование образа: %s"
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
 msgstr ""
+
+#: lxc/delete.go:168
+#, fuzzy, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr "Копирование образа: %s"
+
+#: lxc/delete.go:110
+#, fuzzy, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
+msgstr "Копирование образа: %s"
 
 #: lxc/file.go:1174
 #, fuzzy, c-format
@@ -5693,7 +5703,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, fuzzy, c-format
 msgid "Stopping the instance failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5858,7 +5868,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -2063,6 +2063,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5234,7 +5244,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5398,7 +5408,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2063,6 +2063,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5234,7 +5244,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5398,7 +5408,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2059,6 +2059,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5230,7 +5240,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5394,7 +5404,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -2063,6 +2063,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5234,7 +5244,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5398,7 +5408,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -2212,6 +2212,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5383,7 +5393,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5547,7 +5557,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-05 22:14+0000\n"
+"POT-Creation-Date: 2023-11-07 10:34+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -2062,6 +2062,16 @@ msgstr ""
 #: lxc/config_trust.go:210
 #, c-format
 msgid "Failed converting token operation to certificate add token: %w"
+msgstr ""
+
+#: lxc/delete.go:168
+#, c-format
+msgid "Failed deleting instance %q in project %q: %w"
+msgstr ""
+
+#: lxc/delete.go:110
+#, c-format
+msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
 #: lxc/file.go:1174
@@ -5233,7 +5243,7 @@ msgstr ""
 msgid "Stopping instance failed!"
 msgstr ""
 
-#: lxc/delete.go:134
+#: lxc/delete.go:139
 #, c-format
 msgid "Stopping the instance failed: %s"
 msgstr ""
@@ -5397,7 +5407,7 @@ msgstr ""
 msgid "The direction argument must be one of: ingress, egress"
 msgstr ""
 
-#: lxc/delete.go:118
+#: lxc/delete.go:123
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 


### PR DESCRIPTION
When deleting multiple instances at once, it's not clear which deletion
failed as the instance name is not included in the error message.

This adds the instance name to the error message.
