### PR TITLE
Use default VM block filesystem size from driver

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1039,7 +1039,7 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 			return err
 		}
 
-		stateDiskSizeStr := deviceConfig.DefaultVMBlockFilesystemSize
+		stateDiskSizeStr := d.storagePool.Driver().Info().DefaultVMBlockFilesystemSize
 		if rootDiskDevice["size.state"] != "" {
 			stateDiskSizeStr = rootDiskDevice["size.state"]
 		}

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1250,7 +1250,7 @@ func expandInstancesConfigAndDevices(instances []api.Instance, profiles []api.Pr
 }
 
 // Sum of the effective values for the given limits across all project
-// enties (instances and custom volumes).
+// entities (instances and custom volumes).
 func getTotalsAcrossProjectEntities(info *projectInfo, keys []string, skipUnset bool) (map[string]int64, error) {
 	totals := map[string]int64{}
 

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1328,6 +1328,11 @@ func getInstanceLimits(instance api.Instance, keys []string, skipUnset bool) (ma
 			if instance.Type == instancetype.VM.String() {
 				sizeStateValue, ok := device["size.state"]
 				if !ok {
+					// TODO: In case the VMs storage drivers config drive size isn't the default,
+					// the limits accounting will be incorrect.
+					// This applies for the PowerFlex storage driver whose config drive size
+					// is 8 GB as set in the DefaultVMPowerFlexBlockFilesystemSize variable.
+					// See https://github.com/canonical/lxd/issues/12567
 					sizeStateValue = deviceconfig.DefaultVMBlockFilesystemSize
 				}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2632,7 +2632,7 @@ func (b *lxdBackend) SetInstanceQuota(inst instance.Instance, size string, vmSta
 		// this will also pass empty quota for the config filesystem volume as well, allowing a former
 		// quota to be removed from both volumes.
 		if vmStateSize == "" && size != "" {
-			vmStateSize = deviceConfig.DefaultVMBlockFilesystemSize
+			vmStateSize = b.driver.Info().DefaultVMBlockFilesystemSize
 		}
 
 		fsVol := vol.NewVMBlockFilesystemVolume()

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -28,7 +28,6 @@ import (
 	"github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
-	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
@@ -914,7 +913,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 				// filesystem volume as well, allowing a former quota to be removed from both
 				// volumes.
 				if vmStateSize == "" && size != "" {
-					vmStateSize = deviceConfig.DefaultVMBlockFilesystemSize
+					vmStateSize = b.driver.Info().DefaultVMBlockFilesystemSize
 				}
 
 				l.Debug("Applying filesystem volume quota from root disk config", logger.Ctx{"size.state": vmStateSize})

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/revert"
@@ -88,20 +89,21 @@ func (d *btrfs) load() error {
 // Info returns info about the driver and its environment.
 func (d *btrfs) Info() Info {
 	return Info{
-		Name:                  "btrfs",
-		Version:               btrfsVersion,
-		OptimizedImages:       true,
-		OptimizedBackups:      true,
-		OptimizedBackupHeader: true,
-		PreservesInodes:       !d.state.OS.RunningInUserNS,
-		Remote:                d.isRemote(),
-		VolumeTypes:           []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:          false,
-		RunningCopyFreeze:     false,
-		DirectIO:              true,
-		IOUring:               true,
-		MountedRoot:           true,
-		Buckets:               true,
+		Name:                         "btrfs",
+		Version:                      btrfsVersion,
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              true,
+		OptimizedBackups:             true,
+		OptimizedBackupHeader:        true,
+		PreservesInodes:              !d.state.OS.RunningInUserNS,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 false,
+		RunningCopyFreeze:            false,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  true,
+		Buckets:                      true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/revert"
@@ -78,17 +79,18 @@ func (d *ceph) isRemote() bool {
 // Info returns info about the driver and its environment.
 func (d *ceph) Info() Info {
 	return Info{
-		Name:              "ceph",
-		Version:           cephVersion,
-		OptimizedImages:   true,
-		PreservesInodes:   false,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:      true,
-		RunningCopyFreeze: true,
-		DirectIO:          true,
-		IOUring:           true,
-		MountedRoot:       false,
+		Name:                         "ceph",
+		Version:                      cephVersion,
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              true,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 true,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  false,
 	}
 }
 

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
@@ -75,17 +76,18 @@ func (d *cephfs) isRemote() bool {
 // Info returns the pool driver information.
 func (d *cephfs) Info() Info {
 	return Info{
-		Name:              "cephfs",
-		Version:           cephfsVersion,
-		OptimizedImages:   false,
-		PreservesInodes:   false,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeCustom},
-		VolumeMultiNode:   true,
-		BlockBacking:      false,
-		RunningCopyFreeze: false,
-		DirectIO:          true,
-		MountedRoot:       true,
+		Name:                         "cephfs",
+		Version:                      cephfsVersion,
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              false,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeCustom},
+		VolumeMultiNode:              true,
+		BlockBacking:                 false,
+		RunningCopyFreeze:            false,
+		DirectIO:                     true,
+		MountedRoot:                  true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -33,18 +34,19 @@ func (d *dir) load() error {
 // Info returns info about the driver and its environment.
 func (d *dir) Info() Info {
 	return Info{
-		Name:              "dir",
-		Version:           "1",
-		OptimizedImages:   false,
-		PreservesInodes:   false,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:      false,
-		RunningCopyFreeze: true,
-		DirectIO:          true,
-		IOUring:           true,
-		MountedRoot:       true,
-		Buckets:           true,
+		Name:                         "dir",
+		Version:                      "1",
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              false,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 false,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  true,
+		Buckets:                      true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/revert"
 	"github.com/canonical/lxd/shared"
@@ -84,18 +85,19 @@ func (d *lvm) load() error {
 // Info returns info about the driver and its environment.
 func (d *lvm) Info() Info {
 	return Info{
-		Name:              "lvm",
-		Version:           lvmVersion,
-		OptimizedImages:   d.usesThinpool(), // Only thinpool pools support optimized images.
-		PreservesInodes:   false,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:      true,
-		RunningCopyFreeze: true,
-		DirectIO:          true,
-		IOUring:           true,
-		MountedRoot:       false,
-		Buckets:           true,
+		Name:                         "lvm",
+		Version:                      lvmVersion,
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              d.usesThinpool(), // Only thinpool pools support optimized images.
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 true,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		IOUring:                      true,
+		MountedRoot:                  false,
+		Buckets:                      true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/canonical/lxd/lxd/backup"
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/revert"
@@ -23,16 +24,17 @@ func (d *mock) load() error {
 // Info returns info about the driver and its environment.
 func (d *mock) Info() Info {
 	return Info{
-		Name:              "mock",
-		Version:           "1",
-		OptimizedImages:   false,
-		PreservesInodes:   false,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:      false,
-		RunningCopyFreeze: true,
-		DirectIO:          true,
-		MountedRoot:       true,
+		Name:                         "mock",
+		Version:                      "1",
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              false,
+		PreservesInodes:              false,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 false,
+		RunningCopyFreeze:            true,
+		DirectIO:                     true,
+		MountedRoot:                  true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -2,21 +2,22 @@ package drivers
 
 // Info represents information about a storage driver.
 type Info struct {
-	Name                  string
-	Version               string
-	VolumeTypes           []VolumeType // Supported volume types.
-	Buckets               bool         // Buckets supported.
-	Remote                bool         // Whether the driver uses a remote backing store.
-	VolumeMultiNode       bool         // Whether volumes can be used on multiple nodes concurrently.
-	OptimizedImages       bool         // Whether driver stores images as separate volume.
-	OptimizedBackups      bool         // Whether driver supports optimized volume backups.
-	OptimizedBackupHeader bool         // Whether driver generates an optimised backup header file in backup.
-	PreservesInodes       bool         // Whether driver preserves inodes when volumes are moved hosts.
-	BlockBacking          bool         // Whether driver uses block devices as backing store.
-	RunningCopyFreeze     bool         // Whether instance should be frozen during snapshot if running.
-	DirectIO              bool         // Whether the driver supports direct I/O.
-	IOUring               bool         // Whether the driver supports io_uring.
-	MountedRoot           bool         // Whether the pool directory itself is a mount.
+	Name                         string
+	Version                      string
+	VolumeTypes                  []VolumeType // Supported volume types.
+	DefaultVMBlockFilesystemSize string       // Default volume size for VM block filesystems.
+	Buckets                      bool         // Buckets supported.
+	Remote                       bool         // Whether the driver uses a remote backing store.
+	VolumeMultiNode              bool         // Whether volumes can be used on multiple nodes concurrently.
+	OptimizedImages              bool         // Whether driver stores images as separate volume.
+	OptimizedBackups             bool         // Whether driver supports optimized volume backups.
+	OptimizedBackupHeader        bool         // Whether driver generates an optimised backup header file in backup.
+	PreservesInodes              bool         // Whether driver preserves inodes when volumes are moved hosts.
+	BlockBacking                 bool         // Whether driver uses block devices as backing store.
+	RunningCopyFreeze            bool         // Whether instance should be frozen during snapshot if running.
+	DirectIO                     bool         // Whether the driver supports direct I/O.
+	IOUring                      bool         // Whether the driver supports io_uring.
+	MountedRoot                  bool         // Whether the pool directory itself is a mount.
 }
 
 // VolumeFiller provides a struct for filling a volume.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/revert"
@@ -116,18 +117,19 @@ func (d *zfs) load() error {
 // Info returns info about the driver and its environment.
 func (d *zfs) Info() Info {
 	info := Info{
-		Name:              "zfs",
-		Version:           zfsVersion,
-		OptimizedImages:   true,
-		OptimizedBackups:  true,
-		PreservesInodes:   true,
-		Remote:            d.isRemote(),
-		VolumeTypes:       []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
-		BlockBacking:      shared.IsTrue(d.config["volume.zfs.block_mode"]),
-		RunningCopyFreeze: false,
-		DirectIO:          zfsDirectIO,
-		MountedRoot:       false,
-		Buckets:           true,
+		Name:                         "zfs",
+		Version:                      zfsVersion,
+		DefaultVMBlockFilesystemSize: deviceConfig.DefaultVMBlockFilesystemSize,
+		OptimizedImages:              true,
+		OptimizedBackups:             true,
+		PreservesInodes:              true,
+		Remote:                       d.isRemote(),
+		VolumeTypes:                  []VolumeType{VolumeTypeBucket, VolumeTypeCustom, VolumeTypeImage, VolumeTypeContainer, VolumeTypeVM},
+		BlockBacking:                 shared.IsTrue(d.config["volume.zfs.block_mode"]),
+		RunningCopyFreeze:            false,
+		DirectIO:                     zfsDirectIO,
+		MountedRoot:                  false,
+		Buckets:                      true,
 	}
 
 	return info

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	deviceConfig "github.com/canonical/lxd/lxd/device/config"
 	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/refcount"
@@ -416,7 +415,7 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 		newConf["size"] = v.config["size.state"]
 	} else {
 		// Fallback to the default VM filesystem size.
-		newConf["size"] = deviceConfig.DefaultVMBlockFilesystemSize
+		newConf["size"] = v.driver.Info().DefaultVMBlockFilesystemSize
 	}
 
 	vol := NewVolume(v.driver, v.pool, v.volType, ContentTypeFS, v.name, newConf, v.poolConfig)


### PR DESCRIPTION
To accommodate the Dell PowerFlex storage driver, the default size for VM block filesystems should be exported directly through the storage driver. This allows changing the default size per driver and removes the burden of having internal driver knowledge outside of the `lxd/storage` package.

The projects instance limits accounting requires a follow up since the total value will be incorrect in case of the PowerFlex driver. See this issue for later reference: https://github.com/canonical/lxd/issues/12567.