### PR TITLE
Clarify restricted.containers.privilege config option

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1098,7 +1098,7 @@ When set to `allow`, {config:option}`instance-security:security.nesting` can be 
 Possible values are `unprivileged`, `isolated`, and `allow`.
 
 - When set to `unpriviliged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.
+- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and forces using a unique idmap per container using {config:option}`instance-security:security.idmap.isolated` set to `true`.
 - When set to `allow`, there is no restriction.
 ```
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1254,7 +1254,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		// Possible values are `unprivileged`, `isolated`, and `allow`.
 		//
 		// - When set to `unpriviliged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.
-		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.
+		// - When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and forces using a unique idmap per container using {config:option}`instance-security:security.idmap.isolated` set to `true`.
 		// - When set to `allow`, there is no restriction.
 		// ---
 		//  type: string

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1188,7 +1188,7 @@
 					{
 						"restricted.containers.privilege": {
 							"defaultdesc": "`unprivileged`",
-							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unpriviliged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` and {config:option}`instance-security:security.idmap.isolated` to `true`.\n- When set to `allow`, there is no restriction.",
+							"longdesc": "Possible values are `unprivileged`, `isolated`, and `allow`.\n\n- When set to `unpriviliged`, this option prevents setting {config:option}`instance-security:security.privileged` to `true`.\n- When set to `isolated`, this option prevents setting {config:option}`instance-security:security.privileged` to `true` and forces using a unique idmap per container using {config:option}`instance-security:security.idmap.isolated` set to `true`.\n- When set to `allow`, there is no restriction.",
 							"shortdesc": "Which settings for privileged containers to prevent",
 							"type": "string"
 						}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/12591

The fact that it automatically assumes `security.idmap.isolated=true` if `restricted.containers.privilege` is set to `isoldated` seems a bit odd since it is not the default value. However saying that this is the default behavior should explain the config option more thoroughly.
