### PR TITLE
VM: Support bootorder in edk2 CSM mode

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1459,6 +1459,11 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		qemuCmd = append(qemuCmd, "-debugcon", "file:"+d.EDK2LogFilePath(), "-global", "isa-debugcon.iobase=0x402")
 	}
 
+	// This feature specific to the snap-shipped CSM edk2 version, because we have a custom patch to make it work.
+	if shared.InSnap() && shared.IsTrue(d.expandedConfig["security.csm"]) {
+		qemuCmd = append(qemuCmd, "-fw_cfg", "name=opt/com.canonical.lxd/force_csm,string=yes")
+	}
+
 	// If stateful, restore now.
 	if stateful {
 		if !d.stateful {


### PR DESCRIPTION
In the LXD snap we ship a patched version of the CSM edk2 firmware. Implementation is in the patch ("edk2: force CSM boot mode for bootorder").

Idea behind this is to be able to apply boot priority configuration for CSM boot mode. While it works perfecly well for UEFI boot mode, it does not work with CSM mode. It means that CSM boot options are always come after UEFI boot options, and even worser, manual changing of the UEFI configuration does not help because bootorder setting are always reset during reboot of the VM (edk2 maintains bootorder settings in agreement with what Qemu supplies using fw_cfg "bootorder" interface).

Usage example:

Suppose that you have a "iso" disk device:
lxc config device add myvm iso disk source=/fullpath/to.iso

And you want to choose it as a first option:
$ lxc config device set myvm iso boot.priority=2

That's all.

Fixes #11908