### PR TITLE
Fix ExecInstance fails if args are nil or stdout is not provided

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1133,7 +1133,13 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 
 	opAPI := op.Get()
 
-	// Process additional arguments
+	// Ensure args are not nil.
+	if args == nil {
+		args = &InstanceExecArgs{}
+	}
+
+	// NOTE: This check is here just to prevent mess in git diff becaue removing this check
+	// changes the indentation of the below code.
 	if args != nil {
 		// Parse the fds
 		fds := map[string]string{}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1138,6 +1138,12 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 		args = &InstanceExecArgs{}
 	}
 
+	// Ensure Stdout is not nil. Otherwise, connection will be terminated
+	// immediately because there is nothing to wait for on the client's side.
+	if args.Stdout == nil {
+		args.Stdout = discard{}
+	}
+
 	// NOTE: This check is here just to prevent mess in git diff becaue removing this check
 	// changes the indentation of the below code.
 	if args != nil {
@@ -2917,5 +2923,15 @@ func (r *ProtocolLXD) proxyMigration(targetOp *operation, targetSecrets map[stri
 		}
 	}()
 
+	return nil
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (discard) Close() error {
 	return nil
 }


### PR DESCRIPTION
Issue:
- Providing nil arguments (`InstanceExecArgs`) to the [ExecInstance](https://github.com/canonical/lxd/blob/8308c8045cc2eb24703a39e13499d06482005d3b/client/lxd_instances.go#L1101) timeouts after 5 seconds.
- Not setting `Stdout` in arguments provided to the [ExecInstance](https://github.com/canonical/lxd/blob/8308c8045cc2eb24703a39e13499d06482005d3b/client/lxd_instances.go#L1101) results in command being terminated with `137` exit code.

In both cases, command is not executed.

---

Timeout is definitely related to passing nil `lxd.InstanceExecArgs`. If args are nil, we return the operation before the client connects to the websocket, which leads to the server timeouting after 5 seconds ([lxd/instance_exec.go#174](https://github.com/canonical/lxd/blob/8308c8045cc2eb24703a39e13499d06482005d3b/lxd/instance_exec.go#L174)) because it cannot establish the connection with all websockets present in the operation.

The `137` exit code is related to passing nil `Stdout` in `lxd.InstanceExecArgs`. In such case the result is:

```
Unexpected read on stdout websocket, killing command  PID=440768 err="read unix /var/snap/lxd/common/lxd/unix.socket->@: read: connection reset by peer" instance=c1 interactive=false number=1 project=default
```


This happens because there is nothing to wait for on the client’s side and we terminate the websocket connection almost immediately -> client disconnects, which is detected in [lxd/instance_exec.go#444-465](https://github.com/canonical/lxd/blob/main/lxd/instance_exec.go#L444-L465) and produces the above error on the server and simply kills the command. 

I don’t know how to depict this, but in [client/lxd_instances.go#1291-1318](https://github.com/canonical/lxd/blob/8308c8045cc2eb24703a39e13499d06482005d3b/client/lxd_instances.go#L1291-L1318) the connections get closed immediately because all `dones` channels are already closed.  

A simple solution for that is to use *Discarder* if `args.Stdout` is nil. This way, we can retain a connection until the command is fully executed on the instance.