### PR TITLE
Respect all flags when moving an instance

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2324,3 +2324,8 @@ This introduces a new `io.bus` property to disk devices which can be used to ove
 
 ## `storage_cephfs_create_missing`
 This introduces the configuration keys `cephfs.create_missing`, `cephfs.osd_pg_num`, `cephfs.meta_pool` and `cephfs.osd_pool` to be used when adding a `cephfs` storage pool to instruct LXD to create the necessary entities for the storage pool, if they do not exist.
+
+## `instance_move_config`
+
+This API extension provides the ability to use flags `--profile`, `--no-profile`, `--device`, and `--config`
+when moving an instance between projects and/or storage pools.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1662,6 +1662,32 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstancePost:
         properties:
+            Config:
+                additionalProperties:
+                    type: string
+                description: Instance configuration file.
+                example:
+                    security.nesting: "true"
+                type: object
+            Devices:
+                additionalProperties:
+                    additionalProperties:
+                        type: string
+                    type: object
+                description: Instance devices.
+                example:
+                    root:
+                        path: /
+                        pool: default
+                        type: disk
+                type: object
+            Profiles:
+                description: List of profiles applied to the instance.
+                example:
+                    - default
+                items:
+                    type: string
+                type: array
             allow_inconsistent:
                 description: AllowInconsistent allow inconsistent copies when migrating.
                 example: false

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1535,7 +1535,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2732,11 +2732,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3638,11 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5364,15 +5364,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5380,15 +5380,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6817,7 +6817,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1146,7 +1146,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1395,7 +1395,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1430,7 +1430,7 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1494,7 +1494,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1869,7 +1869,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2491,7 +2491,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2940,7 +2940,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3141,12 +3141,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3922,12 +3922,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4140,12 +4140,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4166,7 +4166,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4679,7 +4679,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profile to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5881,7 +5881,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -5970,16 +5970,16 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5987,17 +5987,17 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6133,7 +6133,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6240,7 +6240,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6249,7 +6249,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6371,7 +6371,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6687,7 +6687,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7168,7 +7168,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8066,7 +8066,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1030,7 +1030,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1197,7 +1197,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1549,7 +1549,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2138,7 +2138,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2768,11 +2768,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3489,12 +3489,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3693,11 +3693,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3717,7 +3717,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3937,7 +3937,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4220,7 +4220,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5367,7 +5367,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5451,15 +5451,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5467,15 +5467,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5609,7 +5609,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5712,7 +5712,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5721,7 +5721,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5841,7 +5841,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6136,7 +6136,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6373,7 +6373,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6921,7 +6921,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1001,7 +1001,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1103,7 +1103,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
@@ -1276,7 +1276,7 @@ msgstr "Perfil %s eliminado de %s"
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1350,7 +1350,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -1385,7 +1385,7 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1445,7 +1445,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1804,7 +1804,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2397,7 +2397,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3034,12 +3034,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3766,12 +3766,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Aliases:"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4005,7 +4005,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4223,7 +4223,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4508,7 +4508,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profile to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -5667,7 +5667,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5751,16 +5751,16 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5768,16 +5768,16 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5911,7 +5911,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6015,7 +6015,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6024,7 +6024,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6442,7 +6442,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6733,7 +6733,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7364,7 +7364,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1141,7 +1141,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgstr "Périphérique %s retiré de %s"
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1398,7 +1398,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1433,7 +1433,7 @@ msgstr "État : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1497,7 +1497,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1894,7 +1894,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2524,7 +2524,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3184,12 +3184,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -4004,12 +4004,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4226,12 +4226,12 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 #, fuzzy
 msgid "Move instances within or in between LXD servers"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4252,7 +4252,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -4476,7 +4476,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -4779,7 +4779,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profile to apply to the new instance"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -6013,7 +6013,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -6103,15 +6103,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6119,15 +6119,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6270,7 +6270,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6378,7 +6378,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6387,7 +6387,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6510,7 +6510,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -6826,7 +6826,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7364,7 +7364,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8327,7 +8327,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2736,11 +2736,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3642,11 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4166,7 +4166,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5284,7 +5284,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5368,15 +5368,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5384,15 +5384,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5757,7 +5757,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6036,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6273,7 +6273,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6821,7 +6821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1101,7 +1101,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1271,7 +1271,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1344,7 +1344,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1378,7 +1378,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1798,7 +1798,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2392,7 +2392,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3025,12 +3025,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3764,12 +3764,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3977,11 +3977,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4001,7 +4001,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4219,7 +4219,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4505,7 +4505,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -5662,7 +5662,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5748,15 +5748,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5764,15 +5764,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6011,7 +6011,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6020,7 +6020,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6435,7 +6435,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -6728,7 +6728,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7359,7 +7359,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1115,7 +1115,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1291,7 +1291,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1368,7 +1368,7 @@ msgstr "新しいインスタンスに適用するキー/値の設定"
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
@@ -1402,7 +1402,7 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1477,7 +1477,7 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
@@ -1826,7 +1826,7 @@ msgstr "警告を削除します"
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2440,7 +2440,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2892,7 +2892,7 @@ msgstr "設定されている自動でのインスタンスの有効期限設定
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr "コピー中にファイルが更新された場合のエラーを無視します"
 
