### PR TITLE
github: have curl fail instead of feeding bogus data on download error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -259,11 +259,11 @@ jobs:
           chmod +x "$(go env GOPATH)/bin/minio"
 
           # Download latest release of openfga server.
-          curl -s https://api.github.com/repos/openfga/openfga/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -L {} -o openfga.tar.gz
+          curl -sSfL https://api.github.com/repos/openfga/openfga/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -sSfL {} -o openfga.tar.gz
           tar -xzf openfga.tar.gz -C "$(go env GOPATH)/bin/"
 
           # Download latest release of openfga cli.
-          curl -s https://api.github.com/repos/openfga/cli/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -L {} -o fga.tar.gz
+          curl -sSfL https://api.github.com/repos/openfga/cli/releases/latest | jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))' | xargs -I {} curl -sSfL {} -o fga.tar.gz
           tar -xzf fga.tar.gz -C "$(go env GOPATH)/bin/"
 
       - name: Download go dependencies


### PR DESCRIPTION
The goal it to avoid this sort of error https://github.com/canonical/lxd/actions/runs/7079803622/job/19269110476?pr=12588:

```
+ curl -s https://api.github.com/repos/openfga/openfga/releases/latest
+ jq -r '.assets | .[] | .browser_download_url | select(. | test("_linux_amd64.tar.gz$"))'
+ xargs -I '{}' curl -L '{}' -o openfga.tar.gz
jq: error (at <stdin>:1): Cannot iterate over null (null)
++ go env GOPATH
+ tar -xzf openfga.tar.gz -C /home/runner/go/bin/
tar (child): openfga.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
Error: Process completed with exit code 2.
```