### PR TITLE
doc/cloud-init: overwrite link text to make spell checker happy

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -92,7 +92,7 @@ config:
 ```
 
 ```{tip}
-See {doc}`cloud-init:howto/debug_user_data` for information on how to check whether the syntax is correct.
+See {ref}`How to validate user data <cloud-init:check_user_data_cloud_config>` for information on how to check whether the syntax is correct.
 ```
 
 ## How to check the `cloud-init` status


### PR DESCRIPTION
In the cloud-init doc, "config" is allowed as a word. It's not a word though. ;-)