@@ -3098,11 +3098,11 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
@@ -3967,12 +3967,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4171,11 +4171,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr "LXD サーバ内もしくはサーバ間でインスタンスを移動します"
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4206,7 +4206,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
@@ -4428,7 +4428,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -4713,7 +4713,7 @@ msgstr "新しいイメージに適用するプロファイル"
 msgid "Profile to apply to the new instance"
 msgstr "新しいインスタンスに適用するプロファイル"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr "移動先のインスタンスに適用するプロファイル"
 
@@ -5912,7 +5912,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -5996,16 +5996,16 @@ msgstr "ターゲットのパスと --listen オプションは同時に指定�
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
@@ -6013,15 +6013,15 @@ msgstr "--mode と --target は同時に指定できません"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
@@ -6160,7 +6160,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
@@ -6282,7 +6282,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull, push or relay"
 msgstr "転送モード。pull, push, relay のいずれか"
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
@@ -6291,7 +6291,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6412,7 +6412,7 @@ msgstr "未知の出力タイプ: %q"
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
@@ -6709,7 +6709,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -6950,7 +6950,7 @@ msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
@@ -7601,7 +7601,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1535,7 +1535,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2732,11 +2732,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3638,11 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5364,15 +5364,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5380,15 +5380,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6817,7 +6817,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2023-11-27 13:02+0100\n"
+        "POT-Creation-Date: 2023-12-01 11:57+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -720,7 +720,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -820,7 +820,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -984,7 +984,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734 lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56 lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1697 lxc/storage_volume.go:1824 lxc/storage_volume.go:1970 lxc/storage_volume.go:2074 lxc/storage_volume.go:2114 lxc/storage_volume.go:2207 lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
+#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734 lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1697 lxc/storage_volume.go:1824 lxc/storage_volume.go:1970 lxc/storage_volume.go:2074 lxc/storage_volume.go:2114 lxc/storage_volume.go:2207 lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1031,7 +1031,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
@@ -1058,7 +1058,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -1112,7 +1112,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252 lxc/storage_volume.go:338
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252 lxc/storage_volume.go:338
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1416,7 +1416,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1189 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:40 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:32 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:88 lxc/remote.go:628 lxc/remote.go:664 lxc/remote.go:752 lxc/remote.go:823 lxc/remote.go:878 lxc/remote.go:916 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1903,7 +1903,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2308,7 +2308,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid   "Ignore copy errors for volatile files"
 msgstr  ""
 
