### PR TITLE
lxd/apparmor: Allow qemu access to microceph conf

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -83,6 +83,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Snap-specific paths
   /var/snap/lxd/common/ceph/**                         r,
   /var/snap/microceph/*/conf/**                        r,
+  /var/snap/lxd/*/microceph/conf/**                    r,
   {{ .rootPath }}/etc/ceph/**                          r,
   {{ .rootPath }}/run/systemd/resolve/stub-resolv.conf r,
   {{ .rootPath }}/run/systemd/resolve/resolv.conf      r,


### PR DESCRIPTION
This is going to be necessary once https://github.com/canonical/lxd-pkg-snap/commit/dd708ada26e490e0e782e5c3af23b9bd3538e8a7 is promoted to `latest/stable` for qemu to be able to access the path to `ceph.conf` created by the snap content interface, rather than directly symlinking to the state directory of MicroCeph.