### PR TITLE
Retain root disk device when moving an instance to different project

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -282,6 +282,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_container_devices_unix_char "container devices - unix-char"
     run_test test_container_devices_unix_block "container devices - unix-block"
     run_test test_container_devices_tpm "container devices - tpm"
+    run_test test_container_move "container server-side move"
     run_test test_container_syscall_interception "container syscall interception"
     run_test test_security "security features"
     run_test test_security_protection "container protection"

--- a/test/suites/container_move.sh
+++ b/test/suites/container_move.sh
@@ -1,0 +1,59 @@
+test_container_move() {
+  ensure_import_testimage
+  ensure_has_localhost_remote "${LXD_ADDR}"
+
+  lxd_backend=$(storage_backend "$LXD_DIR")
+  pool=$(lxc profile device get default root pool)
+  pool2="test-pool"
+  image="testimage"
+  project="test-project"
+  profile="test-profile"
+
+  # Setup.
+  lxc project create "${project}" --
+  lxc storage create "${pool2}" "${lxd_backend}"
+  lxc profile create "${profile}"
+  lxc profile device add default root disk pool="${pool2}" path=/ --project "${project}"
+
+  # Move project, verify root disk device is retained.
+  lxc init "${image}" c1
+  lxc move c1 --target-project "${project}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c1" ]         # Verify project.
+  [ "$(lxc config device get c1 root pool --project ${project})" = "${pool}" ] # Verify pool is retained.
+  lxc delete -f c1 --project "${project}"
+
+  # Move to different storage pool.
+  lxc init "${image}" c2
+  lxc move c2 --storage "${pool2}"
+  [ "$(lxc ls --format csv --columns n)" = "c2" ]          # Verify project.
+  [ "$(lxc config device get c2 root pool)" = "${pool2}" ] # Verify pool.
+  lxc delete -f c2
+
+  # Move to different storage pool and project.
+  lxc init "${image}" c3
+  lxc move c3 --target-project "${project}" --storage "${pool2}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c3" ]          # Verify project.
+  [ "$(lxc config device get c3 root pool --project ${project})" = "${pool2}" ] # Verify pool.
+  lxc delete -f c3 --project "${project}"
+
+  # Ensure profile is not retained.
+  lxc init "${image}" c4 --profile default --profile "${profile}"
+  ! lxc move c4 --target-project "${project}" # Err: Profile not found in target project
+  lxc delete -f c4
+
+  # Create matching profile in target project and ensure it is applied on move.
+  lxc profile create "${profile}" --project "${project}"
+  lxc profile set "${profile}" user.foo="test" --project "${project}"
+  lxc init "${image}" c5 --profile default --profile "${profile}"
+  lxc move c5 --target-project "${project}"
+  [ "$(lxc ls --project ${project} --format csv --columns n)" = "c5" ] # Verify project.
+  [ "$(lxc config get c5 user.foo -e --project ${project})" = "test" ] # Verify pool.
+  lxc delete -f c5 --project "${project}"
+
+  # Cleanup.
+  lxc profile device remove default root --project "${project}"
+  lxc profile delete "${profile}" --project "${project}"
+  lxc profile delete "${profile}"
+  lxc storage delete "${pool2}"
+  lxc project delete "${project}"
+}


### PR DESCRIPTION
This PR fixes the behavior of #12412 where root disk device is moved if different one is specified by new profiles.

Root disk device is now always retained unless the user explicitly specifies it using `--storage` flag.

Example:
```sh
# Create new project and storage pool.
$ lxc project create p1
$ lxc storage create test zfs

# Add new storage pool to default profile of a new project.
$ lxc profile device add default root disk pool=test path=/ --project p1

$ lxc init ubuntu:22.04 c1

# A new profile would previously overwrite the existing root disk device.
$ lxc move c1 --target-project p1

$ lxc config show c1 --project p1
# ...
# devices:
#   root:
#     path: /
#     pool: default
#     type: disk
```