@@ -2501,11 +2501,11 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
@@ -3188,12 +3188,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3322,11 +3322,11 @@ msgstr  ""
 msgid   "Mount files from instances"
 msgstr  ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid   "Move instances within or in between LXD servers"
 msgstr  ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid   "Move instances within or in between LXD servers\n"
         "\n"
         "Transfer modes (--mode):\n"
@@ -3341,7 +3341,7 @@ msgstr  ""
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
@@ -3549,7 +3549,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -3823,7 +3823,7 @@ msgstr  ""
 msgid   "Profile to apply to the new instance"
 msgstr  ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid   "Profile to apply to the target instance"
 msgstr  ""
 
@@ -4892,7 +4892,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -4973,15 +4973,15 @@ msgstr  ""
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid   "The --mode flag can't be used with --storage or --target-project"
 msgstr  ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
@@ -4989,15 +4989,15 @@ msgstr  ""
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid   "The --storage flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
@@ -5128,7 +5128,7 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
@@ -5224,7 +5224,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay"
 msgstr  ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
@@ -5233,7 +5233,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5346,7 +5346,7 @@ msgstr  ""
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
@@ -5615,7 +5615,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -5843,7 +5843,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6342,7 +6342,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid   "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--instance-only]\n"
         "    Move an instance between two hosts, renaming it if destination name differs.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1410,7 +1410,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1755,7 +1755,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2335,7 +2335,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2952,11 +2952,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3659,12 +3659,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3858,11 +3858,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3882,7 +3882,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4100,7 +4100,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5500,7 +5500,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5584,15 +5584,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5600,15 +5600,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5742,7 +5742,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5845,7 +5845,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5854,7 +5854,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5973,7 +5973,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6252,7 +6252,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6489,7 +6489,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7037,7 +7037,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1108,7 +1108,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1384,7 +1384,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1444,7 +1444,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1789,7 +1789,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2791,7 +2791,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2986,11 +2986,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3693,12 +3693,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3892,11 +3892,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3916,7 +3916,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4134,7 +4134,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4416,7 +4416,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5534,7 +5534,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5618,15 +5618,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5634,15 +5634,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5776,7 +5776,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5879,7 +5879,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5888,7 +5888,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6007,7 +6007,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6286,7 +6286,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6523,7 +6523,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7071,7 +7071,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1535,7 +1535,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2732,11 +2732,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3638,11 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5364,15 +5364,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5380,15 +5380,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6817,7 +6817,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1026,7 +1026,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1127,7 +1127,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgstr "Dispositivo %s removido de %s"
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1379,7 +1379,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 #, fuzzy
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -1414,7 +1414,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1848,7 +1848,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2450,7 +2450,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3089,12 +3089,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3829,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4041,11 +4041,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4065,7 +4065,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4283,7 +4283,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4568,7 +4568,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profile to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 #, fuzzy
 msgid "Profile to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -5752,7 +5752,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5838,16 +5838,16 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,17 +5855,17 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5999,7 +5999,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6103,7 +6103,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6112,7 +6112,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 #, fuzzy
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6537,7 +6537,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7388,7 +7388,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1463,7 +1463,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1834,7 +1834,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2875,7 +2875,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -3076,12 +3076,12 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3826,12 +3826,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4040,11 +4040,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -4065,7 +4065,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4285,7 +4285,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4570,7 +4570,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5743,7 +5743,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5828,15 +5828,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5844,15 +5844,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5986,7 +5986,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6089,7 +6089,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -6098,7 +6098,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6219,7 +6219,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6518,7 +6518,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6975,7 +6975,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7855,7 +7855,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2736,11 +2736,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3642,11 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4166,7 +4166,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5284,7 +5284,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5368,15 +5368,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5384,15 +5384,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5757,7 +5757,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6036,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6273,7 +6273,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6821,7 +6821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2736,11 +2736,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3642,11 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4166,7 +4166,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5284,7 +5284,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5368,15 +5368,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5384,15 +5384,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5757,7 +5757,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6036,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6273,7 +6273,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6821,7 +6821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1096,7 +1096,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1535,7 +1535,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2115,7 +2115,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2732,11 +2732,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3439,12 +3439,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3638,11 +3638,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3662,7 +3662,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4162,7 +4162,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5364,15 +5364,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5380,15 +5380,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5625,7 +5625,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6032,7 +6032,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6269,7 +6269,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6817,7 +6817,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1100,7 +1100,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2736,11 +2736,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3642,11 +3642,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3666,7 +3666,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3884,7 +3884,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4166,7 +4166,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5284,7 +5284,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5368,15 +5368,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5384,15 +5384,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5629,7 +5629,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5638,7 +5638,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5757,7 +5757,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6036,7 +6036,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6273,7 +6273,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6821,7 +6821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1249,7 +1249,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2690,7 +2690,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2885,11 +2885,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3592,12 +3592,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3791,11 +3791,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3815,7 +3815,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4315,7 +4315,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5517,15 +5517,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5533,15 +5533,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5675,7 +5675,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5778,7 +5778,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5787,7 +5787,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6185,7 +6185,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6970,7 +6970,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2023-11-08 07:19+0000\n"
+"POT-Creation-Date: 2023-12-01 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:138 lxc/init.go:216 lxc/project.go:129
+#: lxc/copy.go:138 lxc/init.go:216 lxc/move.go:380 lxc/project.go:129
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:116
+#: lxc/move.go:117
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 
 #: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
 #: lxc/config.go:857 lxc/copy.go:60 lxc/info.go:45 lxc/init.go:56
