### PR TITLE
Set correct RBD content type for qemu drives

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3860,8 +3860,14 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 			volumeName = volName
 		}
 
+		// Identify the right content type.
+		rbdContentType := storageDrivers.ContentTypeBlock
+		if driveConf.FSType == "iso9660" {
+			rbdContentType = storageDrivers.ContentTypeISO
+		}
+
 		// Get the RBD image name.
-		vol := storageDrivers.NewVolume(nil, "", volumeType, storageDrivers.ContentTypeBlock, volumeName, nil, nil)
+		vol := storageDrivers.NewVolume(nil, "", volumeType, rbdContentType, volumeName, nil, nil)
 		rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
 
 		// Parse the options (ceph credentials).


### PR DESCRIPTION
In case a Ceph RBD gets added to the instances qemu config, the correct content type needs to be taken in order to generate the right volume name including it's specific suffix for either block or ISO drives.