### PR TITLE
Add missing pool name to storage volume import command.

### DIFF
--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -109,7 +109,7 @@ In this scenario, use the following command to create an empty VM:
 
 The second step is to import an ISO image that can later be attached to the VM as a storage volume:
 
-    lxc storage volume import <path-to-image.iso> iso-volume --type=iso
+    lxc storage volume import default <path-to-image.iso> iso-volume --type=iso
 
 Lastly, you need to attach the custom ISO volume to the VM using the following command:
 


### PR DESCRIPTION
In the instructions for booting from an ISO image the pool name is missing from the volume import command.