### PR TITLE
github: instruct dependabot to also look after the stable-4.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,17 @@ updates:
     schedule:
       interval: "weekly"
 
+  # XXX: check on other (non-default) stable branches
   - package-ecosystem: "github-actions"
     directory: "/"
     labels: []
     schedule:
       interval: "weekly"
     target-branch: "stable-5.0"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "stable-4.0"


### PR DESCRIPTION
This might be useful to push out more point releases to 4.0 whenever one of our dependency gets a security fix.