### PR TITLE
Rename ring buffer to com.canonical.lxd 

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -237,8 +237,8 @@ func (c *cmdAgent) startStatusNotifier(ctx context.Context, chConnected <-chan s
 
 // writeStatus writes a status code to the vserial ring buffer used to detect agent status on host.
 func (c *cmdAgent) writeStatus(status string) error {
-	if shared.PathExists("/dev/virtio-ports/org.linuxcontainers.lxd") {
-		vSerial, err := os.OpenFile("/dev/virtio-ports/org.linuxcontainers.lxd", os.O_RDWR, 0600)
+	if shared.PathExists("/dev/virtio-ports/com.canonical.lxd") {
+		vSerial, err := os.OpenFile("/dev/virtio-ports/com.canonical.lxd", os.O_RDWR, 0600)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2487,8 +2487,7 @@ func (d *qemu) generateConfigShare() error {
 	lxdAgentServiceUnit := `[Unit]
 Description=LXD - agent
 Documentation=https://documentation.ubuntu.com/lxd/en/latest/
-ConditionPathExists=/dev/virtio-ports/org.linuxcontainers.lxd
-Before=cloud-init.target cloud-init.service cloud-init-local.service
+Before=multi-user.target cloud-init.target cloud-init.service cloud-init-local.service
 DefaultDependencies=no
 
 [Service]
@@ -2500,9 +2499,6 @@ Restart=on-failure
 RestartSec=5s
 StartLimitInterval=60
 StartLimitBurst=10
-
-[Install]
-WantedBy=multi-user.target
 `
 
 	err = os.WriteFile(filepath.Join(configDrivePath, "systemd", "lxd-agent.service"), []byte(lxdAgentServiceUnit), 0400)
@@ -2562,7 +2558,12 @@ chown -R root:root "${PREFIX}"
 		return err
 	}
 
-	lxdAgentRules := `ACTION=="add", SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ACTION=="add", RUN+="/bin/systemctl start lxd-agent.service"`
+	lxdAgentRules := `SYMLINK=="virtio-ports/com.canonical.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="lxd-agent.service"
+
+# Legacy.
+SYMLINK=="virtio-ports/org.linuxcontainers.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="lxd-agent.service"
+`
+
 	err = os.WriteFile(filepath.Join(configDrivePath, "udev", "99-lxd-agent.rules"), []byte(lxdAgentRules), 0400)
 	if err != nil {
 		return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2591,7 +2591,8 @@ fi
 rm -f /lib/systemd/system/lxd-agent-9p.service \
     /lib/systemd/system/lxd-agent-virtiofs.service \
     /etc/systemd/system/multi-user.target.wants/lxd-agent-9p.service \
-    /etc/systemd/system/multi-user.target.wants/lxd-agent-virtiofs.service
+    /etc/systemd/system/multi-user.target.wants/lxd-agent-virtiofs.service \
+    /etc/systemd/system/multi-user.target.wants/lxd-agent.service
 
 # Install the units.
 cp udev/99-lxd-agent.rules /lib/udev/rules.d/

--- a/lxd/instance/drivers/driver_qemu_config_test.go
+++ b/lxd/instance/drivers/driver_qemu_config_test.go
@@ -132,8 +132,13 @@ func TestQemuConfigTemplates(t *testing.T) {
 
 			[device "qemu_serial"]
 			driver = "virtserialport"
-			name = "org.linuxcontainers.lxd"
+			name = "com.canonical.lxd"
 			chardev = "qemu_serial-chardev"
+			bus = "dev-qemu_serial.0"
+
+			[device "qemu_serial_legacy"]
+			driver = "virtserialport"
+			name = "org.linuxcontainers.lxd"
 			bus = "dev-qemu_serial.0"
 
 			# Spice agent

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -186,8 +186,15 @@ func qemuSerial(opts *qemuSerialOpts) []cfgSection {
 		name: `device "qemu_serial"`,
 		entries: []cfgEntry{
 			{key: "driver", value: "virtserialport"},
-			{key: "name", value: "org.linuxcontainers.lxd"},
+			{key: "name", value: "com.canonical.lxd"},
 			{key: "chardev", value: opts.charDevName},
+			{key: "bus", value: "dev-qemu_serial.0"},
+		},
+	}, {
+		name: `device "qemu_serial_legacy"`,
+		entries: []cfgEntry{
+			{key: "driver", value: "virtserialport"},
+			{key: "name", value: "org.linuxcontainers.lxd"},
 			{key: "bus", value: "dev-qemu_serial.0"},
 		},
 	}, {

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -177,12 +177,15 @@ func qemuSerial(opts *qemuSerialOpts) []cfgSection {
 		comment: "Virtual serial bus",
 		entries: qemuDeviceEntries(&entriesOpts),
 	}, {
+		// Ring buffer used by the lxd agent to report (write) its status to. LXD server will read
+		// its content via QMP using "ringbuf-read" command.
 		name:    fmt.Sprintf(`chardev "%s"`, opts.charDevName),
 		comment: "LXD serial identifier",
 		entries: []cfgEntry{
 			{key: "backend", value: "ringbuf"},
 			{key: "size", value: fmt.Sprintf("%dB", opts.ringbufSizeBytes)}},
 	}, {
+		// QEMU serial device connected to the above ring buffer.
 		name: `device "qemu_serial"`,
 		entries: []cfgEntry{
 			{key: "driver", value: "virtserialport"},
@@ -191,6 +194,10 @@ func qemuSerial(opts *qemuSerialOpts) []cfgSection {
 			{key: "bus", value: "dev-qemu_serial.0"},
 		},
 	}, {
+		// Legacy QEMU serial device, not connected to any ring buffer. Its purpose is to
+		// create a symlink in /dev/virtio-ports/, triggering a udev rule to start the lxd-agent.
+		// This is necessary for backward compatibility with virtual machines lacking the
+		// updated lxd-agent-loader package, which includes updated udev rules and a systemd unit.
 		name: `device "qemu_serial_legacy"`,
 		entries: []cfgEntry{
 			{key: "driver", value: "virtserialport"},


### PR DESCRIPTION
This PR updates the name of ring buffer from `org.linuxcontainers.lxd` to `com.canonical.lxd`.

With this change in place, restart of existing VMs will be required. Otherwise, (old) lxd-agent will write data to the `org.linuxcontainers.lxd` qemu serial device that is not connected to the new ring buffer from which lxd server will try to read. After VM is restarted, new lxd-agent will be copied from the shared host filesystem to the VM.

Fixes #12149