### PR TITLE
Discover MinIO port using IPv4 address family

### DIFF
--- a/lxd/storage/s3/miniod/miniod.go
+++ b/lxd/storage/s3/miniod/miniod.go
@@ -29,7 +29,7 @@ import (
 )
 
 // minioHost is the host address that the local MinIO processes will listen on.
-const minioHost = "[::1]"
+const minioHost = "127.0.0.1"
 
 // minioLockPrefix is the prefix used for per-bucket MinIO spawn lock.
 const minioLockPrefix = "minio_"


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/12586

In case MinIO gets enabled on a system with IPv6 disabled, binding to the IPv6 localhost address during port discovery will fail due to an unsupported address family.
