### PR TITLE
lxd/instance/exec: Only use keepalives on TCP sockets

### DIFF
--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -99,23 +99,23 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 					if err != nil {
 						logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 					}
-				}
 
-				// Start channel keep alive to run until channel is closed.
-				go func() {
-					pingInterval := time.Second * 10
-					t := time.NewTicker(pingInterval)
-					defer t.Stop()
+					// Start channel keep alive to run until channel is closed.
+					go func() {
+						pingInterval := time.Second * 10
+						t := time.NewTicker(pingInterval)
+						defer t.Stop()
 
-					for {
-						err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
-						if err != nil {
-							return
+						for {
+							err := conn.WriteControl(websocket.PingMessage, []byte("keepalive"), time.Now().Add(5*time.Second))
+							if err != nil {
+								return
+							}
+
+							<-t.C
 						}
-
-						<-t.C
-					}
-				}()
+					}()
+				}
 
 				if fd == execWSControl {
 					s.waitControlConnected.Cancel() // Control connection connected.


### PR DESCRIPTION
Keepalives aren't particularly useful on Unix sockets, and it seems that there are some issues with them sometimes being written but not read: this means that processes launched via `lxc exec` can sometimes eventually hang because a websocket buffer fills up, causing an attempt to send a keepalive to return `EAGAIN`, causing LXD to give up on mirroring output from the corresponding file descriptor, and thus eventually causing subprocesses to hang when the buffer for their standard output/error fills up in turn.

I've observed this particularly on slower architectures such as riscv64 and arm64 in the context of non-interactive `lxc exec` via `launchpad-buildd`, though I don't quite know the exact set of triggers and so don't have a minimal test case - the best I have is building a snap from `https://git.launchpad.net/~canonical-lxd/lxd latest-candidate` in `launchpad-buildd` on riscv64, which reliably hangs prior to this change.