### PR TITLE
Show mounted status of disks and partitions

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2346,3 +2346,8 @@ This extends the metrics to include the containers and virtual machines counts. 
 This API extension enables querying a server's supported instance types.
 When querying the `/1.0` endpoint, a new field named `instance_types` is added to the retrieved data.
 This field indicates which instance types are supported by the server.
+
+## `resources_disk_mounted`
+
+Adds a `mounted` field to disk resources that LXD discovers on the system, reporting whether that disk or partition is
+mounted.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4808,6 +4808,11 @@ definitions:
                 example: INTEL SSDPEKKW256G7
                 type: string
                 x-go-name: Model
+            mounted:
+                description: Mounted status of the disk
+                example: true
+                type: boolean
+                x-go-name: Mounted
             numa_node:
                 description: NUMA node the disk is a part of
                 example: 0
@@ -4882,6 +4887,11 @@ definitions:
                 example: nvme0n1p1
                 type: string
                 x-go-name: ID
+            mounted:
+                description: Mounted status of the partition.
+                example: true
+                type: boolean
+                x-go-name: Mounted
             partition:
                 description: Partition number
                 example: 1

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -280,6 +280,7 @@ func (c *cmdInfo) renderDisk(disk api.ResourcesStorageDisk, prefix string, initi
 	}
 
 	fmt.Printf(prefix+i18n.G("Read-Only: %v")+"\n", disk.ReadOnly)
+	fmt.Printf(prefix+i18n.G("Mounted: %v")+"\n", disk.Mounted)
 	fmt.Printf(prefix+i18n.G("Removable: %v")+"\n", disk.Removable)
 
 	if len(disk.Partitions) != 0 {
@@ -289,6 +290,7 @@ func (c *cmdInfo) renderDisk(disk api.ResourcesStorageDisk, prefix string, initi
 			fmt.Printf(prefix+"    "+i18n.G("ID: %s")+"\n", partition.ID)
 			fmt.Printf(prefix+"    "+i18n.G("Device: %s")+"\n", partition.Device)
 			fmt.Printf(prefix+"    "+i18n.G("Read-Only: %v")+"\n", partition.ReadOnly)
+			fmt.Printf(prefix+"    "+i18n.G("Mounted: %v")+"\n", partition.Mounted)
 			fmt.Printf(prefix+"    "+i18n.G("Size: %s")+"\n", units.GetByteSizeStringIEC(int64(partition.Size), 2))
 		}
 	}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -347,12 +347,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -399,7 +399,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -786,11 +786,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -819,15 +819,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1209,12 +1209,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1700,20 +1700,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2261,17 +2261,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2280,11 +2280,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2441,11 +2441,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2632,7 +2632,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3150,7 +3150,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3423,19 +3423,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3638,6 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3713,11 +3718,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3732,7 +3737,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3745,7 +3750,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3754,12 +3759,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3858,7 +3863,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3927,7 +3932,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3973,7 +3978,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3998,7 +4003,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4027,15 +4032,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4109,7 +4114,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4348,7 +4353,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4417,7 +4422,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4562,7 +4567,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5170,7 +5175,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5183,11 +5188,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5210,7 +5215,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5219,11 +5224,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5321,11 +5326,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5352,7 +5357,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5518,7 +5523,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5559,7 +5564,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5590,7 +5595,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5599,7 +5604,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5648,7 +5653,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5662,13 +5667,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5885,7 +5890,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5931,7 +5936,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5966,7 +5971,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -563,7 +563,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
@@ -592,12 +592,12 @@ msgstr "'%s' ist kein unterstützter Dateityp"
 msgid "(none)"
 msgstr "(kein Wert)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Level %d (Typ: %s): %s"
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
@@ -651,7 +651,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1019,7 +1019,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1067,11 +1067,11 @@ msgstr "Erstellt: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
@@ -1100,16 +1100,16 @@ msgstr " Prozessorauslastung:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1137,7 +1137,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 #, fuzzy
 msgid "Caches:"
 msgstr ""
@@ -1224,7 +1224,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1513,12 +1513,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Fehler: %v\n"
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 #, fuzzy
 msgid "Cores:"
 msgstr "Fehler: %v\n"
@@ -1684,7 +1684,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2044,22 +2044,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
@@ -2330,7 +2330,7 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2641,17 +2641,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2660,11 +2660,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2841,12 +2841,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3039,7 +3039,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
@@ -3586,7 +3586,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3595,7 +3595,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3613,7 +3613,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -3661,7 +3661,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3906,19 +3906,19 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -4140,6 +4140,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, fuzzy, c-format
+msgid "Mounted: %v"
+msgstr "Erstellt: %s"
+
 #: lxc/move.go:36
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
@@ -4219,11 +4224,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4238,7 +4243,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4251,7 +4256,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4260,12 +4265,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4365,7 +4370,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -4438,7 +4443,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4485,7 +4490,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4510,7 +4515,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4539,15 +4544,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4624,7 +4629,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -4872,7 +4877,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4944,7 +4949,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -5106,7 +5111,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5766,7 +5771,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Erstellt: %s"
@@ -5780,11 +5785,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5808,7 +5813,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -5818,11 +5823,11 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5926,11 +5931,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5957,7 +5962,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -6129,7 +6134,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6172,7 +6177,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -6205,7 +6210,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6214,7 +6219,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6263,7 +6268,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -6278,13 +6283,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6527,7 +6532,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6575,7 +6580,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6610,7 +6615,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "Fehler: %v\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -792,11 +792,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
@@ -825,16 +825,16 @@ msgstr "  Χρήση CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1216,12 +1216,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1686,7 +1686,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1715,22 +1715,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
@@ -1981,7 +1981,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2284,17 +2284,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2303,11 +2303,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2477,11 +2477,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2668,7 +2668,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3179,7 +3179,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3204,7 +3204,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3471,20 +3471,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 #, fuzzy
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
@@ -3693,6 +3693,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3768,11 +3773,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3787,7 +3792,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3800,7 +3805,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3809,12 +3814,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3914,7 +3919,7 @@ msgstr ""
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -3984,7 +3989,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4030,7 +4035,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4055,7 +4060,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4084,15 +4089,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4167,7 +4172,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4406,7 +4411,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4475,7 +4480,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4625,7 +4630,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5257,7 +5262,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5270,11 +5275,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5297,7 +5302,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5306,11 +5311,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5408,11 +5413,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5439,7 +5444,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5605,7 +5610,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5646,7 +5651,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5677,7 +5682,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5686,7 +5691,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5735,7 +5740,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5749,13 +5754,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5989,7 +5994,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6035,7 +6040,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6070,7 +6075,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -553,7 +553,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -582,12 +582,12 @@ msgstr "%s no es un tipo de archivo soportado."
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partición %d"
@@ -638,7 +638,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -985,7 +985,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1034,11 +1034,11 @@ msgstr "Creado: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1067,15 +1067,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1098,7 +1098,7 @@ msgstr "Versión de CUDA: %v"
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 #, fuzzy
 msgid "Caches:"
 msgstr "Cacheado: %s"
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1465,12 +1465,12 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "Expira: %s"
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 #, fuzzy
 msgid "Cores:"
 msgstr "Expira: %s"
