### PR TITLE
doc/installing: LXC_DEVEL needs to be fixed on 22.04+

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -171,7 +171,7 @@ sudo snap install --classic go
 If you use the `liblxc-dev` package and get compile time errors when building the `go-lxc` module,
 ensure that the value for `LXC_DEVEL` is `0` for your `liblxc` build. To check that, look at `/usr/include/lxc/version.h`.
 If the `LXC_DEVEL` value is `1`, replace it with `0` to work around the problem. It's a packaging bug, and
-we are aware of it for Ubuntu 22.04/22.10. Ubuntu 23.04/23.10 does not have this problem.
+we are aware of it for Ubuntu 22.04 onward, see [LP: #2039873](https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/2039873).
 ```
 
 There are a few storage drivers for LXD besides the default `dir` driver.


### PR DESCRIPTION
Fixes #12505.