### PR TITLE
Add `lxc file create` subcommand

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -28,8 +28,12 @@ import (
 	"github.com/canonical/lxd/shared/units"
 )
 
-// DirMode represents the file mode for creating dirs on `lxc file pull/push`.
-const DirMode = 0755
+const (
+	// DirMode represents the file mode for creating dirs on `lxc file pull/push`.
+	DirMode = 0755
+	// FileMode represents the file mode for creating files on `lxc file create`.
+	FileMode = 0644
+)
 
 type cmdFile struct {
 	global *cmdGlobal
@@ -97,6 +101,10 @@ func (c *cmdFile) Command() *cobra.Command {
 	// Mount
 	fileMountCmd := cmdFileMount{global: c.global, file: c}
 	cmd.AddCommand(fileMountCmd.Command())
+
+	// Create
+	fileCreateCmd := cmdFileCreate{global: c.global, file: c}
+	cmd.AddCommand(fileCreateCmd.Command())
 
 	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
 	cmd.Args = cobra.NoArgs
@@ -1045,6 +1053,206 @@ func (c *cmdFileMount) Run(cmd *cobra.Command, args []string) error {
 
 	// If SSH SFTP listener specified or no target mount path specified, then use SSH SFTP server.
 	return c.sshSFTPServer(cmd.Context(), instName, resource)
+}
+
+// Create.
+type cmdFileCreate struct {
+	global *cmdGlobal
+	file   *cmdFile
+
+	flagContent string
+	flagForce   bool
+	flagType    string
+}
+
+func (c *cmdFileCreate) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("create", i18n.G("[<remote>:]<instance>/<path> [<symlink target path>]"))
+	cmd.Short = i18n.G("Create files and directories in instances")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Create files and directories in instances`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`lxc file create foo/bar
+   To create a file /bar in the foo instance.
+lxc file create --type=symlink foo/bar baz
+   To create a symlink /bar in instance foo whose target is baz.`))
+
+	cmd.Flags().BoolVarP(&c.file.flagMkdir, "create-dirs", "p", false, i18n.G("Create any directories necessary")+"``")
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force creating files or directories")+"``")
+	cmd.Flags().IntVar(&c.file.flagGID, "gid", -1, i18n.G("Set the file's gid on create")+"``")
+	cmd.Flags().IntVar(&c.file.flagUID, "uid", -1, i18n.G("Set the file's uid on create")+"``")
+	cmd.Flags().StringVar(&c.file.flagMode, "mode", "", i18n.G("Set the file's perms on create")+"``")
+	cmd.Flags().StringVar(&c.flagContent, "content", "", i18n.G("The content of the created file")+"``")
+	cmd.Flags().StringVar(&c.flagType, "type", "file", i18n.G("The type to create (file, symlink, or directory)")+"``")
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+func (c *cmdFileCreate) Run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	if exit {
+		return err
+	}
+
+	if !shared.ValueInSlice(c.flagType, []string{"file", "symlink", "directory"}) {
+		return fmt.Errorf(i18n.G("Invalid type %q"), c.flagType)
+	}
+
+	if c.flagContent != "" && c.flagType != "file" {
+		return fmt.Errorf(i18n.G(`Content can only be used for type "file"`))
+	}
+
+	if len(args) == 2 && c.flagType != "symlink" {
+		return fmt.Errorf(i18n.G(`Symlink target path can only be used for type "symlink"`))
+	}
+
+	if strings.HasSuffix(args[0], "/") {
+		c.flagType = "directory"
+	}
+
+	pathSpec := strings.SplitN(args[0], "/", 2)
+
+	if len(pathSpec) != 2 {
+		return fmt.Errorf(i18n.G("Invalid target %s"), args[0])
+	}
+
+	// Parse remote.
+	resources, err := c.global.ParseServers(pathSpec[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	// re-add leading / that got stripped by the SplitN
+	targetPath := path.Clean("/" + pathSpec[1])
+
+	// normalization may reveal that path is still a dir, e.g. /.
+	if strings.HasSuffix(targetPath, "/") {
+		c.flagType = "directory"
+	}
+
+	var symlinkTargetPath string
+
+	// Determine the target if specified.
+	if len(args) == 2 {
+		symlinkTargetPath = filepath.Clean(args[1])
+	}
+
+	// Determine the target uid
+	uid := 0
+	if c.file.flagUID > 0 {
+		uid = c.file.flagUID
+	}
+
+	// Determine the target gid
+	gid := 0
+	if c.file.flagGID > 0 {
+		gid = c.file.flagGID
+	}
+
+	var mode os.FileMode
+
+	// Determine the target mode
+	if c.flagType == "directory" {
+		mode = os.FileMode(DirMode)
+	} else if c.flagType == "file" {
+		mode = os.FileMode(FileMode)
+	}
+
+	if c.file.flagMode != "" {
+		if len(c.file.flagMode) == 3 {
+			c.file.flagMode = "0" + c.file.flagMode
+		}
+
+		m, err := strconv.ParseInt(c.file.flagMode, 0, 0)
+		if err != nil {
+			return err
+		}
+
+		mode = os.FileMode(m)
+	}
+
+	// Create needed paths if requested
+	if c.file.flagMkdir {
+		err = c.file.recursiveMkdir(resource.server, resource.name, path.Dir(targetPath), nil, int64(uid), int64(gid))
+		if err != nil {
+			return err
+		}
+	}
+
+	var content io.ReadSeeker
+	var readCloser io.ReadCloser
+	var contentLength int64
+
+	if c.flagType == "symlink" {
+		content = strings.NewReader(symlinkTargetPath)
+		readCloser = io.NopCloser(content)
+		contentLength = int64(len(symlinkTargetPath))
+	} else if c.flagType == "file" {
+		if c.flagContent == "-" {
+			// Read from stdin
+			content = os.Stdin
+			readCloser = os.Stdin
+
+			defer func() { _ = os.Stdin.Close() }()
+
+			stat, err := os.Stdin.Stat()
+			if err != nil {
+				return err
+			}
+
+			contentLength = stat.Size()
+		} else {
+			// Read from --content
+			content = strings.NewReader(c.flagContent)
+			readCloser = io.NopCloser(content)
+			contentLength = int64(len(c.flagContent))
+		}
+	}
+
+	fileArgs := lxd.InstanceFileArgs{
+		Type:    c.flagType,
+		UID:     int64(uid),
+		GID:     int64(gid),
+		Mode:    int(mode.Perm()),
+		Content: content,
+	}
+
+	if c.flagForce {
+		fileArgs.WriteMode = "overwrite"
+	}
+
+	progress := cli.ProgressRenderer{
+		Format: fmt.Sprintf(i18n.G("Creating %s: %%s"), targetPath),
+		Quiet:  c.global.flagQuiet,
+	}
+
+	if readCloser != nil {
+		fileArgs.Content = shared.NewReadSeeker(&ioprogress.ProgressReader{
+			ReadCloser: readCloser,
+			Tracker: &ioprogress.ProgressTracker{
+				Length: contentLength,
+				Handler: func(percent int64, speed int64) {
+					progress.UpdateProgress(ioprogress.ProgressData{
+						Text: fmt.Sprintf("%d%% (%s/s)", percent, units.GetByteSizeString(speed, 2)),
+					})
+				},
+			},
+		}, fileArgs.Content)
+	}
+
+	err = resource.server.CreateInstanceFile(resource.name, targetPath, fileArgs)
+	if err != nil {
+		progress.Done("")
+		return err
+	}
+
+	progress.Done("")
+
+	return nil
 }
 
 // sshfsMount mounts the instance's filesystem using sshfs by piping the instance's SFTP connection to sshfs.

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -617,8 +617,9 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			_, dUID, dGID := shared.GetOwnerMode(finfo)
 			if c.file.flagUID == -1 || c.file.flagGID == -1 {
+				_, dUID, dGID := shared.GetOwnerMode(finfo)
+
 				if c.file.flagUID == -1 {
 					uid = dUID
 				}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -333,12 +333,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -427,7 +427,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1116,6 +1116,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1281,8 +1285,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1371,6 +1379,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1427,7 +1440,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1527,70 +1540,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1688,7 +1702,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1754,7 +1768,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1768,7 +1782,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2026,12 +2040,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2046,12 +2060,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2071,7 +2085,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2086,7 +2100,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2096,12 +2110,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2140,7 +2154,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2155,7 +2169,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2181,6 +2195,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2449,22 +2467,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2636,11 +2654,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2654,7 +2672,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2706,7 +2724,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2748,7 +2766,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2764,14 +2782,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3250,7 +3273,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3592,7 +3615,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3630,11 +3653,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4077,7 +4100,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4310,20 +4333,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4361,7 +4384,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,12 +4681,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4735,7 +4758,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4929,15 +4952,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4997,7 +5032,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5337,6 +5372,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5356,11 +5395,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5390,6 +5429,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5537,6 +5580,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5708,7 +5755,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5722,7 +5769,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5738,7 +5785,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5948,7 +5995,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6248,20 +6295,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6729,20 +6780,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6968,16 +7027,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -578,12 +578,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1416,6 +1416,10 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1589,9 +1593,14 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/snapshot.go:27
 #, fuzzy
@@ -1694,6 +1703,11 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Erstelle %s"
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1751,7 +1765,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1861,70 +1875,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -2032,7 +2047,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2103,7 +2118,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2118,7 +2133,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2402,12 +2417,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2422,12 +2437,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2447,7 +2462,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2462,7 +2477,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2472,12 +2487,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2516,7 +2531,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2531,7 +2546,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2560,6 +2575,10 @@ msgstr "Fingerabdruck: %s\n"
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2850,22 +2869,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3043,12 +3062,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3062,7 +3081,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3115,7 +3134,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3159,7 +3178,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3176,14 +3195,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr "Ungültiges Ziel %s"
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
 
 #: lxc/info.go:230
@@ -3707,7 +3731,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4091,7 +4115,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -4130,12 +4154,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4592,7 +4616,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4832,22 +4856,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4887,7 +4911,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5210,12 +5234,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5290,7 +5314,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5496,15 +5520,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Setzt die gid der Datei beim Übertragen"
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Setzt die Dateiberechtigungen beim Übertragen"
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Setzt die uid der Datei beim Übertragen"
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -5572,7 +5611,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5942,6 +5981,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5961,12 +6004,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6001,6 +6044,11 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#: lxc/file.go:1085
+#, fuzzy
+msgid "The content of the created file"
+msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -6152,6 +6200,10 @@ msgstr "entfernte Instanz %s existiert nicht"
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6325,7 +6377,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6340,7 +6392,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6356,7 +6408,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6593,7 +6645,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7119,7 +7171,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7128,7 +7180,16 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: lxc/file.go:123
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7136,7 +7197,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7146,7 +7207,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7979,20 +8040,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8222,16 +8291,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -869,7 +869,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1123,6 +1123,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1288,8 +1292,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1381,6 +1389,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1437,7 +1450,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1541,70 +1554,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1703,7 +1717,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1772,7 +1786,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1786,7 +1800,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2069,12 +2083,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2094,7 +2108,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2109,7 +2123,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2119,12 +2133,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2163,7 +2177,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2178,7 +2192,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2204,6 +2218,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2485,22 +2503,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2672,11 +2690,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2690,7 +2708,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2742,7 +2760,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2784,7 +2802,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2800,14 +2818,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3289,7 +3312,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3647,7 +3670,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3685,11 +3708,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4135,7 +4158,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4368,20 +4391,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4419,7 +4442,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4722,12 +4745,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4800,7 +4823,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5000,15 +5023,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5074,7 +5109,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5424,6 +5459,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5443,11 +5482,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5477,6 +5516,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5624,6 +5667,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5795,7 +5842,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5809,7 +5856,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5825,7 +5872,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6052,7 +6099,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6352,20 +6399,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6833,20 +6884,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7072,16 +7131,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -568,12 +568,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -667,7 +667,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1113,7 +1113,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1143,7 +1143,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1371,6 +1371,10 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de la consola:"
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1540,9 +1544,14 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creando el contenedor"
 
 #: lxc/snapshot.go:27
 #, fuzzy
@@ -1634,6 +1643,11 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creando %s"
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1796,70 +1810,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1959,7 +1974,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2027,7 +2042,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2041,7 +2056,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2308,12 +2323,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2328,12 +2343,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2353,7 +2368,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2368,7 +2383,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2378,12 +2393,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2422,7 +2437,7 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2437,7 +2452,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2463,6 +2478,10 @@ msgstr "Huella dactilar: %s"
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2746,22 +2765,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -2937,11 +2956,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2956,7 +2975,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3008,7 +3027,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3051,7 +3070,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3068,15 +3087,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Nombre del contenedor es: %s"
 
 #: lxc/info.go:230
 #, fuzzy, c-format
@@ -3567,7 +3591,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3932,7 +3956,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -3972,11 +3996,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4421,7 +4445,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4658,20 +4682,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4711,7 +4735,7 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5021,12 +5045,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5099,7 +5123,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5299,15 +5323,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5373,7 +5409,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5724,6 +5760,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5743,11 +5783,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5780,6 +5820,10 @@ msgstr ""
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
+msgstr ""
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -5926,6 +5970,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -6100,7 +6148,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6114,7 +6162,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6130,7 +6178,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6358,7 +6406,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6706,23 +6754,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/file.go:123
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7276,20 +7329,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7515,16 +7576,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -576,12 +576,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -675,7 +675,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1419,6 +1419,10 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1593,8 +1597,13 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr "Créer tous répertoires nécessaires"
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "Créer tous répertoires nécessaires"
 
 #: lxc/snapshot.go:27
@@ -1714,6 +1723,11 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Création de %s"
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1773,7 +1787,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -1886,70 +1900,71 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -2051,7 +2066,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2123,7 +2138,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2138,7 +2153,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2434,12 +2449,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2454,12 +2469,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2479,7 +2494,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2494,7 +2509,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2504,12 +2519,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2549,7 +2564,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2564,7 +2579,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2591,6 +2606,10 @@ msgstr "Empreinte : %s"
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2885,22 +2904,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3086,12 +3105,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3106,7 +3125,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3158,7 +3177,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3202,7 +3221,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3219,14 +3238,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr "Cible invalide %s"
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Cible invalide %s"
 
 #: lxc/info.go:230
@@ -3787,7 +3811,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -4174,7 +4198,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4216,12 +4240,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4691,7 +4715,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4931,22 +4955,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4987,7 +5011,7 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -5329,12 +5353,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5412,7 +5436,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5620,15 +5644,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Définir le gid du fichier lors de l'envoi"
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Définir les permissions du fichier lors de l'envoi"
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Définir l'uid du fichier lors de l'envoi"
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -5696,7 +5735,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6075,6 +6114,10 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6095,11 +6138,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6130,6 +6173,11 @@ msgstr ""
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
+
+#: lxc/file.go:1085
+#, fuzzy
+msgid "The content of the created file"
+msgstr "L'arrêt du conteneur a échoué !"
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -6286,6 +6334,10 @@ msgstr "Le périphérique indiqué n'existe pas"
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6463,7 +6515,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6478,7 +6530,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6494,7 +6546,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6735,7 +6787,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7302,7 +7354,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7314,7 +7366,19 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
+
+#: lxc/file.go:123
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7322,7 +7386,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7335,7 +7399,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8229,20 +8293,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8491,16 +8563,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -337,12 +337,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -431,7 +431,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1120,6 +1120,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1285,8 +1289,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1375,6 +1383,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1431,7 +1444,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1531,70 +1544,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1692,7 +1706,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1758,7 +1772,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1786,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2030,12 +2044,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2050,12 +2064,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2075,7 +2089,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2090,7 +2104,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2100,12 +2114,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2144,7 +2158,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2159,7 +2173,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2185,6 +2199,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2453,22 +2471,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2640,11 +2658,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2658,7 +2676,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2710,7 +2728,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2752,7 +2770,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2768,14 +2786,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3254,7 +3277,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3596,7 +3619,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3634,11 +3657,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4104,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4314,20 +4337,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4365,7 +4388,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,12 +4685,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4739,7 +4762,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4933,15 +4956,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5001,7 +5036,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5341,6 +5376,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5360,11 +5399,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5394,6 +5433,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5541,6 +5584,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5712,7 +5759,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5726,7 +5773,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5742,7 +5789,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5952,7 +5999,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6252,20 +6299,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6733,20 +6784,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6972,16 +7031,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -570,12 +570,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -666,7 +666,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1364,6 +1364,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1532,9 +1536,14 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creazione del container in corso"
 
 #: lxc/snapshot.go:27
 #, fuzzy
@@ -1628,6 +1637,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creazione di %s in corso"
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1685,7 +1699,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1790,70 +1804,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1953,7 +1968,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2023,7 +2038,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2037,7 +2052,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2303,12 +2318,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2323,12 +2338,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2348,7 +2363,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2363,7 +2378,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2373,12 +2388,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2417,7 +2432,7 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2432,7 +2447,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2459,6 +2474,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2739,22 +2758,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -2929,11 +2948,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2947,7 +2966,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2999,7 +3018,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3043,7 +3062,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3060,15 +3079,20 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Proprietà errata: %s"
 
 #: lxc/info.go:230
 #, c-format
@@ -3562,7 +3586,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -3929,7 +3953,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3968,11 +3992,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4419,7 +4443,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4654,21 +4678,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4708,7 +4732,7 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5019,12 +5043,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5097,7 +5121,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5295,15 +5319,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5367,7 +5403,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5720,6 +5756,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5740,11 +5780,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5774,6 +5814,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5922,6 +5966,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -6095,7 +6143,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6110,7 +6158,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6126,7 +6174,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6350,7 +6398,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6701,23 +6749,28 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/file.go:123
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7271,20 +7324,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7511,16 +7572,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7559,10 +7620,6 @@ msgstr "si"
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr "%v (interrompi altre due volte per forzare)"
-
-#, fuzzy
-#~ msgid "Invalid format %q"
-#~ msgstr "Proprietà errata: %s"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<member>]"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -565,12 +565,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -659,7 +659,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -1123,7 +1123,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1153,7 +1153,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1388,6 +1388,10 @@ msgstr "設定の構文エラー: %s"
 msgid "Console log:"
 msgstr "コンソールログ:"
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
@@ -1568,8 +1572,13 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr "必要なディレクトリをすべて作成します"
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "必要なディレクトリをすべて作成します"
 
 #: lxc/snapshot.go:27
@@ -1662,6 +1671,11 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "%s を作成中"
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
@@ -1718,7 +1732,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1818,70 +1832,71 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1985,7 +2000,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2051,7 +2066,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2067,7 +2082,7 @@ msgstr "クラスタグループを編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2351,12 +2366,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2371,12 +2386,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2396,7 +2411,7 @@ msgstr "クライアント %q に対する SFTP インスタンスの接続に�
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2411,7 +2426,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2421,12 +2436,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2465,7 +2480,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2480,7 +2495,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2507,6 +2522,10 @@ msgstr "証明書のフィンガープリント: %s"
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
+msgstr ""
 
 #: lxc/cluster.go:1197
 msgid "Force evacuation without user confirmation"
@@ -2799,22 +2818,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -2998,11 +3017,11 @@ msgstr "入力するデータ"
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3016,7 +3035,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3069,7 +3088,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3118,7 +3137,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3134,14 +3153,19 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr "不正な送り先 %s"
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
 
 #: lxc/info.go:230
@@ -3761,7 +3785,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -4120,7 +4144,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4161,13 +4185,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4626,7 +4650,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -4864,20 +4888,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -4917,7 +4941,7 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -5222,12 +5246,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5300,7 +5324,7 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5551,15 +5575,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "プッシュ時にファイルのgidを設定します"
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "プッシュ時にファイルのパーミションを設定します"
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "プッシュ時にファイルのuidを設定します"
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -5628,7 +5667,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -5969,6 +6008,10 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr "TARGET"
@@ -5988,11 +6031,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6023,6 +6066,11 @@ msgstr "--storage と --target は同時に指定できません"
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
+
+#: lxc/file.go:1085
+#, fuzzy
+msgid "The content of the created file"
+msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -6175,6 +6223,10 @@ msgstr "指定したデバイスが存在しません"
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:83
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6366,7 +6418,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -6380,7 +6432,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -6396,7 +6448,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -6619,7 +6671,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6927,21 +6979,26 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7461,7 +7518,15 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7470,7 +7535,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -7480,7 +7545,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7807,16 +7872,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -333,12 +333,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -427,7 +427,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1116,6 +1116,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1281,8 +1285,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1371,6 +1379,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1427,7 +1440,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1527,70 +1540,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1688,7 +1702,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1754,7 +1768,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1768,7 +1782,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2026,12 +2040,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2046,12 +2060,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2071,7 +2085,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2086,7 +2100,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2096,12 +2110,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2140,7 +2154,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2155,7 +2169,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2181,6 +2195,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2449,22 +2467,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2636,11 +2654,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2654,7 +2672,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2706,7 +2724,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2748,7 +2766,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2764,14 +2782,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3250,7 +3273,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3592,7 +3615,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3630,11 +3653,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4077,7 +4100,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4310,20 +4333,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4361,7 +4384,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,12 +4681,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4735,7 +4758,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4929,15 +4952,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4997,7 +5032,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5337,6 +5372,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5356,11 +5395,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5390,6 +5429,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5537,6 +5580,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5708,7 +5755,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5722,7 +5769,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5738,7 +5785,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5948,7 +5995,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6248,20 +6295,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6729,20 +6780,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6968,16 +7027,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-11-07 10:34+0100\n"
+        "POT-Creation-Date: 2023-11-10 09:03+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -311,12 +311,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -404,7 +404,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -828,7 +828,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -857,7 +857,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1044,6 +1044,10 @@ msgstr  ""
 msgid   "Console log:"
 msgstr  ""
 
+#: lxc/file.go:1104
+msgid   "Content can only be used for type \"file\""
+msgstr  ""
+
 #: lxc/storage_volume.go:538
 msgid   "Content type, block or filesystem"
 msgstr  ""
@@ -1202,8 +1206,12 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid   "Create any directories necessary"
+msgstr  ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid   "Create files and directories in instances"
 msgstr  ""
 
 #: lxc/snapshot.go:27
@@ -1291,6 +1299,11 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid   "Creating %s: %%s"
+msgstr  ""
+
 #: lxc/init.go:160
 msgid   "Creating the instance"
 msgstr  ""
@@ -1340,7 +1353,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1416,7 +1429,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175 lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1498,7 +1511,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1564,7 +1577,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1576,7 +1589,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1814,12 +1827,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1834,12 +1847,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -1859,7 +1872,7 @@ msgstr  ""
 msgid   "Failed deleting instance snapshot %q in project %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -1874,7 +1887,7 @@ msgstr  ""
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -1884,12 +1897,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -1928,7 +1941,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -1943,7 +1956,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1968,6 +1981,10 @@ msgstr  ""
 
 #: lxc/cluster.go:1170
 msgid   "Force a particular evacuation action"
+msgstr  ""
+
+#: lxc/file.go:1081
+msgid   "Force creating files or directories"
 msgstr  ""
 
 #: lxc/cluster.go:1197
@@ -2222,22 +2239,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2406,11 +2423,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2424,7 +2441,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2476,7 +2493,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2517,7 +2534,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2531,14 +2548,19 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid   "Invalid target %s"
+msgstr  ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid   "Invalid type %q"
 msgstr  ""
 
 #: lxc/info.go:230
@@ -3002,7 +3024,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -3278,7 +3300,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3314,11 +3336,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3746,7 +3768,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -3955,20 +3977,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4006,7 +4028,7 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -4299,12 +4321,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4375,7 +4397,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4541,15 +4563,27 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid   "Set the file's gid on create"
+msgstr  ""
+
+#: lxc/file.go:476
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid   "Set the file's perms on create"
+msgstr  ""
+
+#: lxc/file.go:477
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid   "Set the file's uid on create"
+msgstr  ""
+
+#: lxc/file.go:475
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4609,7 +4643,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4949,6 +4983,10 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
+#: lxc/file.go:1108
+msgid   "Symlink target path can only be used for type \"symlink\""
+msgstr  ""
+
 #: lxc/alias.go:140
 msgid   "TARGET"
 msgstr  ""
@@ -4965,11 +5003,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -4999,6 +5037,10 @@ msgstr  ""
 
 #: lxc/move.go:175
 msgid   "The --target-project flag can't be used with --target"
+msgstr  ""
+
+#: lxc/file.go:1085
+msgid   "The content of the created file"
 msgstr  ""
 
 #: lxc/move.go:191
@@ -5142,6 +5184,10 @@ msgstr  ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid   "The specified device doesn't match the network"
+msgstr  ""
+
+#: lxc/file.go:1086
+msgid   "The type to create (file, symlink, or directory)"
 msgstr  ""
 
 #: lxc/publish.go:83
@@ -5302,7 +5348,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -5316,7 +5362,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -5331,7 +5377,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5538,7 +5584,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -5823,19 +5869,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr  ""
+
+#: lxc/file.go:123
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6269,17 +6319,24 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid   "lxc file create foo/bar\n"
+        "   To create a file /bar in the foo instance.\n"
+        "lxc file create --type=symlink foo/bar baz\n"
+        "   To create a symlink /bar in instance foo whose target is baz."
+msgstr  ""
+
+#: lxc/file.go:978
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -6471,16 +6528,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -553,12 +553,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -647,7 +647,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1111,7 +1111,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1336,6 +1336,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1501,8 +1505,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1591,6 +1599,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1647,7 +1660,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1747,70 +1760,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1908,7 +1922,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1974,7 +1988,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2246,12 +2260,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2266,12 +2280,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2291,7 +2305,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2306,7 +2320,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2316,12 +2330,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2375,7 +2389,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2401,6 +2415,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2669,22 +2687,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2856,11 +2874,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2892,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2944,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2986,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +3002,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3470,7 +3493,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3812,7 +3835,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3850,11 +3873,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4297,7 +4320,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4530,20 +4553,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4581,7 +4604,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4878,12 +4901,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4955,7 +4978,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5149,15 +5172,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5217,7 +5252,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5557,6 +5592,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5576,11 +5615,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5610,6 +5649,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5757,6 +5800,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5928,7 +5975,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5942,7 +5989,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5958,7 +6005,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6168,7 +6215,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6468,20 +6515,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6949,20 +7000,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7188,16 +7247,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -587,12 +587,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -681,7 +681,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1370,6 +1370,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1535,8 +1539,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1625,6 +1633,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1681,7 +1694,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1781,70 +1794,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1942,7 +1956,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2008,7 +2022,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2022,7 +2036,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2280,12 +2294,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2300,12 +2314,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2325,7 +2339,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2340,7 +2354,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2350,12 +2364,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2394,7 +2408,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2409,7 +2423,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2435,6 +2449,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2703,22 +2721,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2890,11 +2908,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2908,7 +2926,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2960,7 +2978,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3002,7 +3020,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3018,14 +3036,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3504,7 +3527,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3846,7 +3869,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3884,11 +3907,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4331,7 +4354,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4564,20 +4587,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4615,7 +4638,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4912,12 +4935,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4989,7 +5012,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5183,15 +5206,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5251,7 +5286,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5591,6 +5626,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5610,11 +5649,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5644,6 +5683,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5791,6 +5834,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5962,7 +6009,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5976,7 +6023,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5992,7 +6039,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6202,7 +6249,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6502,20 +6549,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6983,20 +7034,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7222,16 +7281,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -333,12 +333,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -427,7 +427,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1116,6 +1116,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1281,8 +1285,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1371,6 +1379,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1427,7 +1440,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1527,70 +1540,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1688,7 +1702,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1754,7 +1768,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1768,7 +1782,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2026,12 +2040,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2046,12 +2060,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2071,7 +2085,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2086,7 +2100,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2096,12 +2110,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2140,7 +2154,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2155,7 +2169,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2181,6 +2195,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2449,22 +2467,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2636,11 +2654,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2654,7 +2672,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2706,7 +2724,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2748,7 +2766,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2764,14 +2782,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3250,7 +3273,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3592,7 +3615,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3630,11 +3653,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4077,7 +4100,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4310,20 +4333,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4361,7 +4384,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,12 +4681,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4735,7 +4758,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4929,15 +4952,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4997,7 +5032,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5337,6 +5372,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5356,11 +5395,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5390,6 +5429,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5537,6 +5580,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5708,7 +5755,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5722,7 +5769,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5738,7 +5785,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5948,7 +5995,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6248,20 +6295,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6729,20 +6780,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6968,16 +7027,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -577,12 +577,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -681,7 +681,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -1135,7 +1135,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1165,7 +1165,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1400,6 +1400,10 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Console log:"
 msgstr "Log de Console:"
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1568,9 +1572,14 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Editar arquivos no container"
 
 #: lxc/snapshot.go:27
 msgid "Create instance snapshots"
@@ -1671,6 +1680,11 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
+#: lxc/file.go:1229
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Criando %s"
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1730,7 +1744,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1840,70 +1854,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -2005,7 +2020,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2074,7 +2089,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2089,7 +2104,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2361,12 +2376,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2381,12 +2396,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2406,7 +2421,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2421,7 +2436,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2431,12 +2446,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2475,7 +2490,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2490,7 +2505,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2516,6 +2531,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2804,22 +2823,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -2993,11 +3012,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3011,7 +3030,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3063,7 +3082,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3106,7 +3125,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3123,15 +3142,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Editar arquivos no container"
 
 #: lxc/info.go:230
 #, fuzzy, c-format
@@ -3621,7 +3645,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -3993,7 +4017,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -4032,11 +4056,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4481,7 +4505,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4719,21 +4743,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4773,7 +4797,7 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5092,12 +5116,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5170,7 +5194,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5375,15 +5399,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5450,7 +5486,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5810,6 +5846,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5829,12 +5869,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5869,6 +5909,11 @@ msgstr "--refresh só pode ser usado com containers"
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
+
+#: lxc/file.go:1085
+#, fuzzy
+msgid "The content of the created file"
+msgstr "Editar templates de arquivo do container"
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -6015,6 +6060,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -6188,7 +6237,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6203,7 +6252,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6219,7 +6268,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6454,7 +6503,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6776,20 +6825,25 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Editar templates de arquivo do container"
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7301,20 +7355,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7540,16 +7602,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -586,12 +586,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -681,7 +681,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1388,6 +1388,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1557,9 +1561,14 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/snapshot.go:27
 #, fuzzy
@@ -1660,6 +1669,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 #, fuzzy
 msgid "Creating the instance"
@@ -1717,7 +1731,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1826,70 +1840,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1989,7 +2004,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2059,7 +2074,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2073,7 +2088,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2347,12 +2362,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2367,12 +2382,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2392,7 +2407,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2407,7 +2422,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2417,12 +2432,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2461,7 +2476,7 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2476,7 +2491,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2502,6 +2517,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2787,22 +2806,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2979,11 +2998,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2998,7 +3017,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3050,7 +3069,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3093,7 +3112,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3110,15 +3129,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:1100
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Имя контейнера: %s"
 
 #: lxc/info.go:230
 #, c-format
@@ -3616,7 +3640,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3992,7 +4016,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -4031,11 +4055,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4485,7 +4509,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4718,20 +4742,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4771,7 +4795,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5087,12 +5111,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5165,7 +5189,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5365,15 +5389,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5441,7 +5477,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5801,6 +5837,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5820,11 +5860,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5855,6 +5895,11 @@ msgstr ""
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
+
+#: lxc/file.go:1085
+#, fuzzy
+msgid "The content of the created file"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/move.go:191
 msgid "The destination LXD server is not clustered"
@@ -6001,6 +6046,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -6173,7 +6222,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6187,7 +6236,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6203,7 +6252,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6434,7 +6483,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6930,7 +6979,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -6938,7 +6987,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/file.go:123
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -6946,7 +7003,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -6955,7 +7012,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7767,20 +7824,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8006,16 +8071,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -337,12 +337,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -431,7 +431,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1120,6 +1120,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1285,8 +1289,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1375,6 +1383,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1431,7 +1444,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1531,70 +1544,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1692,7 +1706,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1758,7 +1772,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1786,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2030,12 +2044,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2050,12 +2064,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2075,7 +2089,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2090,7 +2104,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2100,12 +2114,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2144,7 +2158,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2159,7 +2173,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2185,6 +2199,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2453,22 +2471,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2640,11 +2658,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2658,7 +2676,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2710,7 +2728,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2752,7 +2770,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2768,14 +2786,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3254,7 +3277,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3596,7 +3619,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3634,11 +3657,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4104,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4314,20 +4337,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4365,7 +4388,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,12 +4685,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4739,7 +4762,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4933,15 +4956,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5001,7 +5036,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5341,6 +5376,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5360,11 +5399,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5394,6 +5433,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5541,6 +5584,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5712,7 +5759,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5726,7 +5773,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5742,7 +5789,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5952,7 +5999,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6252,20 +6299,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6733,20 +6784,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6972,16 +7031,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -337,12 +337,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -431,7 +431,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1120,6 +1120,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1285,8 +1289,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1375,6 +1383,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1431,7 +1444,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1531,70 +1544,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1692,7 +1706,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1758,7 +1772,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1786,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2030,12 +2044,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2050,12 +2064,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2075,7 +2089,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2090,7 +2104,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2100,12 +2114,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2144,7 +2158,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2159,7 +2173,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2185,6 +2199,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2453,22 +2471,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2640,11 +2658,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2658,7 +2676,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2710,7 +2728,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2752,7 +2770,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2768,14 +2786,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3254,7 +3277,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3596,7 +3619,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3634,11 +3657,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4104,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4314,20 +4337,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4365,7 +4388,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,12 +4685,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4739,7 +4762,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4933,15 +4956,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5001,7 +5036,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5341,6 +5376,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5360,11 +5399,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5394,6 +5433,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5541,6 +5584,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5712,7 +5759,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5726,7 +5773,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5742,7 +5789,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5952,7 +5999,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6252,20 +6299,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6733,20 +6784,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6972,16 +7031,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -333,12 +333,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -427,7 +427,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1116,6 +1116,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1281,8 +1285,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1371,6 +1379,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1427,7 +1440,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1527,70 +1540,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1688,7 +1702,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1754,7 +1768,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1768,7 +1782,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2026,12 +2040,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2046,12 +2060,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2071,7 +2085,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2086,7 +2100,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2096,12 +2110,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2140,7 +2154,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2155,7 +2169,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2181,6 +2195,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2449,22 +2467,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2636,11 +2654,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2654,7 +2672,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2706,7 +2724,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2748,7 +2766,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2764,14 +2782,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3250,7 +3273,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3592,7 +3615,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3630,11 +3653,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4077,7 +4100,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4310,20 +4333,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4361,7 +4384,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4658,12 +4681,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4735,7 +4758,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4929,15 +4952,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -4997,7 +5032,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5337,6 +5372,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5356,11 +5395,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5390,6 +5429,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5537,6 +5580,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5708,7 +5755,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5722,7 +5769,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5738,7 +5785,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5948,7 +5995,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6248,20 +6295,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6729,20 +6780,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6968,16 +7027,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -337,12 +337,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -431,7 +431,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1120,6 +1120,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1285,8 +1289,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1375,6 +1383,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1431,7 +1444,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1531,70 +1544,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1692,7 +1706,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1758,7 +1772,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1772,7 +1786,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2030,12 +2044,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2050,12 +2064,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2075,7 +2089,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2090,7 +2104,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2100,12 +2114,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2144,7 +2158,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2159,7 +2173,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2185,6 +2199,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2453,22 +2471,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2640,11 +2658,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2658,7 +2676,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2710,7 +2728,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2752,7 +2770,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2768,14 +2786,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3254,7 +3277,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3596,7 +3619,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3634,11 +3657,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4081,7 +4104,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4314,20 +4337,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4365,7 +4388,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4662,12 +4685,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4739,7 +4762,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4933,15 +4956,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5001,7 +5036,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5341,6 +5376,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5360,11 +5399,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5394,6 +5433,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5541,6 +5584,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5712,7 +5759,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5726,7 +5773,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5742,7 +5789,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5952,7 +5999,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6252,20 +6299,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6733,20 +6784,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6972,16 +7031,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -486,12 +486,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -580,7 +580,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1269,6 +1269,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1434,8 +1438,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1524,6 +1532,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1580,7 +1593,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1680,70 +1693,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1841,7 +1855,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1907,7 +1921,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1921,7 +1935,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2179,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2199,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2224,7 +2238,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2239,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2249,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2293,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2308,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2334,6 +2348,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2602,22 +2620,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2789,11 +2807,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2807,7 +2825,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2859,7 +2877,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2901,7 +2919,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2917,14 +2935,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3403,7 +3426,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3745,7 +3768,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3783,11 +3806,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4230,7 +4253,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4463,20 +4486,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4514,7 +4537,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4811,12 +4834,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4888,7 +4911,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5082,15 +5105,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5150,7 +5185,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5490,6 +5525,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5509,11 +5548,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5543,6 +5582,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5690,6 +5733,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5861,7 +5908,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5875,7 +5922,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5891,7 +5938,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6101,7 +6148,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6401,20 +6448,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6882,20 +6933,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7121,16 +7180,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-07 10:34+0100\n"
+"POT-Creation-Date: 2023-11-10 09:03+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -336,12 +336,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:925
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:815
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:465
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:332
+#: lxc/file.go:340
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:538
+#: lxc/file.go:546
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1119,6 +1119,10 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
+#: lxc/file.go:1104
+msgid "Content can only be used for type \"file\""
+msgstr ""
+
 #: lxc/storage_volume.go:538
 msgid "Content type, block or filesystem"
 msgstr ""
@@ -1284,8 +1288,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:243 lxc/file.go:466
+#: lxc/file.go:251 lxc/file.go:474 lxc/file.go:1080
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:1071 lxc/file.go:1072
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/snapshot.go:27
@@ -1374,6 +1382,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:1229
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:160
 msgid "Creating the instance"
 msgstr ""
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:117 lxc/file.go:118
+#: lxc/file.go:125 lxc/file.go:126
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1530,70 +1543,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
-#: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
-#: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
-#: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
-#: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
-#: lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216
-#: lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94
-#: lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266
-#: lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492
-#: lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702
-#: lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887
-#: lxc/network_allocations.go:51 lxc/network_forward.go:29
-#: lxc/network_forward.go:86 lxc/network_forward.go:167
-#: lxc/network_forward.go:231 lxc/network_forward.go:329
-#: lxc/network_forward.go:398 lxc/network_forward.go:496
-#: lxc/network_forward.go:526 lxc/network_forward.go:668
-#: lxc/network_forward.go:730 lxc/network_forward.go:745
-#: lxc/network_forward.go:810 lxc/network_load_balancer.go:29
-#: lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169
-#: lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331
-#: lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497
-#: lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670
-#: lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746
-#: lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896
-#: lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972
-#: lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158
-#: lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399
-#: lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643
-#: lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156
-#: lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354
-#: lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584
-#: lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759
-#: lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952
-#: lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176
-#: lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424
-#: lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750
-#: lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
-#: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
-#: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88
-#: lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823
-#: lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24
-#: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
-#: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
-#: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183
-#: lxc/storage_bucket.go:244 lxc/storage_bucket.go:377
-#: lxc/storage_bucket.go:453 lxc/storage_bucket.go:530
-#: lxc/storage_bucket.go:624 lxc/storage_bucket.go:693
-#: lxc/storage_bucket.go:727 lxc/storage_bucket.go:768
-#: lxc/storage_bucket.go:847 lxc/storage_bucket.go:925
-#: lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124
-#: lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240
+#: lxc/export.go:32 lxc/file.go:82 lxc/file.go:126 lxc/file.go:175
+#: lxc/file.go:245 lxc/file.go:467 lxc/file.go:976 lxc/file.go:1072
+#: lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363
+#: lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019
+#: lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529
+#: lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220
+#: lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507
+#: lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912
+#: lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128
+#: lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29
+#: lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218
+#: lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412
+#: lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653
+#: lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766
+#: lxc/network_acl.go:887 lxc/network_allocations.go:51
+#: lxc/network_forward.go:29 lxc/network_forward.go:86
+#: lxc/network_forward.go:167 lxc/network_forward.go:231
+#: lxc/network_forward.go:329 lxc/network_forward.go:398
+#: lxc/network_forward.go:496 lxc/network_forward.go:526
+#: lxc/network_forward.go:668 lxc/network_forward.go:730
+#: lxc/network_forward.go:745 lxc/network_forward.go:810
+#: lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90
+#: lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233
+#: lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399
+#: lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527
+#: lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731
+#: lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810
+#: lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911
+#: lxc/network_load_balancer.go:972 lxc/network_peer.go:28
+#: lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215
+#: lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488
+#: lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28
+#: lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211
+#: lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434
+#: lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632
+#: lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811
+#: lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028
+#: lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225
+#: lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250
+#: lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552
+#: lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802
+#: lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93
+#: lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410
+#: lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690
+#: lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34
+#: lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628
+#: lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878
+#: lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
+#: lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220
+#: lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665
+#: lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244
+#: lxc/storage_bucket.go:377 lxc/storage_bucket.go:453
+#: lxc/storage_bucket.go:530 lxc/storage_bucket.go:624
+#: lxc/storage_bucket.go:693 lxc/storage_bucket.go:727
+#: lxc/storage_bucket.go:768 lxc/storage_bucket.go:847
+#: lxc/storage_bucket.go:925 lxc/storage_bucket.go:989
+#: lxc/storage_bucket.go:1124 lxc/storage_volume.go:43
+#: lxc/storage_volume.go:165 lxc/storage_volume.go:240
 #: lxc/storage_volume.go:331 lxc/storage_volume.go:534
 #: lxc/storage_volume.go:613 lxc/storage_volume.go:688
 #: lxc/storage_volume.go:770 lxc/storage_volume.go:851
@@ -1691,7 +1705,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:984
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1757,7 +1771,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:69
+#: lxc/file.go:73
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1771,7 +1785,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:166 lxc/file.go:167
+#: lxc/file.go:174 lxc/file.go:175
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2029,12 +2043,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2049,12 +2063,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2074,7 +2088,7 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2089,7 +2103,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2099,12 +2113,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2143,7 +2157,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2158,7 +2172,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:810
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2184,6 +2198,10 @@ msgstr ""
 
 #: lxc/cluster.go:1170
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:1081
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1197
@@ -2452,22 +2470,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2639,11 +2657,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2657,7 +2675,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1034
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2709,7 +2727,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1029
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2751,7 +2769,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:142
+#: lxc/file.go:150
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2767,14 +2785,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:305
+#: lxc/file.go:313
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:487
+#: lxc/file.go:495 lxc/file.go:1118
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:1100
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:230
@@ -3253,7 +3276,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:77 lxc/file.go:78
+#: lxc/file.go:81 lxc/file.go:82
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:586
+#: lxc/file.go:594
 msgid "Missing target directory"
 msgstr ""
 
@@ -3633,11 +3656,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:280
+#: lxc/file.go:288
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:975 lxc/file.go:976
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4080,7 +4103,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4313,20 +4336,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:236 lxc/file.go:237
+#: lxc/file.go:244 lxc/file.go:245
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:416 lxc/file.go:757
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:458 lxc/file.go:459
+#: lxc/file.go:466 lxc/file.go:467
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:691 lxc/file.go:857
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4364,7 +4387,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:244 lxc/file.go:465
+#: lxc/file.go:252 lxc/file.go:473
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4661,12 +4684,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -4738,7 +4761,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:985
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -4932,15 +4955,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:468
+#: lxc/file.go:1082
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:476
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:1084
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:477
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:467
+#: lxc/file.go:1083
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:475
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5000,7 +5035,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:983
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5340,6 +5375,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:1108
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5359,11 +5398,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1022
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1016
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5393,6 +5432,10 @@ msgstr ""
 
 #: lxc/move.go:175
 msgid "The --target-project flag can't be used with --target"
+msgstr ""
+
+#: lxc/file.go:1085
+msgid "The content of the created file"
 msgstr ""
 
 #: lxc/move.go:191
@@ -5540,6 +5583,10 @@ msgstr ""
 
 #: lxc/network.go:484 lxc/network.go:569
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:1086
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:83
@@ -5711,7 +5758,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:200
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -5725,7 +5772,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -5741,7 +5788,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:797
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -5951,7 +5998,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:66
+#: lxc/file.go:70
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6251,20 +6298,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:165
+#: lxc/file.go:173
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:115
+#: lxc/file.go:1070
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:123
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:235
+#: lxc/file.go:243
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:974
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6732,20 +6783,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:1074
+msgid ""
+"lxc file create foo/bar\n"
+"   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:978
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:239
+#: lxc/file.go:247
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:461
+#: lxc/file.go:469
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -6971,16 +7030,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1044
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -117,6 +117,32 @@ test_filemanip() {
     lxc delete idmap --force
   fi
 
+  # Test lxc file create.
+
+  # Create a new empty file.
+  lxc file create filemanip/tmp/create-test
+  [ -z "$(lxc exec filemanip --project=test -- cat /tmp/create-test)" ]
+  # This fails because the parent directory doesn't exist.
+  ! lxc file create filemanip/tmp/create-test-dir/foo || false
+  # Create foo along with the parent directory.
+  lxc file create --create-dirs filemanip/tmp/create-test-dir/foo
+  [ -z "$(lxc exec filemanip --project=test -- cat /tmp/create-test-dir/foo)" ]
+  # Overwrite previously created file, and add content.
+  lxc file create -f --content="foo" filemanip/tmp/create-test-dir/foo
+  [ "$(lxc exec filemanip --project=test -- cat /tmp/create-test-dir/foo)" = "foo" ]
+  # Overwrite previously created file, and add content from stdin.
+  echo bar | lxc file create -f --content=- filemanip/tmp/create-test-dir/foo
+  [ "$(lxc exec filemanip --project=test -- cat /tmp/create-test-dir/foo)" = "bar" ]
+  # Create directory using --type flag.
+  lxc file create --type=directory filemanip/tmp/create-test-dir/sub-dir
+  lxc exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir
+  # Create directory using trailing "/".
+  lxc file create filemanip/tmp/create-test-dir/sub-dir-1/
+  lxc exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir-1
+  # Create symlink.
+  lxc file create --type=symlink filemanip/tmp/create-symlink foo
+  [ "$(lxc exec filemanip --project=test -- readlink /tmp/create-symlink)" = "foo" ]
+
   # Test SFTP functionality.
   cmd=$(unset -f lxc; command -v lxc)
   $cmd file mount filemanip --listen=127.0.0.1:2022 --no-auth &


### PR DESCRIPTION
This adds a new `lxc file create` subcommand which allows creating files, symlinks, and directories without having to specify a source.

Fixes #12437