@@ -1624,7 +1624,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1942,7 +1942,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
@@ -1971,20 +1971,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr "Disco:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr "Discos:"
 
@@ -2237,7 +2237,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 #, fuzzy
 msgid "Expires at"
@@ -2544,17 +2544,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2563,11 +2563,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2737,12 +2737,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2775,7 +2775,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3122,7 +3122,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Creado: %s"
@@ -3456,7 +3456,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3465,7 +3465,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr "Registro:"
 
@@ -3481,7 +3481,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -3525,7 +3525,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3750,19 +3750,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3981,6 +3981,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, fuzzy, c-format
+msgid "Mounted: %v"
+msgstr "Creado: %s"
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -4056,11 +4061,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4075,7 +4080,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4088,7 +4093,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4097,12 +4102,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4201,7 +4206,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4270,7 +4275,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4316,7 +4321,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4341,7 +4346,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4370,15 +4375,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4453,7 +4458,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -4696,7 +4701,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4767,7 +4772,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4919,7 +4924,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5556,7 +5561,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
@@ -5569,11 +5574,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5596,7 +5601,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -5606,11 +5611,11 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5708,11 +5713,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5739,7 +5744,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5907,7 +5912,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5949,7 +5954,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5980,7 +5985,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5989,7 +5994,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6038,7 +6043,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -6054,13 +6059,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6294,7 +6299,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6341,7 +6346,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6376,7 +6381,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -561,7 +561,7 @@ msgstr ""
 "### Ceci est une représentation yaml d'un membre du cluster.\n"
 "### Toute ligne commençant par un '#' sera ignorée."
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
@@ -590,12 +590,12 @@ msgstr "'%s' n'est pas un format de fichier pris en charge."
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Niveau %d (type: %s): %s"
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partition %d"
@@ -643,7 +643,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
 
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1023,7 +1023,7 @@ msgstr "Copie de l'image : %s"
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1071,11 +1071,11 @@ msgstr "Créé : %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
@@ -1104,15 +1104,15 @@ msgstr "CPU utilisé :"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1136,7 +1136,7 @@ msgstr "Afficher la version du client"
 msgid "Cached: %s"
 msgstr "Créé : %s"
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 #, fuzzy
 msgid "Caches:"
 msgstr "Créé : %s"
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1517,12 +1517,12 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, fuzzy, c-format
 msgid "Core %d"
 msgstr "erreur : %v"
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 #, fuzzy
 msgid "Cores:"
 msgstr "erreur : %v"
@@ -1704,7 +1704,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -2033,7 +2033,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
@@ -2063,22 +2063,22 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr "  Disque utilisé :"
@@ -2359,7 +2359,7 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 #, fuzzy
 msgid "Expires at"
@@ -2674,17 +2674,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2693,11 +2693,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2876,12 +2876,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgstr "PID"
 msgid "ID: %d"
 msgstr "Pid : %d"
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2928,7 +2928,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3081,7 +3081,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -3274,7 +3274,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3681,7 +3681,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr "Journal : "
 
@@ -3699,7 +3699,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -3743,7 +3743,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3986,20 +3986,20 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 #, fuzzy
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
@@ -4226,6 +4226,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, fuzzy, c-format
+msgid "Mounted: %v"
+msgstr "Publié : %s"
+
 #: lxc/move.go:36
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
@@ -4305,11 +4310,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4324,7 +4329,7 @@ msgstr "NON"
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4337,7 +4342,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 #, fuzzy
 msgid "Name"
@@ -4347,12 +4352,12 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, fuzzy, c-format
 msgid "Name: %v"
 msgstr "Nom : %s"
@@ -4452,7 +4457,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -4525,7 +4530,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4582,7 +4587,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4608,7 +4613,7 @@ msgstr ""
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, fuzzy, c-format
 msgid "PID: %d"
 msgstr "Pid : %d"
@@ -4637,15 +4642,15 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 #, fuzzy
 msgid "Partitions:"
 msgstr "Options :"
@@ -4724,7 +4729,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -4972,7 +4977,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -5046,7 +5051,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, fuzzy, c-format
 msgid "Removable: %v"
 msgstr "Serveur distant : %s"
@@ -5208,7 +5213,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -5896,7 +5901,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "État : %s"
@@ -5910,11 +5915,11 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5938,7 +5943,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -5948,12 +5953,12 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -6057,11 +6062,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -6090,7 +6095,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6266,7 +6271,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6308,7 +6313,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -6343,7 +6348,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6352,7 +6357,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Publié : %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6401,7 +6406,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -6417,13 +6422,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -6669,7 +6674,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6717,7 +6722,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, fuzzy, c-format
 msgid "Used: %v"
 msgstr "Publié : %s"
@@ -6753,7 +6758,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, fuzzy, c-format
 msgid "Vendor: %v"
 msgstr "erreur : %v"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -322,7 +322,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -351,12 +351,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -403,7 +403,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -790,11 +790,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -823,15 +823,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1213,12 +1213,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1704,20 +1704,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2265,17 +2265,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2445,11 +2445,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3427,19 +3427,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3642,6 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3717,11 +3722,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3736,7 +3741,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3758,12 +3763,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3862,7 +3867,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3931,7 +3936,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3977,7 +3982,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4031,15 +4036,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4113,7 +4118,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4352,7 +4357,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4421,7 +4426,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4566,7 +4571,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5187,11 +5192,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5214,7 +5219,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5223,11 +5228,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5325,11 +5330,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5356,7 +5361,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5522,7 +5527,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5563,7 +5568,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5594,7 +5599,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5603,7 +5608,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5652,7 +5657,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5666,13 +5671,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5889,7 +5894,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5935,7 +5940,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5970,7 +5975,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -555,7 +555,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -584,12 +584,12 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -637,7 +637,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -984,7 +984,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1032,11 +1032,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
