### PR TITLE
 Prevent panic when devlxd server is stopped

### DIFF
--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -169,7 +169,11 @@ func stopDevlxdServer(d *Daemon) error {
 	d.devlxdRunning = false
 	d.devlxdMu.Unlock()
 
-	return servers["devlxd"].Close()
+	if servers["devlxd"] != nil {
+		return servers["devlxd"].Close()
+	}
+
+	return nil
 }
 
 func getClient(CID uint32, port int, serverCertificate string) (*http.Client, error) {


### PR DESCRIPTION
Prevent panic when devlxd server is stopped on VM with `security.devlxd=false`.

Fixes #12629