### PR TITLE
lxd/device/proxy: Consider routed NIC IPs for wildcard target check

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -407,7 +407,8 @@ func (d *proxy) setupNAT() error {
 			return err
 		}
 
-		if nicType != "bridged" {
+		// Check if the instance has a NIC with a static IP that is reachable from the host.
+		if !shared.ValueInSlice(nicType, []string{"bridged", "routed"}) {
 			continue
 		}
 


### PR DESCRIPTION
These too are reachable from the host, just like bridged NIC ones.