@@ -1065,15 +1065,15 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1457,12 +1457,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1965,21 +1965,21 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr "Utilizzo disco:"
@@ -2233,7 +2233,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2540,17 +2540,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2559,11 +2559,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2730,12 +2730,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3114,7 +3114,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -3449,7 +3449,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3458,7 +3458,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3476,7 +3476,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3519,7 +3519,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3748,19 +3748,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3977,6 +3977,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -4052,11 +4057,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4071,7 +4076,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4084,7 +4089,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4093,12 +4098,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4197,7 +4202,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4266,7 +4271,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4313,7 +4318,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4338,7 +4343,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4367,15 +4372,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4451,7 +4456,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4693,7 +4698,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4764,7 +4769,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4917,7 +4922,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5550,7 +5555,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -5563,11 +5568,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5591,7 +5596,7 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -5601,11 +5606,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5704,11 +5709,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5735,7 +5740,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -5903,7 +5908,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5945,7 +5950,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5976,7 +5981,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5985,7 +5990,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6034,7 +6039,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -6049,13 +6054,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6285,7 +6290,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6333,7 +6338,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6368,7 +6373,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -550,7 +550,7 @@ msgstr ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
@@ -579,12 +579,12 @@ msgstr "'%s' はサポートされないタイプのファイルです"
 msgid "(none)"
 msgstr "(none)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- レベル %d (タイプ: %s): %s"
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr "- パーティション %d"
@@ -631,7 +631,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
 
@@ -888,7 +888,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -997,7 +997,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1047,11 +1047,11 @@ msgstr "ブランド: %v"
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1071,7 +1071,7 @@ msgstr "CONTENT-TYPE"
 msgid "COUNT"
 msgstr "COUNT"
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
@@ -1080,15 +1080,15 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
@@ -1111,7 +1111,7 @@ msgstr "CUDA バージョン: %v"
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr "キャッシュ:"
 
@@ -1199,7 +1199,7 @@ msgstr "設定キーを設定できません: %s"
 msgid "Cannot use metrics type certificate when using a token"
 msgstr "トークンを使っている時はメトリクスタイプの証明書を使えません"
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr "カード %d:"
@@ -1496,12 +1496,12 @@ msgstr "イメージのコピー中: %s"
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr "コア %d"
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr "コア:"
 
@@ -1652,7 +1652,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1966,7 +1966,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr "デバイス: %s"
@@ -1997,20 +1997,20 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr "ディスク:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr "ディスク:"
 
@@ -2279,7 +2279,7 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr "失効日時"
@@ -2601,17 +2601,17 @@ msgstr "Forward delay"
 msgid "Found alias %q references an argument outside the given number"
 msgstr "エイリアス %q が指定した番号以外の引数を参照しているのが見つかりました"
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr "空き: %v"
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr "クロック数: %vMhz"
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
@@ -2620,11 +2620,11 @@ msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr "GPU:"
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr "GPUs:"
 
@@ -2791,11 +2791,11 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
@@ -2828,7 +2828,7 @@ msgstr "ID"
 msgid "ID: %d"
 msgstr "ID: %d"
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr "ID: %s"
@@ -2841,7 +2841,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -2994,7 +2994,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
@@ -3652,7 +3652,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -3661,7 +3661,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr "ログ:"
 
@@ -3677,7 +3677,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -3720,7 +3720,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr "MTU"
 
@@ -3951,19 +3951,19 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr "メモリ:"
 
@@ -4171,6 +4171,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, fuzzy, c-format
+msgid "Mounted: %v"
+msgstr "モデル: %v"
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
@@ -4259,11 +4264,11 @@ msgstr "NETWORK ZONES"
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr "NIC:"
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr "NICs:"
 
@@ -4278,7 +4283,7 @@ msgstr "NO"
 msgid "NUMA node: %v"
 msgstr "NUMA ノード: %v"
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr "NUMA ノード:\n"
 
@@ -4291,7 +4296,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr "名前"
@@ -4300,12 +4305,12 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr "名前: %v"
@@ -4406,7 +4411,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -4476,7 +4481,7 @@ msgstr "コピー先のボリュームに対するストレージプールが指
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
@@ -4522,7 +4527,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4547,7 +4552,7 @@ msgstr "PEER"
 msgid "PID"
 msgstr "PID"
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr "PID: %d"
@@ -4576,15 +4581,15 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr "パーティション:"
 
@@ -4660,7 +4665,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -4902,7 +4907,7 @@ msgstr "ROLE"
 msgid "ROLES"
 msgstr "ROLES"
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
@@ -4973,7 +4978,7 @@ msgstr "リモートの管理者パスワード"
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr "リムーバブルディスク: %v"
@@ -5119,7 +5124,7 @@ msgstr "クラスターメンバーに join するためのトークンを要求
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -5802,7 +5807,7 @@ msgstr "警告を表示します"
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr "サイズ: %s"
@@ -5815,11 +5820,11 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr "ソケット %d:"
@@ -5842,7 +5847,7 @@ msgstr "インスタンスを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr "状態"
 
@@ -5851,11 +5856,11 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -5953,11 +5958,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -5984,7 +5989,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6156,7 +6161,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
@@ -6208,7 +6213,7 @@ msgstr ""
 "仮想マシン上にローカルな LXD サーバを簡単にセットアップするには、https://"
 "multipass.run の使用を検討してください。"
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr "スレッド:"
 
@@ -6245,7 +6250,7 @@ msgstr ""
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -6256,7 +6261,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "合計: %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr "合計: %v"
@@ -6305,7 +6310,7 @@ msgstr "通信ポリシー"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr "タイプ"
 
@@ -6321,13 +6326,13 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
@@ -6553,7 +6558,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"
@@ -6603,7 +6608,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr "使用済: %v"
@@ -6640,7 +6645,7 @@ msgstr "VLAN フィルタリング"
 msgid "VLAN:"
 msgstr "VLAN:"
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr "ベンダー: %v"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -347,12 +347,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -399,7 +399,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -786,11 +786,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -819,15 +819,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1209,12 +1209,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1700,20 +1700,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2261,17 +2261,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2280,11 +2280,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2441,11 +2441,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2632,7 +2632,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3150,7 +3150,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3423,19 +3423,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3638,6 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3713,11 +3718,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3732,7 +3737,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3745,7 +3750,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3754,12 +3759,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3858,7 +3863,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3927,7 +3932,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3973,7 +3978,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3998,7 +4003,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4027,15 +4032,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4109,7 +4114,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4348,7 +4353,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4417,7 +4422,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4562,7 +4567,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5170,7 +5175,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5183,11 +5188,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5210,7 +5215,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5219,11 +5224,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5321,11 +5326,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5352,7 +5357,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5518,7 +5523,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5559,7 +5564,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5590,7 +5595,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5599,7 +5604,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5648,7 +5653,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5662,13 +5667,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5885,7 +5890,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5931,7 +5936,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5966,7 +5971,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-01-18 19:58+0100\n"
+        "POT-Creation-Date: 2024-01-19 14:34+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -296,7 +296,7 @@ msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
@@ -325,12 +325,12 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid   "- Level %d (type: %s): %s"
 msgstr  ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid   "- Partition %d"
 msgstr  ""
