### PR TITLE
doc/projects: clarify restricted.devices.disk

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1102,7 +1102,7 @@ Possible values are `unprivileged`, `isolated`, and `allow`.
 - When set to `allow`, there is no restriction.
 ```
 
-```{config:option} restricted.devices.disk project-restricted
+````{config:option} restricted.devices.disk project-restricted
 :defaultdesc: "`managed`"
 :shortdesc: "Which disk devices can be used"
 :type: "string"
@@ -1111,7 +1111,16 @@ Possible values are `allow`, `block`, or `managed`.
 - When set to `block`, this option prevents using all disk devices except the root one.
 - When set to `managed`, this option allows using disk devices only if `pool=` is set.
 - When set to `allow`, there is no restriction on which disk devices can be used.
-```
+
+  ```{important}
+  When allowing all disk devices, make sure to set
+  {config:option}`project-restricted:restricted.devices.disk.paths` to a list of
+  path prefixes that you want to allow.
+  If you do not restrict the allowed paths, users can attach any disk device, including
+  shifted devices (`disk` devices with [`shift`](devices-disk-options) set to `true`),
+  which can be used to gain root access to the system.
+  ```
+````
 
 ```{config:option} restricted.devices.disk.paths project-restricted
 :shortdesc: "Which `source` can be used for `disk` devices"

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -88,6 +88,7 @@ You can also set an initial configuration directly when creating an instance. Fo
 
 Note that you cannot use initial volume configurations with custom volume options or to set the volume's size.
 
+(devices-disk-options)=
 ## Device options
 
 `disk` devices have the following device options:

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1342,6 +1342,15 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 		// - When set to `block`, this option prevents using all disk devices except the root one.
 		// - When set to `managed`, this option allows using disk devices only if `pool=` is set.
 		// - When set to `allow`, there is no restriction on which disk devices can be used.
+		//
+		//   ```{important}
+		//   When allowing all disk devices, make sure to set
+		//   {config:option}`project-restricted:restricted.devices.disk.paths` to a list of
+		//   path prefixes that you want to allow.
+		//   If you do not restrict the allowed paths, users can attach any disk device, including
+		//   shifted devices (`disk` devices with [`shift`](devices-disk-options) set to `true`),
+		//   which can be used to gain root access to the system.
+		//   ```
 		// ---
 		//  type: string
 		//  defaultdesc: `managed`

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1196,7 +1196,7 @@
 					{
 						"restricted.devices.disk": {
 							"defaultdesc": "`managed`",
-							"longdesc": "Possible values are `allow`, `block`, or `managed`.\n\n- When set to `block`, this option prevents using all disk devices except the root one.\n- When set to `managed`, this option allows using disk devices only if `pool=` is set.\n- When set to `allow`, there is no restriction on which disk devices can be used.",
+							"longdesc": "Possible values are `allow`, `block`, or `managed`.\n\n- When set to `block`, this option prevents using all disk devices except the root one.\n- When set to `managed`, this option allows using disk devices only if `pool=` is set.\n- When set to `allow`, there is no restriction on which disk devices can be used.\n\n  ```{important}\n  When allowing all disk devices, make sure to set\n  {config:option}`project-restricted:restricted.devices.disk.paths` to a list of\n  path prefixes that you want to allow.\n  If you do not restrict the allowed paths, users can attach any disk device, including\n  shifted devices (`disk` devices with [`shift`](devices-disk-options) set to `true`),\n  which can be used to gain root access to the system.\n  ```",
 							"shortdesc": "Which disk devices can be used",
 							"type": "string"
 						}


### PR DESCRIPTION
Clarify that you really should set `restricted.devices.disk.paths` when you set `restricted.devices.disk=allow`.

Fixes #12606.