### PR TITLE
lxd/instance/drivers/driver_qemu: use OVMF_CODE.fd in a non-snap envi…

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8110,7 +8110,13 @@ func (d *qemu) checkFeatures(hostArch int, qemuPath string) (map[string]any, err
 	}
 
 	if d.architectureSupportsUEFI(hostArch) {
-		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", filepath.Join(d.ovmfPath(), ovmfGenericFirmwares[0].code)))
+		ovmfCode := "OVMF_CODE.fd"
+
+		if shared.InSnap() {
+			ovmfCode = ovmfGenericFirmwares[0].code
+		}
+
+		qemuArgs = append(qemuArgs, "-drive", fmt.Sprintf("if=pflash,format=raw,readonly=on,file=%s", filepath.Join(d.ovmfPath(), ovmfCode)))
 	}
 
 	var stderr bytes.Buffer


### PR DESCRIPTION
…ronment

Tom Parrott reported that QEMU feature checks fail when LXD is running directly on the host without snap. That's because OVMF_CODE.4MB.fd does not exist outside of a snap. So, let's use an old OVMF_CODE.fd name for this case.