@@ -376,7 +376,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793 lxc/info.go:451
+#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793 lxc/info.go:453
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -603,7 +603,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -706,7 +706,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid   "Backups:"
 msgstr  ""
 
@@ -752,11 +752,11 @@ msgstr  ""
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -776,7 +776,7 @@ msgstr  ""
 msgid   "COUNT"
 msgstr  ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid   "CPU (%s):"
 msgstr  ""
@@ -785,15 +785,15 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid   "CPU usage:"
 msgstr  ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid   "CPUs (%s):"
 msgstr  ""
@@ -816,7 +816,7 @@ msgstr  ""
 msgid   "Cached: %s"
 msgstr  ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid   "Caches:"
 msgstr  ""
 
@@ -896,7 +896,7 @@ msgstr  ""
 msgid   "Cannot use metrics type certificate when using a token"
 msgstr  ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid   "Card %d:"
 msgstr  ""
@@ -1130,12 +1130,12 @@ msgstr  ""
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid   "Core %d"
 msgstr  ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid   "Cores:"
 msgstr  ""
 
@@ -1281,7 +1281,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1481,7 +1481,7 @@ msgstr  ""
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid   "Device: %s"
 msgstr  ""
@@ -1510,20 +1510,20 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid   "Disk %d:"
 msgstr  ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid   "Disk usage:"
 msgstr  ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid   "Disk:"
 msgstr  ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid   "Disks:"
 msgstr  ""
 
@@ -1749,7 +1749,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323 lxc/storage_volume.go:1373
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323 lxc/storage_volume.go:1373
 msgid   "Expires at"
 msgstr  ""
 
@@ -2034,17 +2034,17 @@ msgstr  ""
 msgid   "Found alias %q references an argument outside the given number"
 msgstr  ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid   "Free: %v"
 msgstr  ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid   "Frequency: %vMhz"
 msgstr  ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
@@ -2053,11 +2053,11 @@ msgstr  ""
 msgid   "GLOBAL"
 msgstr  ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid   "GPU:"
 msgstr  ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid   "GPUs:"
 msgstr  ""
 
@@ -2214,11 +2214,11 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid   "Host interface"
 msgstr  ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid   "Hugepages:\n"
 msgstr  ""
 
@@ -2251,7 +2251,7 @@ msgstr  ""
 msgid   "ID: %d"
 msgstr  ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid   "ID: %s"
 msgstr  ""
@@ -2264,7 +2264,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2402,7 +2402,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid   "Instance Only"
 msgstr  ""
 
@@ -2582,7 +2582,7 @@ msgstr  ""
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid   "Last Used: %s"
 msgstr  ""
@@ -2893,7 +2893,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -2902,7 +2902,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid   "Log:"
 msgstr  ""
 
@@ -2918,7 +2918,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid   "MAC address"
 msgstr  ""
 
@@ -2961,7 +2961,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid   "MTU"
 msgstr  ""
 
@@ -3172,19 +3172,19 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid   "Memory usage:"
 msgstr  ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid   "Memory:"
 msgstr  ""
 
@@ -3322,6 +3322,11 @@ msgstr  ""
 msgid   "Mount files from instances"
 msgstr  ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid   "Mounted: %v"
+msgstr  ""
+
 #: lxc/move.go:36
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
@@ -3386,11 +3391,11 @@ msgstr  ""
 msgid   "NETWORKS"
 msgstr  ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid   "NIC:"
 msgstr  ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid   "NICs:"
 msgstr  ""
 
@@ -3403,7 +3408,7 @@ msgstr  ""
 msgid   "NUMA node: %v"
 msgstr  ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid   "NUMA nodes:\n"
 msgstr  ""
 
@@ -3416,7 +3421,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321 lxc/storage_volume.go:1371
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321 lxc/storage_volume.go:1371
 msgid   "Name"
 msgstr  ""
 
@@ -3424,12 +3429,12 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid   "Name: %v"
 msgstr  ""
@@ -3527,7 +3532,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid   "Network usage:"
 msgstr  ""
 
@@ -3596,7 +3601,7 @@ msgstr  ""
 msgid   "No value found in %q"
 msgstr  ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid   "Node %d:\n"
 msgstr  ""
@@ -3642,7 +3647,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -3667,7 +3672,7 @@ msgstr  ""
 msgid   "PID"
 msgstr  ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid   "PID: %d"
 msgstr  ""
@@ -3696,15 +3701,15 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid   "Packets sent"
 msgstr  ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid   "Partitions:"
 msgstr  ""
 
@@ -3770,7 +3775,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -3993,7 +3998,7 @@ msgstr  ""
 msgid   "ROLES"
 msgstr  ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid   "Read-Only: %v"
 msgstr  ""
@@ -4061,7 +4066,7 @@ msgstr  ""
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid   "Removable: %v"
 msgstr  ""
@@ -4205,7 +4210,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid   "Resources:"
 msgstr  ""
 
@@ -4782,7 +4787,7 @@ msgstr  ""
 msgid   "Size: %.2fMiB"
 msgstr  ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid   "Size: %s"
 msgstr  ""
@@ -4795,11 +4800,11 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid   "Socket %d:"
 msgstr  ""
@@ -4822,7 +4827,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid   "State"
 msgstr  ""
 
@@ -4831,11 +4836,11 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid   "Stateful"
 msgstr  ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -4933,11 +4938,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -4961,7 +4966,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid   "Taken at"
 msgstr  ""
 
@@ -5124,7 +5129,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
@@ -5160,7 +5165,7 @@ msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "To easily setup a local LXD server in a virtual machine, consider using: https://multipass.run"
 msgstr  ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid   "Threads:"
 msgstr  ""
 
@@ -5189,7 +5194,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773 lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773 lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5198,7 +5203,7 @@ msgstr  ""
 msgid   "Total: %s"
 msgstr  ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid   "Total: %v"
 msgstr  ""
@@ -5247,7 +5252,7 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid   "Type"
 msgstr  ""
 
