### PR TITLE
github: instruct dependabot to also look after the stable-5.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,10 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "stable-5.0"


### PR DESCRIPTION
As found by @roosterfish we need to duplicate the `updates` config to have the 2 branches covered by Dependabot. This is also what another project does (https://github.com/paritytech/parity-bridges-common/blob/master/.github/dependabot.yml#L124) and it works for them as Dependabot opened 2 PRs, one for their `master` branch and another for their `polkadot-staging` one:

https://github.com/paritytech/parity-bridges-common/pull/2714
https://github.com/paritytech/parity-bridges-common/pull/2715