### PR TITLE
Trust ca certs

### DIFF
--- a/lxd/auth/driver_tls.go
+++ b/lxd/auth/driver_tls.go
@@ -172,5 +172,11 @@ func (t *tls) certificateDetails(fingerprint string) (certificate.Type, bool, []
 		return certificate.TypeMetrics, false, nil, nil
 	}
 
+	// If we're in a CA environment, it's possible for a certificate to be trusted despite not being present in the trust store.
+	// We rely on the validation of the certificate (and its potential revocation) having been done in CheckTrustState.
+	if shared.PathExists(shared.VarPath("server.ca")) {
+		return certificate.TypeClient, true, nil, nil
+	}
+
 	return -1, false, nil, api.StatusErrorf(http.StatusForbidden, "Client certificate not found")
 }


### PR DESCRIPTION
This PR cherry-picks fixes from https://github.com/lxc/incus/pull/221 which prevented TLS authorization when using CA certificates.

I have added an extra commit to enforce that a user is authenticated before calling the access handler.