@@ -5259,12 +5264,12 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837 lxc/storage_volume.go:1270
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837 lxc/storage_volume.go:1270
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -5478,7 +5483,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""
@@ -5521,7 +5526,7 @@ msgstr  ""
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid   "Used: %v"
 msgstr  ""
@@ -5555,7 +5560,7 @@ msgstr  ""
 msgid   "VLAN:"
 msgstr  ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid   "Vendor: %v"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -538,7 +538,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -567,12 +567,12 @@ msgstr ""
 msgid "(none)"
 msgstr "(geen)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -619,7 +619,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1006,11 +1006,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -1030,7 +1030,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -1039,15 +1039,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1070,7 +1070,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1429,12 +1429,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1891,7 +1891,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1920,20 +1920,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2481,17 +2481,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2500,11 +2500,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2661,11 +2661,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2698,7 +2698,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2711,7 +2711,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2852,7 +2852,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3370,7 +3370,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3429,7 +3429,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3643,19 +3643,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3858,6 +3858,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3933,11 +3938,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3952,7 +3957,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3965,7 +3970,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3974,12 +3979,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4078,7 +4083,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4147,7 +4152,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4193,7 +4198,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4218,7 +4223,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4247,15 +4252,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4329,7 +4334,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4568,7 +4573,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4637,7 +4642,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4782,7 +4787,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5390,7 +5395,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5403,11 +5408,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5430,7 +5435,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5439,11 +5444,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5541,11 +5546,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5572,7 +5577,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5738,7 +5743,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5779,7 +5784,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5810,7 +5815,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5819,7 +5824,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5868,7 +5873,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5882,13 +5887,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6105,7 +6110,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6151,7 +6156,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6186,7 +6191,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -572,7 +572,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -601,12 +601,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -653,7 +653,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1040,11 +1040,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -1073,15 +1073,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -1186,7 +1186,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1463,12 +1463,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1954,20 +1954,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -2212,7 +2212,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2515,17 +2515,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2534,11 +2534,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2695,11 +2695,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2732,7 +2732,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3395,7 +3395,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3404,7 +3404,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3420,7 +3420,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3463,7 +3463,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3677,19 +3677,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3892,6 +3892,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3967,11 +3972,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3986,7 +3991,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3999,7 +4004,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4008,12 +4013,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4181,7 +4186,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4227,7 +4232,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4252,7 +4257,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4281,15 +4286,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4363,7 +4368,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4602,7 +4607,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4671,7 +4676,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4816,7 +4821,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5424,7 +5429,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5437,11 +5442,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5464,7 +5469,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5473,11 +5478,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5575,11 +5580,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5606,7 +5611,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5772,7 +5777,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5813,7 +5818,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5844,7 +5849,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5853,7 +5858,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5902,7 +5907,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5916,13 +5921,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6139,7 +6144,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6185,7 +6190,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6220,7 +6225,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -347,12 +347,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -399,7 +399,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -786,11 +786,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -819,15 +819,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1209,12 +1209,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1700,20 +1700,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2261,17 +2261,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2280,11 +2280,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2441,11 +2441,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2632,7 +2632,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3150,7 +3150,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3423,19 +3423,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3638,6 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3713,11 +3718,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3732,7 +3737,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3745,7 +3750,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3754,12 +3759,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3858,7 +3863,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3927,7 +3932,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3973,7 +3978,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3998,7 +4003,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4027,15 +4032,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4109,7 +4114,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4348,7 +4353,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4417,7 +4422,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4562,7 +4567,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5170,7 +5175,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5183,11 +5188,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5210,7 +5215,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5219,11 +5224,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5321,11 +5326,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5352,7 +5357,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5518,7 +5523,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5559,7 +5564,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5590,7 +5595,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5599,7 +5604,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5648,7 +5653,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5662,13 +5667,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5885,7 +5890,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5931,7 +5936,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5966,7 +5971,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -562,7 +562,7 @@ msgstr ""
 "### Essa é uma representação yaml do membro do cluster.\n"
 "### Qualquer linha iniciando em '# será ignorada"
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
@@ -591,12 +591,12 @@ msgstr "'%s' não é um tipo de arquivo suportado"
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr "- Nível %d (tipo: %s): %s"
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr "- Partição %d"
@@ -652,7 +652,7 @@ msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 #, fuzzy
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1010,7 +1010,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1058,11 +1058,11 @@ msgstr "Marca: %v"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
@@ -1091,15 +1091,15 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, fuzzy, c-format
 msgid "CPUs (%s):"
 msgstr "CPUs:"
@@ -1122,7 +1122,7 @@ msgstr "Versão CUDA: %v"
 msgid "Cached: %s"
 msgstr "Em cache: %s"
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 #, fuzzy
 msgid "Caches:"
 msgstr "Em cache: %s"
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr "Cartão %d:"
@@ -1495,12 +1495,12 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1988,7 +1988,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, fuzzy, c-format
 msgid "Device: %s"
 msgstr "Em cache: %s"
@@ -2017,21 +2017,21 @@ msgstr "Desabilitar alocação de pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Desabilitar stdin (ler de /dev/null)"
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr "Uso de disco:"
@@ -2293,7 +2293,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2597,17 +2597,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2616,11 +2616,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2796,11 +2796,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2833,7 +2833,7 @@ msgstr "ID"
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2846,7 +2846,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2989,7 +2989,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -3177,7 +3177,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Criado: %s"
@@ -3508,7 +3508,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3517,7 +3517,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3535,7 +3535,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3578,7 +3578,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3813,19 +3813,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -4041,6 +4041,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, fuzzy, c-format
+msgid "Mounted: %v"
+msgstr "Marca: %v"
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -4116,11 +4121,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4135,7 +4140,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4148,7 +4153,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4157,12 +4162,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4261,7 +4266,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4330,7 +4335,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4376,7 +4381,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4401,7 +4406,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4430,15 +4435,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4513,7 +4518,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4758,7 +4763,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4829,7 +4834,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4986,7 +4991,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5642,7 +5647,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5655,11 +5660,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5682,7 +5687,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5691,11 +5696,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5794,11 +5799,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5825,7 +5830,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5995,7 +6000,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6037,7 +6042,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -6068,7 +6073,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6077,7 +6082,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6126,7 +6131,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -6141,13 +6146,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6388,7 +6393,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6436,7 +6441,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6471,7 +6476,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -571,7 +571,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -600,12 +600,12 @@ msgstr ""
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -652,7 +652,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1007,7 +1007,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -1055,11 +1055,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, fuzzy, c-format
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
@@ -1088,16 +1088,16 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1121,7 +1121,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -1203,7 +1203,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1483,12 +1483,12 @@ msgstr "Копирование образа: %s"
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1650,7 +1650,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -2001,22 +2001,22 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, fuzzy, c-format
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 #, fuzzy
 msgid "Disk:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 #, fuzzy
 msgid "Disks:"
 msgstr " Использование диска:"
