### PR TITLE
github: enable dependabot gomod checking for 4.0/5.0 stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,26 @@ updates:
       interval: "weekly"
 
   # XXX: check on other (non-default) stable branches
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "stable-5.0"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     labels: []
     schedule:
       interval: "weekly"
     target-branch: "stable-5.0"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "stable-4.0"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot needs to be told to check after `gomod` too for non-default branches.