### PR TITLE
Fix VM live migration regression in edge

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1039,7 +1039,13 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 			return err
 		}
 
-		stateDiskSizeStr := d.storagePool.Driver().Info().DefaultVMBlockFilesystemSize
+		// Don't access d.storagePool directly since it isn't populated at this stage.
+		pool, err := d.getStoragePool()
+		if err != nil {
+			return err
+		}
+
+		stateDiskSizeStr := pool.Driver().Info().DefaultVMBlockFilesystemSize
 		if rootDiskDevice["size.state"] != "" {
 			stateDiskSizeStr = rootDiskDevice["size.state"]
 		}


### PR DESCRIPTION
This was caused by https://github.com/canonical/lxd/pull/12566. 

When validating the live migration of a VM, the pool needs to be loaded first since that is the first time the value gets accessed. Otherwise it will panic.