@@ -2274,7 +2274,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2583,17 +2583,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2602,11 +2602,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2778,12 +2778,12 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2829,7 +2829,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2974,7 +2974,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3164,7 +3164,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, fuzzy, c-format
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
@@ -3502,7 +3502,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3511,7 +3511,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3529,7 +3529,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3808,20 +3808,20 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 #, fuzzy
 msgid "Memory:"
 msgstr " Использование памяти:"
@@ -4040,6 +4040,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -4116,11 +4121,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -4135,7 +4140,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -4148,7 +4153,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -4157,12 +4162,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4262,7 +4267,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -4333,7 +4338,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4380,7 +4385,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4405,7 +4410,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4434,15 +4439,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4517,7 +4522,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4756,7 +4761,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4829,7 +4834,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4984,7 +4989,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5629,7 +5634,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, fuzzy, c-format
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
@@ -5643,11 +5648,11 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5670,7 +5675,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -5680,11 +5685,11 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5785,11 +5790,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5816,7 +5821,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5982,7 +5987,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -6023,7 +6028,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -6054,7 +6059,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -6063,7 +6068,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -6112,7 +6117,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -6127,13 +6132,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6369,7 +6374,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6417,7 +6422,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6452,7 +6457,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -322,7 +322,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -351,12 +351,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -403,7 +403,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -790,11 +790,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -823,15 +823,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1213,12 +1213,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1704,20 +1704,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2265,17 +2265,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2445,11 +2445,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3427,19 +3427,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3642,6 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3717,11 +3722,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3736,7 +3741,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3758,12 +3763,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3862,7 +3867,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3931,7 +3936,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3977,7 +3982,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4031,15 +4036,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4113,7 +4118,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4352,7 +4357,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4421,7 +4426,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4566,7 +4571,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5187,11 +5192,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5214,7 +5219,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5223,11 +5228,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5325,11 +5330,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5356,7 +5361,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5522,7 +5527,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5563,7 +5568,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5594,7 +5599,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5603,7 +5608,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5652,7 +5657,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5666,13 +5671,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5889,7 +5894,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5935,7 +5940,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5970,7 +5975,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -322,7 +322,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -351,12 +351,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -403,7 +403,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -790,11 +790,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -823,15 +823,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1213,12 +1213,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1704,20 +1704,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2265,17 +2265,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2445,11 +2445,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3427,19 +3427,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3642,6 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3717,11 +3722,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3736,7 +3741,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3758,12 +3763,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3862,7 +3867,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3931,7 +3936,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3977,7 +3982,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4031,15 +4036,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4113,7 +4118,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4352,7 +4357,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4421,7 +4426,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4566,7 +4571,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5187,11 +5192,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5214,7 +5219,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5223,11 +5228,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5325,11 +5330,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5356,7 +5361,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5522,7 +5527,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5563,7 +5568,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5594,7 +5599,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5603,7 +5608,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5652,7 +5657,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5666,13 +5671,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5889,7 +5894,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5935,7 +5940,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5970,7 +5975,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -318,7 +318,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -347,12 +347,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -399,7 +399,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -786,11 +786,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -819,15 +819,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1209,12 +1209,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1700,20 +1700,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2261,17 +2261,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2280,11 +2280,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2441,11 +2441,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2632,7 +2632,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3150,7 +3150,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3209,7 +3209,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3423,19 +3423,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3638,6 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3713,11 +3718,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3732,7 +3737,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3745,7 +3750,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3754,12 +3759,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3858,7 +3863,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3927,7 +3932,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3973,7 +3978,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3998,7 +4003,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4027,15 +4032,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4109,7 +4114,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4348,7 +4353,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4417,7 +4422,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4562,7 +4567,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5170,7 +5175,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5183,11 +5188,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5210,7 +5215,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5219,11 +5224,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5321,11 +5326,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5352,7 +5357,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5518,7 +5523,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5559,7 +5564,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5590,7 +5595,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5599,7 +5604,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5648,7 +5653,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5662,13 +5667,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5885,7 +5890,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5931,7 +5936,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5966,7 +5971,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -322,7 +322,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -351,12 +351,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -403,7 +403,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -790,11 +790,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -823,15 +823,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1213,12 +1213,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1675,7 +1675,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1704,20 +1704,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1962,7 +1962,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2265,17 +2265,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2445,11 +2445,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3213,7 +3213,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3427,19 +3427,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3642,6 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3717,11 +3722,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3736,7 +3741,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3749,7 +3754,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3758,12 +3763,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3862,7 +3867,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3931,7 +3936,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3977,7 +3982,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4002,7 +4007,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4031,15 +4036,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4113,7 +4118,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4352,7 +4357,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4421,7 +4426,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4566,7 +4571,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5187,11 +5192,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5214,7 +5219,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5223,11 +5228,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5325,11 +5330,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5356,7 +5361,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5522,7 +5527,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5563,7 +5568,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5594,7 +5599,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5603,7 +5608,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5652,7 +5657,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5666,13 +5671,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5889,7 +5894,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5935,7 +5940,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5970,7 +5975,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -471,7 +471,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -500,12 +500,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -552,7 +552,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -963,7 +963,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -972,15 +972,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1362,12 +1362,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1514,7 +1514,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1824,7 +1824,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1853,20 +1853,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -2111,7 +2111,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2414,17 +2414,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2433,11 +2433,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2594,11 +2594,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2631,7 +2631,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2644,7 +2644,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2971,7 +2971,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3294,7 +3294,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3303,7 +3303,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3319,7 +3319,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3362,7 +3362,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3576,19 +3576,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3791,6 +3791,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3866,11 +3871,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3885,7 +3890,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3898,7 +3903,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3907,12 +3912,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -4011,7 +4016,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -4080,7 +4085,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -4126,7 +4131,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4151,7 +4156,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4180,15 +4185,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4262,7 +4267,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4501,7 +4506,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4570,7 +4575,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4715,7 +4720,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5323,7 +5328,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5336,11 +5341,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5363,7 +5368,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5372,11 +5377,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5474,11 +5479,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5505,7 +5510,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5671,7 +5676,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5712,7 +5717,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5743,7 +5748,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5752,7 +5757,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5801,7 +5806,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5815,13 +5820,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -6038,7 +6043,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -6084,7 +6089,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -6119,7 +6124,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-18 19:58+0100\n"
+"POT-Creation-Date: 2024-01-19 14:34+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -321,7 +321,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/info.go:319
+#: lxc/info.go:321
 #, c-format
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
@@ -350,12 +350,12 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/info.go:309
+#: lxc/info.go:311
 #, c-format
 msgid "- Level %d (type: %s): %s"
 msgstr ""
 
