### PR TITLE
test: if backend is ZFS (also through random backend) and version less than 2.2, skip idmapped mount

### DIFF
--- a/test/suites/container_devices_disk.sh
+++ b/test/suites/container_devices_disk.sh
@@ -15,11 +15,15 @@ test_container_devices_disk() {
 }
 
 test_container_devices_disk_shift() {
+  # shellcheck disable=2039,3043
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
   if [ -n "${LXD_IDMAPPED_MOUNTS_DISABLE:-}" ]; then
     return
   fi
 
-  if [ "${LXD_BACKEND}" = "zfs" ]; then
+  if [ "${lxd_backend}" = "zfs" ]; then
     # ZFS 2.2 is required for idmapped mounts support.
     zfs_version=$(zfs --version | grep -m 1 '^zfs-' | cut -d '-' -f 2)
     if [ "$(printf '%s\n' "$zfs_version" "2.2" | sort -V | head -n1)" = "$zfs_version" ]; then


### PR DESCRIPTION
This fix avoids running into the issue of having a `LXD_BACKEND=random` but being zfs underneath leading to a failure of `test_container_devices_disk` for a zfs version not being greater of equal to `2.2` (official support for idmapped mounts for ZFS). Now, we read the `${lxddir}/lxd.backend` (and not the env variable) to be certain  of that.