### PR TITLE
VM: Strip noisy eof error when lxd-agent disconnects during exec session

### DIFF
--- a/lxd/instance/drivers/driver_qemu_cmd.go
+++ b/lxd/instance/drivers/driver_qemu_cmd.go
@@ -1,7 +1,9 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -72,6 +74,13 @@ func (c *qemuCmd) Wait() (int, error) {
 	}
 
 	if err != nil {
+		// Error of type EOF indicates the session ended unexpectedly,
+		// so we inform the client of the disconnection with a more
+		// descriptive message.
+		if errors.Is(err, io.EOF) {
+			return exitStatus, fmt.Errorf("Disconnected")
+		}
+
 		return exitStatus, err
 	}
 


### PR DESCRIPTION
Currently, when VM is halted, an error including operation URL is displayed to the user.
~Instead of returning an entire error we return just EOF (so that error can still be detected on the client's side).~
Return no error if error is of type EOF.

Fixes #12511