-#: lxc/info.go:288
+#: lxc/info.go:289
 #, c-format
 msgid "- Partition %d"
 msgstr ""
@@ -402,7 +402,7 @@ msgid "--refresh can only be used with instances"
 msgstr ""
 
 #: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
-#: lxc/info.go:451
+#: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:476
+#: lxc/image.go:945 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:644 lxc/storage_volume.go:1336
+#: lxc/info.go:646 lxc/storage_volume.go:1336
 msgid "Backups:"
 msgstr ""
 
@@ -789,11 +789,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:567 lxc/network.go:851
+#: lxc/info.go:569 lxc/network.go:851
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:568 lxc/network.go:852
+#: lxc/info.go:570 lxc/network.go:852
 msgid "Bytes sent"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgstr ""
 msgid "COUNT"
 msgstr ""
 
-#: lxc/info.go:354
+#: lxc/info.go:356
 #, c-format
 msgid "CPU (%s):"
 msgstr ""
@@ -822,15 +822,15 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:517
+#: lxc/info.go:519
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:521
+#: lxc/info.go:523
 msgid "CPU usage:"
 msgstr ""
 
-#: lxc/info.go:357
+#: lxc/info.go:359
 #, c-format
 msgid "CPUs (%s):"
 msgstr ""
@@ -853,7 +853,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/info.go:307
+#: lxc/info.go:309
 msgid "Caches:"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Cannot use metrics type certificate when using a token"
 msgstr ""
 
-#: lxc/info.go:401 lxc/info.go:413
+#: lxc/info.go:403 lxc/info.go:415
 #, c-format
 msgid "Card %d:"
 msgstr ""
@@ -1212,12 +1212,12 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/info.go:315
+#: lxc/info.go:317
 #, c-format
 msgid "Core %d"
 msgstr ""
 
-#: lxc/info.go:313
+#: lxc/info.go:315
 msgid "Cores:"
 msgstr ""
 
@@ -1364,7 +1364,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:487 lxc/storage_volume.go:1290
+#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
-#: lxc/info.go:266 lxc/info.go:290
+#: lxc/info.go:266 lxc/info.go:291
 #, c-format
 msgid "Device: %s"
 msgstr ""
@@ -1703,20 +1703,20 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:425
+#: lxc/info.go:427
 #, c-format
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:510
+#: lxc/info.go:512
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/info.go:420
+#: lxc/info.go:422
 msgid "Disk:"
 msgstr ""
 
-#: lxc/info.go:423
+#: lxc/info.go:425
 msgid "Disks:"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1323
+#: lxc/info.go:632 lxc/info.go:683 lxc/storage_volume.go:1323
 #: lxc/storage_volume.go:1373
 msgid "Expires at"
 msgstr ""
@@ -2264,17 +2264,17 @@ msgstr ""
 msgid "Found alias %q references an argument outside the given number"
 msgstr ""
 
-#: lxc/info.go:368 lxc/info.go:379 lxc/info.go:384 lxc/info.go:390
+#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
 #, c-format
 msgid "Free: %v"
 msgstr ""
 
-#: lxc/info.go:316 lxc/info.go:327
+#: lxc/info.go:318 lxc/info.go:329
 #, c-format
 msgid "Frequency: %vMhz"
 msgstr ""
 
-#: lxc/info.go:325
+#: lxc/info.go:327
 #, c-format
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
@@ -2283,11 +2283,11 @@ msgstr ""
 msgid "GLOBAL"
 msgstr ""
 
-#: lxc/info.go:396
+#: lxc/info.go:398
 msgid "GPU:"
 msgstr ""
 
-#: lxc/info.go:399
+#: lxc/info.go:401
 msgid "GPUs:"
 msgstr ""
 
@@ -2444,11 +2444,11 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:556
+#: lxc/info.go:558
 msgid "Host interface"
 msgstr ""
 
-#: lxc/info.go:367 lxc/info.go:378
+#: lxc/info.go:369 lxc/info.go:380
 msgid "Hugepages:\n"
 msgstr ""
 
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "ID: %d"
 msgstr ""
 
-#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:289
+#: lxc/info.go:198 lxc/info.go:265 lxc/info.go:290
 #, c-format
 msgid "ID: %s"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:572
+#: lxc/info.go:574
 msgid "IP addresses"
 msgstr ""
 
@@ -2635,7 +2635,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/info.go:682
+#: lxc/info.go:684
 msgid "Instance Only"
 msgstr ""
 
@@ -2821,7 +2821,7 @@ msgstr ""
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
-#: lxc/info.go:491
+#: lxc/info.go:493
 #, c-format
 msgid "Last Used: %s"
 msgstr ""
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:479 lxc/storage_volume.go:1279
+#: lxc/info.go:481 lxc/storage_volume.go:1279
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:710
+#: lxc/info.go:712
 msgid "Log:"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:560
+#: lxc/info.go:562
 msgid "MAC address"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:566
 msgid "MTU"
 msgstr ""
 
@@ -3426,19 +3426,19 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:530
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:534
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:544
+#: lxc/info.go:546
 msgid "Memory usage:"
 msgstr ""
 
-#: lxc/info.go:365
+#: lxc/info.go:367
 msgid "Memory:"
 msgstr ""
 
@@ -3641,6 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
+#: lxc/info.go:283 lxc/info.go:293
+#, c-format
+msgid "Mounted: %v"
+msgstr ""
+
 #: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
@@ -3716,11 +3721,11 @@ msgstr ""
 msgid "NETWORKS"
 msgstr ""
 
-#: lxc/info.go:408
+#: lxc/info.go:410
 msgid "NIC:"
 msgstr ""
 
-#: lxc/info.go:411
+#: lxc/info.go:413
 msgid "NICs:"
 msgstr ""
 
@@ -3735,7 +3740,7 @@ msgstr ""
 msgid "NUMA node: %v"
 msgstr ""
 
-#: lxc/info.go:374
+#: lxc/info.go:376
 msgid "NUMA nodes:\n"
 msgstr ""
 