-#: lxc/move.go:65 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
+#: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
 #: lxc/network_forward.go:406 lxc/network_forward.go:529
@@ -1099,7 +1099,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:57
+#: lxc/move.go:58
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:58 lxc/move.go:63
+#: lxc/copy.go:58 lxc/move.go:64
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:66 lxc/profile.go:252
+#: lxc/copy.go:61 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
@@ -1538,7 +1538,7 @@ msgstr ""
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:36 lxc/network.go:32
+#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32
 #: lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372
 #: lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720
 #: lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005
@@ -2118,7 +2118,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:273 lxc/move.go:349
+#: lxc/move.go:291 lxc/move.go:367
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2540,7 +2540,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
-#: lxc/copy.go:64 lxc/move.go:67
+#: lxc/copy.go:64 lxc/move.go:68
 msgid "Ignore copy errors for volatile files"
 msgstr ""
 
@@ -2735,11 +2735,11 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:134 lxc/storage_volume.go:1745
+#: lxc/move.go:135 lxc/storage_volume.go:1745
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:131
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
@@ -3442,12 +3442,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:291 lxc/move.go:364
+#: lxc/move.go:309 lxc/move.go:423
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:316 lxc/move.go:369
+#: lxc/move.go:334 lxc/move.go:428
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3641,11 +3641,11 @@ msgstr ""
 msgid "Mount files from instances"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:36
 msgid "Move instances within or in between LXD servers"
 msgstr ""
 
-#: lxc/move.go:36
+#: lxc/move.go:37
 msgid ""
 "Move instances within or in between LXD servers\n"
 "\n"
@@ -3665,7 +3665,7 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:61
+#: lxc/move.go:62
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -3883,7 +3883,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:58
+#: lxc/copy.go:53 lxc/init.go:51 lxc/move.go:59
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -4165,7 +4165,7 @@ msgstr ""
 msgid "Profile to apply to the new instance"
 msgstr ""
 
-#: lxc/move.go:59
+#: lxc/move.go:60
 msgid "Profile to apply to the target instance"
 msgstr ""
 
@@ -5283,7 +5283,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:64
+#: lxc/copy.go:59 lxc/import.go:35 lxc/init.go:54 lxc/move.go:65
 msgid "Storage pool name"
 msgstr ""
 
