### PR TITLE
Read system certs directly from `/etc/ssl`

### DIFF
--- a/shared/network_unix.go
+++ b/shared/network_unix.go
@@ -4,7 +4,6 @@ package shared
 
 import (
 	"crypto/x509"
-	"os"
 )
 
 func systemCertPool() (*x509.CertPool, error) {
@@ -12,14 +11,6 @@ func systemCertPool() (*x509.CertPool, error) {
 	pool, err := x509.SystemCertPool()
 	if err != nil {
 		return nil, err
-	}
-
-	// Attempt to load the system's pool too (for snaps)
-	if PathExists("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt") {
-		snapCerts, err := os.ReadFile("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt")
-		if err == nil {
-			pool.AppendCertsFromPEM(snapCerts)
-		}
 	}
 
 	return pool, nil


### PR DESCRIPTION
If LXD failed to pick up system certs from `/etc/ssl` via `x509.SystemCertPool` (https://pkg.go.dev/crypto/x509#SystemCertPool and https://cs.opensource.google/go/go/+/master:src/crypto/x509/root_linux.go) then it would try to read `/var/lib/snapd/hostfs/etc/ssl`, which is itself symlinked to `/etc/ssl` in the LXD snap confinement. 

As of https://forum.snapcraft.io/t/custom-certificate-support/28168, snaps should be able to read `/etc/ssl` directly, so this makes the second check redundant. Additionally, any other snap using `ConnectLXD` should be able to read the system certs as well, though they may fail to read `/var/lib/snapd/hostfs`. 
