### PR TITLE
Fix instance name generation not respecting existing instances

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -49,9 +49,9 @@ func (c *ClusterTx) GetInstanceNames(ctx context.Context, project string) ([]str
 	stmt := `
 SELECT instances.name FROM instances
   JOIN projects ON projects.id = instances.project_id
-  WHERE projects.name = ? AND instances.type = ?
+  WHERE projects.name = ?
 `
-	return query.SelectStrings(ctx, c.tx, stmt, project, instancetype.Any)
+	return query.SelectStrings(ctx, c.tx, stmt, project)
 }
 
 // GetNodeAddressOfInstance returns the address of the node hosting the


### PR DESCRIPTION
I've noticed that when generating an instance name ([lxd/instances_post.go#1005](https://github.com/canonical/lxd/blob/main/lxd/instances_post.go#L1005-L1008)), existing instance names are not respected. The issue seems to be in `GetInstanceNames()` which fetches instance names from a given project with type `Any`.

Since instance type `Any == -1`, no instance names are fetched.

---

Example sql queries (for `default` project):
```sh
# Any (-1)
$ lxd sql global 'SELECT instances.name FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = "default" AND instances.type = "-1"'
+------+
| name |
+------+
+------+

# Container (0)
$ lxd sql global 'SELECT instances.name FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = "default" AND instances.type = "0"'
+------------------+
|       name       |
+------------------+
| ct               |
| c1               |
| c2               |
| striking-weasel  |
| caring-quetzal   |
| renewed-gobbler  |
| precise-bonefish |
| sincere-cheetah  |
| adapting-wren    |
+------------------+

# VM (1)
$ lxd sql global 'SELECT instances.name FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = "default" AND instances.type = "1"'
+--------+
|  name  |
+--------+
| node-1 |
| node-2 |
+--------+

# All (no type)
$ lxd sql global 'SELECT instances.name FROM instances JOIN projects ON projects.id = instances.project_id WHERE projects.name = "default"'
+------------------+
|       name       |
+------------------+
| adapting-wren    |
| c1               |
| c2               |
| caring-quetzal   |
| ct               |
| node-1           |
| node-2           |
| precise-bonefish |
| renewed-gobbler  |
| sincere-cheetah  |
| striking-weasel  |
+------------------+
```