@@ -5367,15 +5367,15 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/move.go:167
+#: lxc/move.go:168
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:209
+#: lxc/move.go:206 lxc/move.go:227
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:179
+#: lxc/move.go:180
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5383,15 +5383,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:171
+#: lxc/move.go:172
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:175
+#: lxc/move.go:176
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:191
+#: lxc/move.go:192
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:278
+#: lxc/move.go:296
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -5628,7 +5628,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay"
 msgstr ""
 
-#: lxc/move.go:62
+#: lxc/move.go:63
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:338 lxc/move.go:296
+#: lxc/copy.go:338 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -5756,7 +5756,7 @@ msgstr ""
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/move.go:60
+#: lxc/move.go:61
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
@@ -6035,7 +6035,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:84 lxc/move.go:262 lxc/move.go:338
+#: lxc/copy.go:84 lxc/move.go:280 lxc/move.go:356
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6272,7 +6272,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
-#: lxc/move.go:33
+#: lxc/move.go:34
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6820,7 +6820,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:46
+#: lxc/move.go:47
 msgid ""
 "lxc move [<remote>:]<source instance> [<remote>:][<destination instance>] [--"
 "instance-only]\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -107,6 +107,24 @@ type InstancePost struct {
 	//
 	// API extension: instance_allow_inconsistent_copy
 	AllowInconsistent bool `json:"allow_inconsistent" yaml:"allow_inconsistent"`
+
+	// Instance configuration file.
+	// Example: {"security.nesting": "true"}
+	//
+	// API extension: instance_move_config
+	Config map[string]string
+
+	// Instance devices.
+	// Example: {"root": {"type": "disk", "pool": "default", "path": "/"}}
+	//
+	// API extension: instance_move_config
+	Devices map[string]map[string]string
+
+	// List of profiles applied to the instance.
+	// Example: ["default"]
+	//
+	// API extension: instance_move_config
+	Profiles []string
 }
 
 // InstancePostTarget represents the migration target host and operation.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -390,6 +390,7 @@ var APIExtensions = []string{
 	"cluster_internal_custom_volume_copy",
 	"disk_io_bus",
 	"storage_cephfs_create_missing",
+	"instance_move_config",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/container_move.sh
+++ b/test/suites/container_move.sh
@@ -10,50 +10,67 @@ test_container_move() {
   profile="test-profile"
 
   # Setup.
-  lxc project create "${project}" --
+  lxc project create "${project}"
   lxc storage create "${pool2}" "${lxd_backend}"
-  lxc profile create "${profile}"
-  lxc profile device add default root disk pool="${pool2}" path=/ --project "${project}"
+  lxc profile create "${profile}" --project "${project}"
+  lxc profile device add "${profile}" root disk pool="${pool2}" path=/ --project "${project}"
 
-  # Move project, verify root disk device is retained.
+  # Move to different project with same profile (root disk device is retained).
   lxc init "${image}" c1
   lxc move c1 --target-project "${project}"
-  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c1" ]         # Verify project.
-  [ "$(lxc config device get c1 root pool --project ${project})" = "${pool}" ] # Verify pool is retained.
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c1" ]         # Verify new project.
+  [ "$(lxc config device get c1 root pool --project ${project})" = "${pool}" ] # Verify same pool (new local device).
   lxc delete -f c1 --project "${project}"
 
-  # Move to different storage pool.
+  # Move to different project with no profiles (root disk device is retained).
   lxc init "${image}" c2
-  lxc move c2 --storage "${pool2}"
-  [ "$(lxc ls --format csv --columns n)" = "c2" ]          # Verify project.
-  [ "$(lxc config device get c2 root pool)" = "${pool2}" ] # Verify pool.
-  lxc delete -f c2
+  lxc move c2 --target-project "${project}" --no-profiles
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c2" ]         # Verify new project.
+  [ "$(lxc config device get c2 root pool --project ${project})" = "${pool}" ] # Verify same pool (new local device).
+  lxc delete -f c2 --project "${project}"
 
-  # Move to different storage pool and project.
+  # Move to different project with new profiles (root disk device is retained).
   lxc init "${image}" c3
-  lxc move c3 --target-project "${project}" --storage "${pool2}"
-  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c3" ]          # Verify project.
-  [ "$(lxc config device get c3 root pool --project ${project})" = "${pool2}" ] # Verify pool.
+  lxc move c3 --target-project "${project}" --profile "${profile}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c3" ]         # Verify new project.
+  [ "$(lxc config device get c3 root pool --project ${project})" = "${pool}" ] # Verify same pool (new local device).
+  lxc config show c3 -e --project "${project}" | grep -- "- ${profile}"        # Verify new profile.
   lxc delete -f c3 --project "${project}"
 
