### PR TITLE
Configure dependabot to look after the stable-5.0 branch (stable-5.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+    target-branch: "stable-5.0"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch:

> By default, Dependabot checks for manifest files on the default branch and raises pull requests for version updates against this branch.