### PR TITLE
lxd/instance/drivers/driver_qemu: add the boot.debug_edk2 option

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -40,6 +40,13 @@ The number of seconds to wait after the instance started before starting the nex
 The instance with the highest value is started first.
 ```
 
+```{config:option} boot.debug_edk2 instance-boot
+:shortdesc: "Enable debug version of the `edk2`"
+:type: "bool"
+The instance should use a debug version of the `edk2`.
+A log file can be found in `$LXD_DIR/logs/<instance_name>/edk2.log`.
+```
+
 ```{config:option} boot.host_shutdown_timeout instance-boot
 :defaultdesc: "30"
 :liveupdate: "yes"

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -858,7 +858,7 @@ The original VLAN used when moving a VF into an instance.
 
 ```{config:option} volatile.apply_nvram instance-volatile
 :shortdesc: "Whether to regenerate VM NVRAM the next time the instance starts"
-:type: "string"
+:type: "bool"
 
 ```
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -919,7 +919,7 @@
 						"volatile.apply_nvram": {
 							"longdesc": "",
 							"shortdesc": "Whether to regenerate VM NVRAM the next time the instance starts",
-							"type": "string"
+							"type": "bool"
 						}
 					},
 					{

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -51,6 +51,13 @@
 						}
 					},
 					{
+						"boot.debug_edk2": {
+							"longdesc": "The instance should use a debug version of the `edk2`.\nA log file can be found in `$LXD_DIR/logs/\u003cinstance_name\u003e/edk2.log`.",
+							"shortdesc": "Enable debug version of the `edk2`",
+							"type": "bool"
+						}
+					},
+					{
 						"boot.host_shutdown_timeout": {
 							"defaultdesc": "\"30\"",
 							"liveupdate": "yes",

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -1054,6 +1054,14 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  type: string
 	//  shortdesc: Instance `vsock ID` used as of last start
 	"volatile.vsock_id": validate.Optional(validate.IsInt64),
+
+	// lxdmeta:generate(entity=instance, group=boot, key=boot.debug_edk2)
+	// The instance should use a debug version of the `edk2`.
+	// A log file can be found in `$LXD_DIR/logs/<instance_name>/edk2.log`.
+	// ---
+	//  type: bool
+	//  shortdesc: Enable debug version of the `edk2`
+	"boot.debug_edk2": validate.Optional(validate.IsBool),
 }
 
 // ConfigKeyChecker returns a function that will check whether or not

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -1044,7 +1044,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	// lxdmeta:generate(entity=instance, group=volatile, key=volatile.apply_nvram)
 	//
 	// ---
-	//  type: string
+	//  type: bool
 	//  shortdesc: Whether to regenerate VM NVRAM the next time the instance starts
 	"volatile.apply_nvram": validate.Optional(validate.IsBool),
 


### PR DESCRIPTION
This option enables Qemu to use debug version of EDKII firmware.

The story behind this is that we have seen many reports from the community about weird and hardly reproducible issues or reproducible on some specific systems and having debug version of the EDKII seems like a good solution so users can easily enable it and provide us with more details.

LXD will expect that firmware named as OVMF_CODE.4MB.debug.fd and all the debug output will be captured and written to the file edk2.log (inside the $LXD_DIR/logs/<instance_name> directory).

Usage as simple as:
lxc config set myvm boot.debug_edk2=true
and then inspect logs:
cat /var/snap/lxd/common/lxd/logs/myvm/edk2.log