### PR TITLE
client: Always use event listener for operations.

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -631,7 +631,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.PathEscape(containerName)), exec, "", false)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.PathEscape(containerName)), exec, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -1527,7 +1527,7 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), console, "", false)
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), console, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1125,8 +1125,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 	}
 
 	// Send the request
-	useEventListener := r.CheckExtension("operation_wait") != nil
-	op, _, err := r.queryOperation("POST", uri, exec, "", useEventListener)
+	op, _, err := r.queryOperation("POST", uri, exec, "", true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When long polling the operation wait endpoint, we can never guarantee that the request will not time out for very long operations (e.g. an exec session) because intermediate proxies or load balancers may timeout the request if there is no activity. This commit changes the `useEventListener` argument to getOperations to true for all requests. Regardless of whether the `operation_wait` API extension is present.