@@ -3748,7 +3753,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:628 lxc/info.go:679 lxc/storage_volume.go:1321
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1321
 #: lxc/storage_volume.go:1371
 msgid "Name"
 msgstr ""
@@ -3757,12 +3762,12 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:462 lxc/network.go:833 lxc/storage_volume.go:1261
+#: lxc/info.go:464 lxc/network.go:833 lxc/storage_volume.go:1261
 #, c-format
 msgid "Name: %s"
 msgstr ""
 
-#: lxc/info.go:303
+#: lxc/info.go:305
 #, c-format
 msgid "Name: %v"
 msgstr ""
@@ -3861,7 +3866,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:585 lxc/network.go:850
+#: lxc/info.go:587 lxc/network.go:850
 msgid "Network usage:"
 msgstr ""
 
@@ -3930,7 +3935,7 @@ msgstr ""
 msgid "No value found in %q"
 msgstr ""
 
-#: lxc/info.go:376
+#: lxc/info.go:378
 #, c-format
 msgid "Node %d:\n"
 msgstr ""
@@ -3976,7 +3981,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:683 lxc/storage_volume.go:1375
+#: lxc/info.go:685 lxc/storage_volume.go:1375
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4001,7 +4006,7 @@ msgstr ""
 msgid "PID"
 msgstr ""
 
-#: lxc/info.go:483
+#: lxc/info.go:485
 #, c-format
 msgid "PID: %d"
 msgstr ""
@@ -4030,15 +4035,15 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:569 lxc/network.go:853
+#: lxc/info.go:571 lxc/network.go:853
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:570 lxc/network.go:854
+#: lxc/info.go:572 lxc/network.go:854
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/info.go:286
+#: lxc/info.go:287
 msgid "Partitions:"
 msgstr ""
 
@@ -4112,7 +4117,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:497
+#: lxc/info.go:499
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -4351,7 +4356,7 @@ msgstr ""
 msgid "ROLES"
 msgstr ""
 
-#: lxc/info.go:282 lxc/info.go:291
+#: lxc/info.go:282 lxc/info.go:292
 #, c-format
 msgid "Read-Only: %v"
 msgstr ""
@@ -4420,7 +4425,7 @@ msgstr ""
 msgid "Remote names may not contain colons"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:284
 #, c-format
 msgid "Removable: %v"
 msgstr ""
@@ -4565,7 +4570,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:495
+#: lxc/info.go:497
 msgid "Resources:"
 msgstr ""
 
@@ -5173,7 +5178,7 @@ msgstr ""
 msgid "Size: %.2fMiB"
 msgstr ""
 
-#: lxc/info.go:276 lxc/info.go:292
+#: lxc/info.go:276 lxc/info.go:294
 #, c-format
 msgid "Size: %s"
 msgstr ""
@@ -5186,11 +5191,11 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:597 lxc/storage_volume.go:1300
+#: lxc/info.go:599 lxc/storage_volume.go:1300
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/info.go:359
+#: lxc/info.go:361
 #, c-format
 msgid "Socket %d:"
 msgstr ""
@@ -5213,7 +5218,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:556
 msgid "State"
 msgstr ""
 
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:631
+#: lxc/info.go:633
 msgid "Stateful"
 msgstr ""
 
-#: lxc/info.go:464
+#: lxc/info.go:466
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -5324,11 +5329,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:536
+#: lxc/info.go:538
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:540
+#: lxc/info.go:542
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5355,7 +5360,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1372
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1372
 msgid "Taken at"
 msgstr ""
 
@@ -5521,7 +5526,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/info.go:344
+#: lxc/info.go:346
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
@@ -5562,7 +5567,7 @@ msgid ""
 "https://multipass.run"
 msgstr ""
 
-#: lxc/info.go:317
+#: lxc/info.go:319
 msgid "Threads:"
 msgstr ""
 
@@ -5593,7 +5598,7 @@ msgid ""
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
-#: lxc/copy.go:131 lxc/info.go:336 lxc/network.go:821 lxc/storage.go:446
+#: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -5602,7 +5607,7 @@ msgstr ""
 msgid "Total: %s"
 msgstr ""
 
-#: lxc/info.go:370 lxc/info.go:381 lxc/info.go:386 lxc/info.go:392
+#: lxc/info.go:372 lxc/info.go:383 lxc/info.go:388 lxc/info.go:394
 #, c-format
 msgid "Total: %v"
 msgstr ""
@@ -5651,7 +5656,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:553
+#: lxc/info.go:555
 msgid "Type"
 msgstr ""
 
@@ -5665,13 +5670,13 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:473 lxc/network.go:837
+#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:471
+#: lxc/info.go:473
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -5888,7 +5893,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/info.go:702
+#: lxc/info.go:704
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""
@@ -5934,7 +5939,7 @@ msgstr ""
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
-#: lxc/info.go:369 lxc/info.go:380 lxc/info.go:385 lxc/info.go:391
+#: lxc/info.go:371 lxc/info.go:382 lxc/info.go:387 lxc/info.go:393
 #, c-format
 msgid "Used: %v"
 msgstr ""
@@ -5969,7 +5974,7 @@ msgstr ""
 msgid "VLAN:"
 msgstr ""
 
-#: lxc/info.go:299
+#: lxc/info.go:301
 #, c-format
 msgid "Vendor: %v"
 msgstr ""

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -609,6 +609,10 @@ type ResourcesStorageDisk struct {
 	// Example: false
 	ReadOnly bool `json:"read_only" yaml:"read_only"`
 
+	// Mounted status of the disk
+	// Example: true
+	Mounted bool `json:"mounted" yaml:"mounted"`
+
 	// Total size of the disk (bytes)
 	// Example: 256060514304
 	Size uint64 `json:"size" yaml:"size"`
@@ -702,6 +706,10 @@ type ResourcesStorageDiskPartition struct {
 	// Partition number
 	// Example: 1
 	Partition uint64 `json:"partition" yaml:"partition"`
+
+	// Mounted status of the partition.
+	// Example: true
+	Mounted bool `json:"mounted" yaml:"mounted"`
 }
 
 // ResourcesMemory represents the memory resources available on the system

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -395,6 +395,7 @@ var APIExtensions = []string{
 	"init_preseed_storage_volumes",
 	"metrics_instances_count",
 	"server_instance_type_info",
+	"resources_disk_mounted",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Checks `/proc/self/mountinfo` for each disk/partition and if the corresponding major:minor device number exists, then the disk or partition will be considered mounted. 

If a disk has a mounted partition, then the disk itself will also be considered mounted.