### PR TITLE
Encrypt OIDC cookies

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1059,7 +1059,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, nil)
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -454,7 +454,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		logger.Debug("Handling config changed notification")
 		changed := make(map[string]string)
 		for key, value := range req.Config {
-			changed[key] = value.(string)
+			changed[key], _ = value.(string)
 		}
 
 		// Get the current (updated) config.
@@ -601,14 +601,15 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 				return fmt.Errorf("Cannot fetch node config from database: %w", err)
 			}
 
-			newClusterHTTPSAddress, found := nodeValues["cluster.https_address"]
-			if !found && patch {
+			newClusterHTTPSAddress := ""
+			newClusterHTTPSAddressAny, found := nodeValues["cluster.https_address"]
+			if found {
+				newClusterHTTPSAddress, _ = newClusterHTTPSAddressAny.(string)
+			} else if patch {
 				newClusterHTTPSAddress = curConfig["cluster.https_address"]
-			} else if !found {
-				newClusterHTTPSAddress = ""
 			}
 
-			if curConfig["cluster.https_address"] != newClusterHTTPSAddress.(string) {
+			if curConfig["cluster.https_address"] != newClusterHTTPSAddress {
 				return fmt.Errorf("Changing cluster.https_address is currently not supported")
 			}
 		}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -474,7 +474,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		d.globalConfigMu.Unlock()
 
 		// Run any update triggers.
-		err = doApi10UpdateTriggers(d, nil, changed, s.LocalConfig, config)
+		err = doAPI10UpdateTriggers(d, nil, changed, s.LocalConfig, config)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -492,7 +492,7 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 		return response.PreconditionFailed(err)
 	}
 
-	return doApi10Update(d, r, req, false)
+	return doAPI10Update(d, r, req, false)
 }
 
 // swagger:operation PATCH /1.0 server server_patch
@@ -561,10 +561,10 @@ func api10Patch(d *Daemon, r *http.Request) response.Response {
 		return response.EmptySyncResponse
 	}
 
-	return doApi10Update(d, r, req, true)
+	return doAPI10Update(d, r, req, true)
 }
 
-func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) response.Response {
+func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) response.Response {
 	s := d.State()
 
 	// First deal with config specific to the local daemon
@@ -792,7 +792,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	d.globalConfigMu.Unlock()
 
 	// Run any update triggers.
-	err = doApi10UpdateTriggers(d, nodeChanged, clusterChanged, newNodeConfig, newClusterConfig)
+	err = doAPI10UpdateTriggers(d, nodeChanged, clusterChanged, newNodeConfig, newClusterConfig)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -804,7 +804,7 @@ func doApi10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	return response.EmptySyncResponse
 }
 
-func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
+func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]string, nodeConfig *node.Config, clusterConfig *clusterConfig.Config) error {
 	s := d.State()
 
 	maasChanged := false

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -781,7 +781,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			changes[k], _ = v.(string)
 		}
 
-		err = doApi10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)
+		err = doAPI10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)
 		if err != nil {
 			return err
 		}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -240,10 +240,15 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 }
 
 // IsRequest checks if the request is using OIDC authentication. We check for the presence of the Authorization header
-// or one of the ID or refresh tokens.
-func (o *Verifier) IsRequest(r *http.Request) bool {
+// or one of the ID or refresh tokens and the session cookie.
+func (*Verifier) IsRequest(r *http.Request) bool {
 	if r.Header.Get("Authorization") != "" {
 		return true
+	}
+
+	_, err := r.Cookie(cookieNameSessionID)
+	if err != nil {
+		return false
 	}
 
 	idTokenCookie, err := r.Cookie(cookieNameIDToken)

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -39,15 +39,20 @@ type Verifier struct {
 	accessTokenVerifier op.AccessTokenVerifier
 	relyingParty        rp.RelyingParty
 
-	clientID  string
-	issuer    string
-	audience  string
-	cookieKey []byte
+	clientID    string
+	issuer      string
+	audience    string
+	clusterCert func() *shared.CertInfo
 
 	// host is used for setting a valid callback URL when setting the relyingParty.
 	// When creating the relyingParty, the OIDC library performs discovery (e.g. it calls the /well-known/oidc-configuration endpoint).
 	// We don't want to perform this on every request, so we only do it when the request host changes.
 	host string
+
+	// configExpiry is the next time at which the relying party and access token verifier will be considered out of date
+	// and will be refreshed. This refreshes the cookie encryption keys that the relying party uses.
+	configExpiry         time.Time
+	configExpiryInterval time.Duration
 }
 
 // AuthError represents an authentication error.

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -371,14 +371,28 @@ func (*Verifier) setCookies(w http.ResponseWriter, idToken string, refreshToken 
 	return nil
 }
 
+// Opts contains optional configurable fields for the Verifier.
+type Opts struct {
+	ConfigExpiryInterval time.Duration
+}
+
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientid string, audience string) (*Verifier, error) {
-	cookieKey, err := uuid.New().MarshalBinary()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to create UUID: %w", err)
+func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, options *Opts) (*Verifier, error) {
+	opts := &Opts{
+		ConfigExpiryInterval: defaultConfigExpiryInterval,
 	}
 
-	verifier := &Verifier{issuer: issuer, clientID: clientid, audience: audience, cookieKey: cookieKey}
+	if options != nil {
+		opts.ConfigExpiryInterval = options.ConfigExpiryInterval
+	}
+
+	verifier := &Verifier{
+		issuer:               issuer,
+		clientID:             clientID,
+		audience:             audience,
+		clusterCert:          clusterCert,
+		configExpiryInterval: opts.ConfigExpiryInterval,
+	}
 
 	return verifier, nil
 }

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -25,6 +25,13 @@ const (
 
 	// cookieNameRefreshToken is the identifier used to set and retrieve the refresh token.
 	cookieNameRefreshToken = "oidc_refresh"
+
+	// cookieNameSessionID is used to identify the session. It does not need to be encrypted.
+	cookieNameSessionID = "session_id"
+)
+
+const (
+	defaultConfigExpiryInterval = 5 * time.Minute
 )
 
 // Verifier holds all information needed to verify an access token offline.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -297,7 +297,7 @@ func (d *Daemon) getTrustedCertificates() map[certificate.Type]map[string]x509.C
 // This does not perform authorization, only validates authentication.
 // Returns whether trusted or not, the username (or certificate fingerprint) of the trusted client, and the type of
 // client that has been authenticated (cluster, unix, candid or tls).
-func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, string, string, error) {
+func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted bool, username string, method string, err error) {
 	trustedCerts := d.getTrustedCertificates()
 
 	// Allow internal cluster traffic by checking against the trusted certfificates.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1355,7 +1355,7 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience)
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR encrypts the OIDC cookies that are set in the response after logging in to LXD. It finishes the implementation of changes to handling of OIDC authentication as discussed in #12531.

To ensure that the encryption key is the same on all cluster members, we are deriving the key from the cluster private key using [HKDF](https://pkg.go.dev/golang.org/x/crypto/hkdf). 

Closes #12531