### PR TITLE
doc/instances: change pool name to be consistent

### DIFF
--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -126,6 +126,6 @@ Once you're done in the serial console, you need to disconnect from the console 
 
 You should now see the installer. After the installation is done, you need to detach the custom ISO volume:
 
-    lxc storage volume detach default iso-volume iso-vm
+    lxc storage volume detach <pool> iso-volume iso-vm
 
 Now the VM can be rebooted, and it will boot from disk.


### PR DESCRIPTION
Follow-up to #12574 and #12572 - use `<pool>` as the pool name instead of `default`.