### PR TITLE
Use stable random generator for temporary instance name

### DIFF
--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -1074,7 +1074,7 @@ func MoveTemporaryName(inst Instance) (string, error) {
 		instUUID = uuid.New().String()
 		err := inst.VolatileSet(map[string]string{"volatile.uuid": instUUID})
 		if err != nil {
-			return "", fmt.Errorf("Failed generating instance UUID: %w", err)
+			return "", fmt.Errorf("Failed setting volatile.uuid to %s: %w", instUUID, err)
 		}
 	}
 

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/canonical/lxd/lxd/seccomp"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/idmap"
@@ -1049,9 +1050,18 @@ func NextSnapshotName(s *state.State, inst Instance, defaultPattern string) (str
 	return pattern, nil
 }
 
-// temporaryName concatenates the move prefix and instUUID for a temporary instance.
-func temporaryName(instUUID string) string {
-	return fmt.Sprintf("lxd-move-of-%s", instUUID)
+// temporaryName returns the temporary instance name using a stable random generator.
+// The returned string is a valid DNS name.
+func temporaryName(instUUID string) (string, error) {
+	r, err := util.GetStableRandomGenerator(instUUID)
+	if err != nil {
+		return "", err
+	}
+
+	// The longest temporary name is lxd-move-18446744073709551615 which has a length
+	// of 30 characters since 18446744073709551615 is the biggest value for an uint64.
+	// The prefix is attached to have a valid DNS name that doesn't start with numbers.
+	return fmt.Sprintf("lxd-move-%d", r.Uint64()), nil
 }
 
 // MoveTemporaryName returns a name derived from the instance's volatile.uuid, to use when moving an instance
@@ -1068,7 +1078,7 @@ func MoveTemporaryName(inst Instance) (string, error) {
 		}
 	}
 
-	return temporaryName(instUUID), nil
+	return temporaryName(instUUID)
 }
 
 // IsSameLogicalInstance returns true if the supplied Instance and db.Instance have the same project and name or
@@ -1083,12 +1093,22 @@ func IsSameLogicalInstance(inst Instance, dbInst *db.InstanceArgs) bool {
 	if dbInst.Config["volatile.uuid"] == inst.LocalConfig()["volatile.uuid"] {
 		// Accommodate moving instances between storage pools.
 		// Check temporary copy against source.
-		if dbInst.Name == temporaryName(inst.LocalConfig()["volatile.uuid"]) {
+		tempName, err := temporaryName(inst.LocalConfig()["volatile.uuid"])
+		if err != nil {
+			return false
+		}
+
+		if dbInst.Name == tempName {
 			return true
 		}
 
 		// Check source against temporary copy.
-		if inst.Name() == temporaryName(dbInst.Config["volatile.uuid"]) {
+		tempName, err = temporaryName(dbInst.Config["volatile.uuid"])
+		if err != nil {
+			return false
+		}
+
+		if inst.Name() == tempName {
 			return true
 		}
 


### PR DESCRIPTION
This allows not having the full size UUID name but instead use a shorter name which is still derived from the instances UUID and represents a valid DNS name.

It's required to accommodate the Dell PowerFlex storage driver which has a maximum length of 31 characters per storage volume.