-  # Ensure profile is not retained.
-  lxc init "${image}" c4 --profile default --profile "${profile}"
-  ! lxc move c4 --target-project "${project}" # Err: Profile not found in target project
+  # Move to different project with non-existing profile.
+  lxc init "${image}" c4
+  ! lxc move c4 --target-project "${project}" --profile invalid # Err: Profile not found in target project
   lxc delete -f c4
 
-  # Create matching profile in target project and ensure it is applied on move.
-  lxc profile create "${profile}" --project "${project}"
-  lxc profile set "${profile}" user.foo="test" --project "${project}"
-  lxc init "${image}" c5 --profile default --profile "${profile}"
-  lxc move c5 --target-project "${project}"
-  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c5" ] # Verify project.
-  [ "$(lxc config get c5 user.foo -e --project ${project})" = "test" ] # Verify pool.
-  lxc delete -f c5 --project "${project}"
+  # Move to different storage pool.
+  lxc init "${image}" c5
+  lxc move c5 --storage "${pool2}"
+  [ "$(lxc ls --format csv --columns n)" = "c5" ]          # Verify same project.
+  [ "$(lxc config device get c5 root pool)" = "${pool2}" ] # Verify new pool.
+  lxc delete -f c5
 
-  # Cleanup.
-  lxc profile device remove default root --project "${project}"
+  # Move to different project and storage pool.
+  lxc init "${image}" c6
+  lxc move c6 --target-project "${project}" --storage "${pool2}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c6" ]          # Verify new project.
+  [ "$(lxc config device get c6 root pool --project ${project})" = "${pool2}" ] # Verify new pool.
+  lxc delete -f c6 --project "${project}"
+
+  # Move to different project and overwrite storage pool using device entry.
+  lxc init "${image}" c7 --storage "${pool}" --no-profiles
+  lxc move c7 --target-project "${project}" --device "root,pool=${pool2}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c7" ]          # Verify new project.
+  [ "$(lxc config device get c7 root pool --project ${project})" = "${pool2}" ] # Verify new pool.
+  lxc delete -f c7 --project "${project}"
+
+  # Move to different project and apply config entry.
+  lxc init "${image}" c8
+  lxc move c8 --target-project "${project}" --config user.test=success
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c8" ]  # Verify new project.
+  [ "$(lxc config get c8 user.test --project ${project})" = "success" ] # Verify new local config entry.
+  lxc delete -f c8 --project "${project}"
+
   lxc profile delete "${profile}" --project "${project}"
-  lxc profile delete "${profile}"
   lxc storage delete "${pool2}"
   lxc project delete "${project}"
 }


### PR DESCRIPTION
This is second part of server-side instance move between projects or storage pools. A new API extension is introduced, and it indicates that all CLI move flags are respected (`--config`, `--device`, `--profile`, `--no-profiles`).

TODO:
- [x] API extension needs a better a name (currently it is `instance_project_move_2`).
- [x] Add tests for new functionality.

Fixes #12226