### PR TITLE
feat: annotate codebase for storage config options

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1851,3 +1851,834 @@ This value is required by some providers.
 ```
 
 <!-- config group server-oidc end -->
+<!-- config group storage-btrfs-bucket-conf start -->
+```{config:option} size storage-btrfs-bucket-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage bucket"
+:type: "string"
+
+```
+
+<!-- config group storage-btrfs-bucket-conf end -->
+<!-- config group storage-btrfs-pool-conf start -->
+```{config:option} btrfs.mount_options storage-btrfs-pool-conf
+:defaultdesc: "`user_subvol_rm_allowed`"
+:shortdesc: "Mount options for block devices"
+:type: "string"
+
+```
+
+```{config:option} size storage-btrfs-pool-conf
+:defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
+:type: "string"
+When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
+You can increase the size to grow the storage pool.
+
+The default (`auto`) creates a storage pool that uses 20% of the free disk space,
+with a minimum of 5 GiB and a maximum of 30 GiB.
+```
+
+```{config:option} source storage-btrfs-pool-conf
+:shortdesc: "Path to an existing block device, loop file, or Btrfs subvolume"
+:type: "string"
+
+```
+
+```{config:option} source.wipe storage-btrfs-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to wipe the block device before creating the pool"
+:type: "bool"
+Set this option to `true` to wipe the block device specified in `source`
+prior to creating the storage pool.
+```
+
+<!-- config group storage-btrfs-pool-conf end -->
+<!-- config group storage-btrfs-volume-conf start -->
+```{config:option} security.shifted storage-btrfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-btrfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-btrfs-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-btrfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-btrfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-btrfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+<!-- config group storage-btrfs-volume-conf end -->
+<!-- config group storage-ceph-pool-conf start -->
+```{config:option} ceph.cluster_name storage-ceph-pool-conf
+:defaultdesc: "`ceph`"
+:shortdesc: "Name of the Ceph cluster in which to create new storage pools"
+:type: "string"
+
+```
+
+```{config:option} ceph.osd.data_pool_name storage-ceph-pool-conf
+:shortdesc: "Name of the OSD data pool"
+:type: "string"
+
+```
+
+```{config:option} ceph.osd.pg_num storage-ceph-pool-conf
+:defaultdesc: "`32`"
+:shortdesc: "Number of placement groups for the OSD storage pool"
+:type: "string"
+
+```
+
+```{config:option} ceph.osd.pool_name storage-ceph-pool-conf
+:defaultdesc: "name of the pool"
+:shortdesc: "Name of the OSD storage pool"
+:type: "string"
+
+```
+
+```{config:option} ceph.rbd.clone_copy storage-ceph-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to use RBD lightweight clones"
+:type: "bool"
+Enable this option to use RBD lightweight clones rather than full dataset copies.
+```
+
+```{config:option} ceph.rbd.du storage-ceph-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to use RBD `du`"
+:type: "bool"
+This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.
+```
+
+```{config:option} ceph.rbd.features storage-ceph-pool-conf
+:defaultdesc: "`layering`"
+:shortdesc: "Comma-separated list of RBD features to enable on the volumes"
+:type: "string"
+
+```
+
+```{config:option} ceph.user.name storage-ceph-pool-conf
+:defaultdesc: "`admin`"
+:shortdesc: "The Ceph user to use when creating storage pools and volumes"
+:type: "string"
+
+```
+
+```{config:option} source storage-ceph-pool-conf
+:shortdesc: "Existing OSD storage pool to use"
+:type: "string"
+
+```
+
+```{config:option} volatile.pool.pristine storage-ceph-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether the pool was empty on creation time"
+:type: "string"
+
+```
+
+<!-- config group storage-ceph-pool-conf end -->
+<!-- config group storage-ceph-volume-conf start -->
+```{config:option} block.filesystem storage-ceph-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.filesystem`"
+:shortdesc: "File system of the storage volume"
+:type: "string"
+Valid options are: `btrfs`, `ext4`, `xfs`
+If not set, `ext4` is assumed.
+```
+
+```{config:option} block.mount_options storage-ceph-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.mount_options`"
+:shortdesc: "Mount options for block-backed file system volumes"
+:type: "string"
+
+```
+
+```{config:option} security.shifted storage-ceph-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-ceph-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-ceph-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-ceph-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-ceph-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-ceph-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+<!-- config group storage-ceph-volume-conf end -->
+<!-- config group storage-cephfs-pool-conf start -->
+```{config:option} cephfs.cluster_name storage-cephfs-pool-conf
+:defaultdesc: "`ceph`"
+:shortdesc: "Name of the Ceph cluster that contains the CephFS file system"
+:type: "string"
+
+```
+
+```{config:option} cephfs.create_missing storage-cephfs-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Automatically create the CephFS file system"
+:type: "bool"
+Use this option if the CephFS file system does not exist yet.
+LXD will then automatically create the file system and the missing data and metadata OSD pools.
+```
+
+```{config:option} cephfs.data_pool storage-cephfs-pool-conf
+:shortdesc: "Data OSD pool name"
+:type: "string"
+This option specifies the name for the data OSD pool that should be used when creating
+a file system automatically.
+```
+
+```{config:option} cephfs.fscache storage-cephfs-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Enable use of kernel `fscache` and `cachefilesd`"
+:type: "bool"
+
+```
+
+```{config:option} cephfs.meta_pool storage-cephfs-pool-conf
+:shortdesc: "Metadata OSD pool name"
+:type: "string"
+This option specifies the name for the file metadata OSD pool that should be used when
+creating a file system automatically.
+```
+
+```{config:option} cephfs.osd_pg_num storage-cephfs-pool-conf
+:shortdesc: "Number of placement groups when creating missing OSD pools"
+:type: "string"
+This option specifies the number of OSD pool placement groups (`pg_num`) to use
+when creating a missing OSD pool.
+```
+
+```{config:option} cephfs.path storage-cephfs-pool-conf
+:defaultdesc: "`/`"
+:shortdesc: "The base path for the CephFS mount"
+:type: "string"
+
+```
+
+```{config:option} cephfs.user.name storage-cephfs-pool-conf
+:defaultdesc: "`admin`"
+:shortdesc: "The Ceph user to use"
+:type: "string"
+
+```
+
+```{config:option} source storage-cephfs-pool-conf
+:shortdesc: "Existing CephFS file system or file system path to use"
+:type: "string"
+
+```
+
+```{config:option} volatile.pool.pristine storage-cephfs-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether the CephFS file system was empty on creation time"
+:type: "string"
+
+```
+
+<!-- config group storage-cephfs-pool-conf end -->
+<!-- config group storage-cephfs-volume-conf start -->
+```{config:option} security.shifted storage-cephfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-cephfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-cephfs-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-cephfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-cephfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-cephfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+<!-- config group storage-cephfs-volume-conf end -->
+<!-- config group storage-cephobject-bucket-conf start -->
+```{config:option} size storage-cephobject-bucket-conf
+:shortdesc: "Quota of the storage bucket"
+:type: "string"
+
+```
+
+<!-- config group storage-cephobject-bucket-conf end -->
+<!-- config group storage-cephobject-pool-conf start -->
+```{config:option} cephobject.bucket.name_prefix storage-cephobject-pool-conf
+:shortdesc: "Prefix to add to bucket names in Ceph"
+:type: "string"
+
+```
+
+```{config:option} cephobject.cluster_name storage-cephobject-pool-conf
+:shortdesc: "The Ceph cluster to use"
+:type: "string"
+
+```
+
+```{config:option} cephobject.radosgw.endpoint storage-cephobject-pool-conf
+:shortdesc: "URL of the `radosgw` gateway process"
+:type: "string"
+
+```
+
+```{config:option} cephobject.radosgw.endpoint_cert_file storage-cephobject-pool-conf
+:shortdesc: "TLS client certificate to use for endpoint communication"
+:type: "string"
+Specify the path to the file that contains the TLS client certificate.
+```
+
+```{config:option} cephobject.user.name storage-cephobject-pool-conf
+:defaultdesc: "`admin`"
+:shortdesc: "The Ceph user to use"
+:type: "string"
+
+```
+
+```{config:option} volatile.pool.pristine storage-cephobject-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether the `radosgw` `lxd-admin` user existed at creation time"
+:type: "string"
+
+```
+
+<!-- config group storage-cephobject-pool-conf end -->
+<!-- config group storage-dir-pool-conf start -->
+```{config:option} rsync.bwlimit storage-dir-pool-conf
+:defaultdesc: "`0` (no limit)"
+:shortdesc: "Upper limit on the socket I/O for `rsync`"
+:type: "string"
+When `rsync` must be used to transfer storage entities, this option specifies the upper limit
+to be placed on the socket I/O.
+```
+
+```{config:option} rsync.compression storage-dir-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to use compression while migrating storage pools"
+:type: "bool"
+
+```
+
+```{config:option} source storage-dir-pool-conf
+:shortdesc: "Path to an existing directory"
+:type: "string"
+
+```
+
+<!-- config group storage-dir-pool-conf end -->
+<!-- config group storage-dir-volume-conf start -->
+```{config:option} security.shifted storage-dir-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-dir-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-dir-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-dir-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-dir-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-dir-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+<!-- config group storage-dir-volume-conf end -->
+<!-- config group storage-lvm-bucket-conf start -->
+```{config:option} size storage-lvm-bucket-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage bucket"
+:type: "string"
+
+```
+
+<!-- config group storage-lvm-bucket-conf end -->
+<!-- config group storage-lvm-pool-conf start -->
+```{config:option} lvm.thinpool_metadata_size storage-lvm-pool-conf
+:defaultdesc: "`0` (auto)"
+:shortdesc: "The size of the thin pool metadata volume"
+:type: "string"
+By default, LVM calculates an appropriate size.
+```
+
+```{config:option} lvm.thinpool_name storage-lvm-pool-conf
+:defaultdesc: "`LXDThinPool`"
+:shortdesc: "Thin pool where volumes are created"
+:type: "string"
+
+```
+
+```{config:option} lvm.use_thinpool storage-lvm-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether the storage pool uses a thin pool for logical volumes"
+:type: "bool"
+
+```
+
+```{config:option} lvm.vg.force_reuse storage-lvm-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Force using an existing non-empty volume group"
+:type: "bool"
+
+```
+
+```{config:option} lvm.vg_name storage-lvm-pool-conf
+:defaultdesc: "name of the pool"
+:shortdesc: "Name of the volume group to create"
+:type: "string"
+
+```
+
+```{config:option} rsync.bwlimit storage-lvm-pool-conf
+:defaultdesc: "`0` (no limit)"
+:shortdesc: "Upper limit on the socket I/O for `rsync`"
+:type: "string"
+When `rsync` must be used to transfer storage entities, this option specifies the upper limit
+to be placed on the socket I/O.
+```
+
+```{config:option} rsync.compression storage-lvm-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to use compression while migrating storage pools"
+:type: "bool"
+
+```
+
+```{config:option} size storage-lvm-pool-conf
+:defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
+:type: "string"
+When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
+You can increase the size to grow the storage pool.
+
+The default (`auto`) creates a storage pool that uses 20% of the free disk space,
+with a minimum of 5 GiB and a maximum of 30 GiB.
+```
+
+```{config:option} source storage-lvm-pool-conf
+:shortdesc: "Path to an existing block device, loop file, or LVM volume group"
+:type: "string"
+
+```
+
+```{config:option} source.wipe storage-lvm-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to wipe the block device before creating the pool"
+:type: "bool"
+Set this option to `true` to wipe the block device specified in `source`
+prior to creating the storage pool.
+```
+
+<!-- config group storage-lvm-pool-conf end -->
+<!-- config group storage-lvm-volume-conf start -->
+```{config:option} block.filesystem storage-lvm-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.filesystem`"
+:shortdesc: "File system of the storage volume"
+:type: "string"
+Valid options are: `btrfs`, `ext4`, `xfs`
+If not set, `ext4` is assumed.
+```
+
+```{config:option} block.mount_options storage-lvm-volume-conf
+:condition: "block-based volume with content type `filesystem`"
+:defaultdesc: "same as `volume.block.mount_options`"
+:shortdesc: "Mount options for block-backed file system volumes"
+:type: "string"
+
+```
+
+```{config:option} lvm.stripes storage-lvm-volume-conf
+:defaultdesc: "same as `volume.lvm.stripes`"
+:shortdesc: "Number of stripes to use for new volumes (or thin pool volume)"
+:type: "string"
+
+```
+
+```{config:option} lvm.stripes.size storage-lvm-volume-conf
+:defaultdesc: "same as `volume.lvm.stripes.size`"
+:shortdesc: "Size of stripes to use"
+:type: "string"
+The size must be at least 4096 bytes, and a multiple of 512 bytes.
+```
+
+```{config:option} security.shifted storage-lvm-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-lvm-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-lvm-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-lvm-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-lvm-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-lvm-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+<!-- config group storage-lvm-volume-conf end -->
+<!-- config group storage-zfs-bucket-conf start -->
+```{config:option} size storage-zfs-bucket-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage bucket"
+:type: "string"
+
+```
+
+<!-- config group storage-zfs-bucket-conf end -->
+<!-- config group storage-zfs-pool-conf start -->
+```{config:option} size storage-zfs-pool-conf
+:defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
+:type: "string"
+When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
+You can increase the size to grow the storage pool.
+
+The default (`auto`) creates a storage pool that uses 20% of the free disk space,
+with a minimum of 5 GiB and a maximum of 30 GiB.
+```
+
+```{config:option} source storage-zfs-pool-conf
+:shortdesc: "Path to an existing block device, loop file, or ZFS dataset/pool"
+:type: "string"
+
+```
+
+```{config:option} source.wipe storage-zfs-pool-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to wipe the block device before creating the pool"
+:type: "bool"
+Set this option to `true` to wipe the block device specified in `source`
+prior to creating the storage pool.
+```
+
+```{config:option} zfs.clone_copy storage-zfs-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to use ZFS lightweight clones"
+:type: "string"
+Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather
+than full dataset copies.
+Set the option to `rebase` to copy based on the initial image.
+```
+
+```{config:option} zfs.export storage-zfs-pool-conf
+:defaultdesc: "`true`"
+:shortdesc: "Disable zpool export while an unmount is being performed"
+:type: "bool"
+
+```
+
+```{config:option} zfs.pool_name storage-zfs-pool-conf
+:defaultdesc: "name of the pool"
+:shortdesc: "Name of the zpool"
+:type: "string"
+
+```
+
+<!-- config group storage-zfs-pool-conf end -->
+<!-- config group storage-zfs-volume-conf start -->
+```{config:option} block.filesystem storage-zfs-volume-conf
+:condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
+:defaultdesc: "same as `volume.block.filesystem`"
+:shortdesc: "File system of the storage volume"
+:type: "string"
+Valid options are: `btrfs`, `ext4`, `xfs`
+If not set, `ext4` is assumed.
+```
+
+```{config:option} block.mount_options storage-zfs-volume-conf
+:condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
+:defaultdesc: "same as `volume.block.mount_options`"
+:shortdesc: "Mount options for block-backed file system volumes"
+:type: "string"
+
+```
+
+```{config:option} security.shifted storage-zfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.shifted` or `false`"
+:shortdesc: "Enable ID shifting overlay"
+:type: "bool"
+Enabling this option allows attaching the volume to multiple isolated instances.
+```
+
+```{config:option} security.unmapped storage-zfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.security.unmappped` or `false`"
+:shortdesc: "Disable ID mapping for the volume"
+:type: "bool"
+
+```
+
+```{config:option} size storage-zfs-volume-conf
+:condition: "appropriate driver"
+:defaultdesc: "same as `volume.size`"
+:shortdesc: "Size/quota of the storage volume"
+:type: "string"
+
+```
+
+```{config:option} snapshots.expiry storage-zfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.expiry`"
+:shortdesc: "When snapshots are to be deleted"
+:type: "string"
+Specify an expression like `1M 2H 3d 4w 5m 6y`.
+```
+
+```{config:option} snapshots.pattern storage-zfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:shortdesc: "Template for the snapshot name"
+:type: "string"
+You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
+
+{{snapshot_pattern_detail}}
+```
+
+```{config:option} snapshots.schedule storage-zfs-volume-conf
+:condition: "custom volume"
+:defaultdesc: "same as `snapshots.schedule`"
+:shortdesc: "Schedule for automatic volume snapshots"
+:type: "string"
+Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+```{config:option} zfs.block_mode storage-zfs-volume-conf
+:defaultdesc: "same as `volume.zfs.block_mode`"
+:shortdesc: "Whether to use a formatted `zvol` rather than a dataset"
+:type: "bool"
+`zfs.block_mode` can be set only for custom storage volumes.
+To enable ZFS block mode for all storage volumes in the pool, including instance volumes,
+use `volume.zfs.block_mode`.
+```
+
+```{config:option} zfs.blocksize storage-zfs-volume-conf
+:defaultdesc: "same as `volume.zfs.blocksize`"
+:shortdesc: "Size of the ZFS block"
+:type: "string"
+The size must be between 512 bytes and 16 MiB and must be a power of 2.
+For a block volume, a maximum value of 128 KiB will be used even if a higher value is set.
+
+Depending on the value of {config:option}`storage-zfs-volume-conf:zfs.block_mode`,
+the specified size is used to set either `volblocksize` or `recordsize` in ZFS.
+```
+
+```{config:option} zfs.delegate storage-zfs-volume-conf
+:condition: "ZFS 2.2 or higher"
+:defaultdesc: "same as `volume.zfs.delegate`"
+:shortdesc: "Whether to delegate the ZFS dataset"
+:type: "bool"
+This option controls whether to delegate the ZFS dataset and anything underneath it to the
+container or containers that use it. This allows using the `zfs` command in the container.
+```
+
+```{config:option} zfs.remove_snapshots storage-zfs-volume-conf
+:defaultdesc: "same as `volume.zfs.remove_snapshots` or `false`"
+:shortdesc: "Remove snapshots as needed"
+:type: "bool"
+
+```
+
+```{config:option} zfs.reserve_space storage-zfs-volume-conf
+:defaultdesc: "same as `volume.zfs.reserve_space` or `false`"
+:shortdesc: "Use `reservation`/`refreservation` along with `quota`/`refquota`"
+:type: "bool"
+
+```
+
+```{config:option} zfs.use_refquota storage-zfs-volume-conf
+:defaultdesc: "same as `volume.zfs.use_refquota` or `false`"
+:shortdesc: "Use `refquota` instead of `quota` for space"
+:type: "bool"
+
+```
+
+<!-- config group storage-zfs-volume-conf end -->

--- a/doc/howto/cluster_config_storage.md
+++ b/doc/howto/cluster_config_storage.md
@@ -2,7 +2,7 @@
 # How to configure storage for a cluster
 
 All members of a cluster must have identical storage pools.
-The only configuration keys that may differ between pools on different members are [`source`](storage-drivers), [`size`](storage-drivers), [`zfs.pool_name`](storage-zfs-pool-config), [`lvm.thinpool_name`](storage-lvm-pool-config) and [`lvm.vg_name`](storage-lvm-pool-config).
+The only configuration keys that may differ between pools on different members are [`source`](storage-drivers), [`size`](storage-drivers), {config:option}`storage-zfs-pool-conf:zfs.pool_name`, {config:option}`storage-lvm-pool-conf:lvm.thinpool_name` and {config:option}`storage-lvm-pool-conf:lvm.vg_name`.
 See {ref}`clustering-member-config` for more information.
 
 LXD creates a default `local` storage pool for each cluster member during initialization.

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -51,7 +51,7 @@ Therefore, you should never use VMs with Btrfs storage pools.
 
 If you really need to use VMs with Btrfs storage pools, set the instance root disk's [`size.state`](devices-disk) property to twice the size of the root disk's size.
 This configuration allows all blocks in the disk image file to be rewritten without reaching the qgroup quota.
-The [`btrfs.mount_options=compress-force`](storage-btrfs-pool-config) storage pool option can also avoid this scenario, because a side effect of enabling compression is to reduce the maximum extent size such that block rewrites don't cause as much storage to be double-tracked.
+Setting the {config:option}`storage-btrfs-pool-conf:btrfs.mount_options` storage pool option to `compress-force` can also avoid this scenario, because a side effect of enabling compression is to reduce the maximum extent size such that block rewrites don't cause as much storage to be double-tracked.
 However, this is a storage pool option, and it therefore affects all volumes on the pool.
 ```
 

--- a/doc/reference/storage_btrfs.md
+++ b/doc/reference/storage_btrfs.md
@@ -62,32 +62,28 @@ The following configuration options are available for storage pools that use the
 (storage-btrfs-pool-config)=
 ### Storage pool configuration
 
-Key                             | Type      | Default                    | Description
-:--                             | :---      | :------                    | :----------
-`btrfs.mount_options`           | string    | `user_subvol_rm_allowed`   | Mount options for block devices
-`size`                          | string    | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                        | string    | -                          | Path to an existing block device, loop file or Btrfs subvolume
-`source.wipe`                   | bool      | `false`                    | Wipe the block device specified in `source` prior to creating the storage pool
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-btrfs-pool-conf start -->
+    :end-before: <!-- config group storage-btrfs-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                       | Description
-:--                     | :---      | :--------                 | :------                                       | :----------
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`  | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false` | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                         | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`             | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d`| {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`           | {{snapshot_schedule_format}}
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-btrfs-volume-conf start -->
+    :end-before: <!-- config group storage-btrfs-volume-conf end -->
+```
 
 ### Storage bucket configuration
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage bucket
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-btrfs-bucket-conf start -->
+    :end-before: <!-- config group storage-btrfs-bucket-conf end -->
+```

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -38,7 +38,7 @@ Ceph block devices are also called *RBD images*, and you can create *snapshots* 
 ```{note}
 To use the Ceph RBD driver, you must specify it as `ceph`.
 This is slightly misleading, because it uses only Ceph RBD (block storage) functionality, not full Ceph functionality.
-For storage volumes with content type `filesystem` (images, containers and custom file-system volumes), the `ceph` driver uses Ceph RBD images with a file system on top (see [`block.filesystem`](storage-ceph-vol-config)).
+For storage volumes with content type `filesystem` (images, containers and custom file-system volumes), the `ceph` driver uses Ceph RBD images with a file system on top (see {config:option}`storage-ceph-volume-conf:block.filesystem`).
 
 Alternatively, you can use the {ref}`CephFS <storage-cephfs>` driver to create storage volumes with content type `filesystem`.
 ```
@@ -80,7 +80,7 @@ Using an OSD pool of type "erasure"
 : To use a Ceph OSD pool of type "erasure", you must create the OSD pool beforehand.
   You must also create a separate OSD pool of type "replicated" that will be used for storing metadata.
   This is required because Ceph RBD does not support `omap`.
-  To specify which pool is "erasure coded", set the [`ceph.osd.data_pool_name`](storage-ceph-pool-config) configuration option to the erasure coded pool name and the [`source`](storage-ceph-pool-config) configuration option to the replicated pool name.
+  To specify which pool is "erasure coded", set the {config:option}`storage-ceph-pool-conf:ceph.osd.data_pool_name` configuration option to the erasure coded pool name and the {config:option}`storage-ceph-pool-conf:source` configuration option to the replicated pool name.
 
 ## Configuration options
 

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -89,33 +89,19 @@ The following configuration options are available for storage pools that use the
 (storage-ceph-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`ceph.cluster_name`           | string                        | `ceph`                                  | Name of the Ceph cluster in which to create new storage pools
-`ceph.osd.data_pool_name`     | string                        | -                                       | Name of the OSD data pool
-`ceph.osd.pg_num`             | string                        | `32`                                    | Number of placement groups for the OSD storage pool
-`ceph.osd.pool_name`          | string                        | name of the pool                        | Name of the OSD storage pool
-`ceph.rbd.clone_copy`         | bool                          | `true`                                  | Whether to use RBD lightweight clones rather than full dataset copies
-`ceph.rbd.du`                 | bool                          | `true`                                  | Whether to use RBD `du` to obtain disk usage data for stopped instances
-`ceph.rbd.features`           | string                        | `layering`                              | Comma-separated list of RBD features to enable on the volumes
-`ceph.user.name`              | string                        | `admin`                                 | The Ceph user to use when creating storage pools and volumes
-`source`                      | string                        | -                                       | Existing OSD storage pool to use
-`volatile.pool.pristine`      | string                        | `true`                                  | Whether the pool was empty on creation time
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-ceph-pool-conf start -->
+    :end-before: <!-- config group storage-ceph-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 (storage-ceph-vol-config)=
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`      | string    | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`   | string    | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-ceph-volume-conf start -->
+    :end-before: <!-- config group storage-ceph-volume-conf end -->
+```

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -42,7 +42,7 @@ That driver can also be used for custom storage volumes with content type `files
     :end-before: <!-- Include end Ceph driver cluster -->
 ```
 
-You can either create the CephFS file system that you want to use beforehand and specify it through the [`source`](storage-cephfs-pool-config) option, or specify the [`cephfs.create_missing`](storage-cephfs-pool-config) option to automatically create the file system and the data and metadata OSD pools (with the names given in [`cephfs.data_pool`](storage-cephfs-pool-config) and [`cephfs.meta_pool`](storage-cephfs-pool-config)).
+You can either create the CephFS file system that you want to use beforehand and specify it through the {config:option}`storage-cephfs-pool-conf:source` option, or specify the {config:option}`storage-cephfs-pool-conf:cephfs.create_missing` option to automatically create the file system and the data and metadata OSD pools (with the names given in {config:option}`storage-cephfs-pool-conf:cephfs.data_pool` and {config:option}`storage-cephfs-pool-conf:cephfs.meta_pool`).
 
 % Include content from [storage_ceph.md](storage_ceph.md)
 ```{include} storage_ceph.md
@@ -65,30 +65,18 @@ The following configuration options are available for storage pools that use the
 (storage-cephfs-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`cephfs.cluster_name`         | string                        | `ceph`                                  | Name of the Ceph cluster that contains the CephFS file system
-`cephfs.create_missing`       | bool                          | `false`                                 | Create the file system and the missing data and metadata OSD pools
-`cephfs.data_pool`            | string                        | -                                       | Data OSD pool name to create for the file system
-`cephfs.fscache`              | bool                          | `false`                                 | Enable use of kernel `fscache` and `cachefilesd`
-`cephfs.meta_pool`            | string                        | -                                       | Metadata OSD pool name to create for the file system
-`cephfs.osd_pg_num`           | string                        | -                                       | OSD pool `pg_num` to use when creating missing OSD pools
-`cephfs.path`                 | string                        | `/`                                     | The base path for the CephFS mount
-`cephfs.user.name`            | string                        | `admin`                                 | The Ceph user to use
-`source`                      | string                        | -                                       | Existing CephFS file system or file system path to use
-`volatile.pool.pristine`      | string                        | `true`                                  | Whether the CephFS file system was empty on creation time
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-cephfs-pool-conf start -->
+    :end-before: <!-- config group storage-cephfs-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-cephfs-volume-conf start -->
+    :end-before: <!-- config group storage-cephfs-volume-conf end -->
+```

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -65,17 +65,16 @@ The following configuration options are available for storage pools that use the
 (storage-cephobject-pool-config)=
 ### Storage pool configuration
 
-Key                                      | Type                          | Default | Description
-:--                                      | :---                          | :------ | :----------
-`cephobject.bucket.name_prefix`          | string                        | -       | Prefix to add to bucket names in Ceph
-`cephobject.cluster_name`                | string                        | `ceph`  | The Ceph cluster to use
-`cephobject.radosgw.endpoint`            | string                        | -       | URL of the `radosgw` gateway process
-`cephobject.radosgw.endpoint_cert_file`  | string                        | -       | Path to the file containing the TLS client certificate to use for endpoint communication
-`cephobject.user.name`                   | string                        | `admin` | The Ceph user to use
-`volatile.pool.pristine`                 | string                        | `true`  | Whether the `radosgw` `lxd-admin` user existed at creation time
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-cephobject-pool-conf start -->
+    :end-before: <!-- config group storage-cephobject-pool-conf end -->
+```
 
 ### Storage bucket configuration
 
-Key    | Type   | Default                | Description
-:--    | :---   | :------                | :----------
-`size` | string | -                      | Quota of the storage bucket
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-cephobject-bucket-conf start -->
+    :end-before: <!-- config group storage-cephobject-bucket-conf end -->
+```

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -42,7 +42,7 @@ For storage volumes, use the {ref}`Ceph <storage-ceph>` or {ref}`CephFS <storage
 You must set up a `radosgw` environment beforehand and ensure that its HTTP/HTTPS endpoint URL is reachable from the LXD server or servers.
 See [Manual Deployment](https://docs.ceph.com/en/latest/install/manual-deployment/) for information on how to set up a Ceph cluster and [Ceph Object Gateway](https://docs.ceph.com/en/latest/radosgw/) on how to set up a `radosgw` environment.
 
-The `radosgw` URL can be specified at pool creation time using the [`cephobject.radosgw.endpoint`](storage-cephobject-pool-config) option.
+The `radosgw` URL can be specified at pool creation time using the {config:option}`storage-cephobject-pool-conf:cephobject.radosgw.endpoint` option.
 
 LXD uses the `radosgw-admin` command to manage buckets. So this command must be available and operational on the LXD servers.
 

--- a/doc/reference/storage_dir.md
+++ b/doc/reference/storage_dir.md
@@ -28,26 +28,21 @@ The following configuration options are available for storage pools that use the
 
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`rsync.bwlimit`               | string                        | `0` (no limit)                          | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities
-`rsync.compression`           | bool                          | `true`                                  | Whether to use compression while migrating storage pools
-`source`                      | string                        | -                                       | Path to an existing directory
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-dir-pool-conf start -->
+    :end-before: <!-- config group storage-dir-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-dir-volume-conf start -->
+    :end-before: <!-- config group storage-dir-volume-conf end -->
+```
 
 ### Storage bucket configuration
 

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -44,43 +44,29 @@ The following configuration options are available for storage pools that use the
 (storage-lvm-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`lvm.thinpool_name`           | string                        | `LXDThinPool`                           | Thin pool where volumes are created
-`lvm.thinpool_metadata_size`  | string                        | `0` (auto)                              | The size of the thin pool metadata volume (the default is to let LVM calculate an appropriate size)
-`lvm.use_thinpool`            | bool                          | `true`                                  | Whether the storage pool uses a thin pool for logical volumes
-`lvm.vg.force_reuse`          | bool                          | `false`                                 | Force using an existing non-empty volume group
-`lvm.vg_name`                 | string                        | name of the pool                        | Name of the volume group to create
-`rsync.bwlimit`               | string                        | `0` (no limit)                          | The upper limit to be placed on the socket I/O when `rsync` must be used to transfer storage entities
-`rsync.compression`           | bool                          | `true`                                  | Whether to use compression while migrating storage pools
-`size`                        | string                        | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                      | string                        | -                                       | Path to an existing block device, loop file or LVM volume group
-`source.wipe`                 | bool                          | `false`                                 | Wipe the block device specified in `source` prior to creating the storage pool
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-lvm-pool-conf start -->
+    :end-before: <!-- config group storage-lvm-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 (storage-lvm-vol-config)=
 ### Storage volume configuration
 
-Key                     | Type      | Condition     | Default                                        | Description
-:--                     | :---      | :------       | :------                                        | :----------
-`block.filesystem`      | string    | block-based volume with content type `filesystem` | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`   | string    | block-based volume with content type `filesystem` | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`lvm.stripes`           | string    |               | same as `volume.lvm.stripes`                   | Number of stripes to use for new volumes (or thin pool volume)
-`lvm.stripes.size`      | string    |               | same as `volume.lvm.stripes.size`              | Size of stripes to use (at least 4096 bytes and multiple of 512 bytes)
-`security.shifted`      | bool      | custom volume | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    |               | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-lvm-volume-conf start -->
+    :end-before: <!-- config group storage-lvm-volume-conf end -->
+```
 
 ### Storage bucket configuration
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage bucket
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-lvm-bucket-conf start -->
+    :end-before: <!-- config group storage-lvm-bucket-conf end -->
+```

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -25,10 +25,10 @@ The `lvm` driver in LXD uses logical volumes for images, and volume snapshots fo
 
 LXD assumes that it has full control over the volume group.
 Therefore, you should not maintain any file system entities that are not owned by LXD in an LVM volume group, because LXD might delete them.
-However, if you need to reuse an existing volume group (for example, because your setup has only one volume group), you can do so by setting the [`lvm.vg.force_reuse`](storage-lvm-pool-config) configuration.
+However, if you need to reuse an existing volume group (for example, because your setup has only one volume group), you can do so by setting the {config:option}`storage-lvm-pool-conf:lvm.vg.force_reuse` configuration.
 
 By default, LVM storage pools use an LVM thin pool and create logical volumes for all LXD storage entities (images, instances and custom volumes) in there.
-This behavior can be changed by setting [`lvm.use_thinpool`](storage-lvm-pool-config) to `false` when you create the pool.
+This behavior can be changed by setting {config:option}`storage-lvm-pool-conf:lvm.use_thinpool` to `false` when you create the pool.
 In this case, LXD uses "normal" logical volumes for all storage entities that are not snapshots.
 Note that this entails serious performance and space reductions for the `lvm` driver (close to the `dir` driver both in speed and storage usage).
 The reason for this is that most storage operations must fall back to using `rsync`, because logical volumes that are not thin pools do not support snapshots of snapshots.

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -98,43 +98,29 @@ The following configuration options are available for storage pools that use the
 (storage-zfs-pool-config)=
 ### Storage pool configuration
 
-Key                           | Type                          | Default                                 | Description
-:--                           | :---                          | :------                                 | :----------
-`size`                        | string                        | auto (20% of free disk space, >= 5 GiB and <= 30 GiB) | Size of the storage pool when creating loop-based pools (in bytes, suffixes supported, can be increased to grow storage pool)
-`source`                      | string                        | -                                       | Path to an existing block device, loop file or ZFS dataset/pool
-`source.wipe`                 | bool                          | `false`                                 | Wipe the block device specified in `source` prior to creating the storage pool
-`zfs.clone_copy`              | string                        | `true`                                  | Whether to use ZFS lightweight clones rather than full {spellexception}`dataset` copies (Boolean), or `rebase` to copy based on the initial image
-`zfs.export`                  | bool                          | `true`                                  | Disable zpool export while unmount performed
-`zfs.pool_name`               | string                        | name of the pool                        | Name of the zpool
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-zfs-pool-conf start -->
+    :end-before: <!-- config group storage-zfs-pool-conf end -->
+```
 
 {{volume_configuration}}
 
 (storage-zfs-vol-config)=
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`      | string    | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`   | string    | block-based volume with content type `filesystem` (`zfs.block_mode` enabled) | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `snapshots.schedule`                   | {{snapshot_schedule_format}}
-`zfs.blocksize`         | string    |                           | same as `volume.zfs.blocksize`                 | Size of the ZFS block in range from 512 to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set
-`zfs.block_mode`        | bool      |                           | same as `volume.zfs.block_mode`                | Whether to use a formatted `zvol` rather than a {spellexception}`dataset` (`zfs.block_mode` can be set only for custom storage volumes; use `volume.zfs.block_mode` to enable ZFS block mode for all storage volumes in the pool, including instance volumes)
-`zfs.delegate`          | bool      | ZFS 2.2 or higher         | same as `volume.zfs.delegate`                  | Controls whether to delegate the ZFS dataset and anything underneath it to the container(s) using it. Allows the use of the `zfs` command in the container.
-`zfs.remove_snapshots`  | bool      |                           | same as `volume.zfs.remove_snapshots` or `false` | Remove snapshots as needed
-`zfs.use_refquota`      | bool      |                           | same as `volume.zfs.use_refquota` or `false`   | Use `refquota` instead of `quota` for space
-`zfs.reserve_space`     | bool      |                           | same as `volume.zfs.reserve_space` or `false`  | Use `reservation`/`refreservation` along with `quota`/`refquota`
-
-[^*]: {{snapshot_pattern_detail}}
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-zfs-volume-conf start -->
+    :end-before: <!-- config group storage-zfs-volume-conf end -->
+```
 
 ### Storage bucket configuration
 
 To enable storage buckets for local storage pool drivers and allow applications to access the buckets via the S3 protocol, you must configure the {config:option}`server-core:core.storage_buckets_address` server setting.
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage bucket
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group storage-zfs-bucket-conf start -->
+    :end-before: <!-- config group storage-zfs-bucket-conf end -->
+```

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -66,9 +66,9 @@ Restoring from older snapshots
   After determining the correct snapshot, you can {ref}`remove the newer snapshots <storage-edit-snapshots>` so that the snapshot you need is the latest one and you can restore it.
 
   Alternatively, you can configure LXD to automatically discard the newer snapshots during restore.
-  To do so, set the [`zfs.remove_snapshots`](storage-zfs-vol-config) configuration for the volume (or the corresponding `volume.zfs.remove_snapshots` configuration on the storage pool for all volumes in the pool).
+  To do so, set the {config:option}`storage-zfs-volume-conf:zfs.remove_snapshots` configuration for the volume (or the corresponding `volume.zfs.remove_snapshots` configuration on the storage pool for all volumes in the pool).
 
-  Note, however, that if [`zfs.clone_copy`](storage-zfs-pool-config) is set to `true`, instance copies use ZFS snapshots too.
+  Note, however, that if {config:option}`storage-zfs-pool-conf:zfs.clone_copy` is set to `true`, instance copies use ZFS snapshots too.
   In that case, you cannot restore an instance to a snapshot taken before the last copy without having to also delete all its descendants.
   If this is not an option, you can copy the wanted snapshot into a new instance and then delete the old instance.
   You will, however, lose any other snapshots the instance might have had.
@@ -87,9 +87,9 @@ ZFS provides two different quota properties: `quota` and `refquota`.
 `refquota` restricts only the size of the data in the {spellexception}`dataset`, not its snapshots and clones.
 
 By default, LXD uses the `quota` property when you set up a quota for your storage volume.
-If you want to use the `refquota` property instead, set the [`zfs.use_refquota`](storage-zfs-vol-config) configuration for the volume (or the corresponding `volume.zfs.use_refquota` configuration on the storage pool for all volumes in the pool).
+If you want to use the `refquota` property instead, set the {config:option}`storage-zfs-volume-conf:zfs.use_refquota` configuration for the volume (or the corresponding `volume.zfs.use_refquota` configuration on the storage pool for all volumes in the pool).
 
-You can also set the [`zfs.use_reserve_space`](storage-zfs-vol-config) (or `volume.zfs.use_reserve_space`) configuration to use ZFS `reservation` or `refreservation` along with `quota` or `refquota`.
+You can also set the {config:option}`storage-zfs-volume-conf:zfs.reserve_space` (or `volume.zfs.reserve_space`) configuration to use ZFS `reservation` or `refreservation` along with `quota` or `refquota`.
 
 ## Configuration options
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2027,6 +2027,943 @@
 					}
 				]
 			}
+		},
+		"storage-btrfs": {
+			"bucket-conf": {
+				"keys": [
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage bucket",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"pool-conf": {
+				"keys": [
+					{
+						"btrfs.mount_options": {
+							"defaultdesc": "`user_subvol_rm_allowed`",
+							"longdesc": "",
+							"shortdesc": "Mount options for block devices",
+							"type": "string"
+						}
+					},
+					{
+						"size": {
+							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
+							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"shortdesc": "Size of the storage pool (for loop-based pools)",
+							"type": "string"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Path to an existing block device, loop file, or Btrfs subvolume",
+							"type": "string"
+						}
+					},
+					{
+						"source.wipe": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"shortdesc": "Whether to wipe the block device before creating the pool",
+							"type": "bool"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-ceph": {
+			"pool-conf": {
+				"keys": [
+					{
+						"ceph.cluster_name": {
+							"defaultdesc": "`ceph`",
+							"longdesc": "",
+							"shortdesc": "Name of the Ceph cluster in which to create new storage pools",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.osd.data_pool_name": {
+							"longdesc": "",
+							"shortdesc": "Name of the OSD data pool",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.osd.pg_num": {
+							"defaultdesc": "`32`",
+							"longdesc": "",
+							"shortdesc": "Number of placement groups for the OSD storage pool",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.osd.pool_name": {
+							"defaultdesc": "name of the pool",
+							"longdesc": "",
+							"shortdesc": "Name of the OSD storage pool",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.rbd.clone_copy": {
+							"defaultdesc": "`true`",
+							"longdesc": "Enable this option to use RBD lightweight clones rather than full dataset copies.",
+							"shortdesc": "Whether to use RBD lightweight clones",
+							"type": "bool"
+						}
+					},
+					{
+						"ceph.rbd.du": {
+							"defaultdesc": "`true`",
+							"longdesc": "This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.",
+							"shortdesc": "Whether to use RBD `du`",
+							"type": "bool"
+						}
+					},
+					{
+						"ceph.rbd.features": {
+							"defaultdesc": "`layering`",
+							"longdesc": "",
+							"shortdesc": "Comma-separated list of RBD features to enable on the volumes",
+							"type": "string"
+						}
+					},
+					{
+						"ceph.user.name": {
+							"defaultdesc": "`admin`",
+							"longdesc": "",
+							"shortdesc": "The Ceph user to use when creating storage pools and volumes",
+							"type": "string"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Existing OSD storage pool to use",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.pool.pristine": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether the pool was empty on creation time",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"block.filesystem": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.filesystem`",
+							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"shortdesc": "File system of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"block.mount_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.mount_options`",
+							"longdesc": "",
+							"shortdesc": "Mount options for block-backed file system volumes",
+							"type": "string"
+						}
+					},
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-cephfs": {
+			"pool-conf": {
+				"keys": [
+					{
+						"cephfs.cluster_name": {
+							"defaultdesc": "`ceph`",
+							"longdesc": "",
+							"shortdesc": "Name of the Ceph cluster that contains the CephFS file system",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.create_missing": {
+							"defaultdesc": "`false`",
+							"longdesc": "Use this option if the CephFS file system does not exist yet.\nLXD will then automatically create the file system and the missing data and metadata OSD pools.",
+							"shortdesc": "Automatically create the CephFS file system",
+							"type": "bool"
+						}
+					},
+					{
+						"cephfs.data_pool": {
+							"longdesc": "This option specifies the name for the data OSD pool that should be used when creating\na file system automatically.",
+							"shortdesc": "Data OSD pool name",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.fscache": {
+							"defaultdesc": "`false`",
+							"longdesc": "",
+							"shortdesc": "Enable use of kernel `fscache` and `cachefilesd`",
+							"type": "bool"
+						}
+					},
+					{
+						"cephfs.meta_pool": {
+							"longdesc": "This option specifies the name for the file metadata OSD pool that should be used when\ncreating a file system automatically.",
+							"shortdesc": "Metadata OSD pool name",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.osd_pg_num": {
+							"longdesc": "This option specifies the number of OSD pool placement groups (`pg_num`) to use\nwhen creating a missing OSD pool.",
+							"shortdesc": "Number of placement groups when creating missing OSD pools",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.path": {
+							"defaultdesc": "`/`",
+							"longdesc": "",
+							"shortdesc": "The base path for the CephFS mount",
+							"type": "string"
+						}
+					},
+					{
+						"cephfs.user.name": {
+							"defaultdesc": "`admin`",
+							"longdesc": "",
+							"shortdesc": "The Ceph user to use",
+							"type": "string"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Existing CephFS file system or file system path to use",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.pool.pristine": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether the CephFS file system was empty on creation time",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-cephobject": {
+			"bucket-conf": {
+				"keys": [
+					{
+						"size": {
+							"longdesc": "",
+							"shortdesc": "Quota of the storage bucket",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"pool-conf": {
+				"keys": [
+					{
+						"cephobject.bucket.name_prefix": {
+							"longdesc": "",
+							"shortdesc": "Prefix to add to bucket names in Ceph",
+							"type": "string"
+						}
+					},
+					{
+						"cephobject.cluster_name": {
+							"longdesc": "",
+							"shortdesc": "The Ceph cluster to use",
+							"type": "string"
+						}
+					},
+					{
+						"cephobject.radosgw.endpoint": {
+							"longdesc": "",
+							"shortdesc": "URL of the `radosgw` gateway process",
+							"type": "string"
+						}
+					},
+					{
+						"cephobject.radosgw.endpoint_cert_file": {
+							"longdesc": "Specify the path to the file that contains the TLS client certificate.",
+							"shortdesc": "TLS client certificate to use for endpoint communication",
+							"type": "string"
+						}
+					},
+					{
+						"cephobject.user.name": {
+							"defaultdesc": "`admin`",
+							"longdesc": "",
+							"shortdesc": "The Ceph user to use",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.pool.pristine": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether the `radosgw` `lxd-admin` user existed at creation time",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-dir": {
+			"pool-conf": {
+				"keys": [
+					{
+						"rsync.bwlimit": {
+							"defaultdesc": "`0` (no limit)",
+							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"shortdesc": "Upper limit on the socket I/O for `rsync`",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.compression": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to use compression while migrating storage pools",
+							"type": "bool"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Path to an existing directory",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-lvm": {
+			"bucket-conf": {
+				"keys": [
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage bucket",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"pool-conf": {
+				"keys": [
+					{
+						"lvm.thinpool_metadata_size": {
+							"defaultdesc": "`0` (auto)",
+							"longdesc": "By default, LVM calculates an appropriate size.",
+							"shortdesc": "The size of the thin pool metadata volume",
+							"type": "string"
+						}
+					},
+					{
+						"lvm.thinpool_name": {
+							"defaultdesc": "`LXDThinPool`",
+							"longdesc": "",
+							"shortdesc": "Thin pool where volumes are created",
+							"type": "string"
+						}
+					},
+					{
+						"lvm.use_thinpool": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether the storage pool uses a thin pool for logical volumes",
+							"type": "bool"
+						}
+					},
+					{
+						"lvm.vg.force_reuse": {
+							"defaultdesc": "`false`",
+							"longdesc": "",
+							"shortdesc": "Force using an existing non-empty volume group",
+							"type": "bool"
+						}
+					},
+					{
+						"lvm.vg_name": {
+							"defaultdesc": "name of the pool",
+							"longdesc": "",
+							"shortdesc": "Name of the volume group to create",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.bwlimit": {
+							"defaultdesc": "`0` (no limit)",
+							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"shortdesc": "Upper limit on the socket I/O for `rsync`",
+							"type": "string"
+						}
+					},
+					{
+						"rsync.compression": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to use compression while migrating storage pools",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
+							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"shortdesc": "Size of the storage pool (for loop-based pools)",
+							"type": "string"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Path to an existing block device, loop file, or LVM volume group",
+							"type": "string"
+						}
+					},
+					{
+						"source.wipe": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"shortdesc": "Whether to wipe the block device before creating the pool",
+							"type": "bool"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"block.filesystem": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.filesystem`",
+							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"shortdesc": "File system of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"block.mount_options": {
+							"condition": "block-based volume with content type `filesystem`",
+							"defaultdesc": "same as `volume.block.mount_options`",
+							"longdesc": "",
+							"shortdesc": "Mount options for block-backed file system volumes",
+							"type": "string"
+						}
+					},
+					{
+						"lvm.stripes": {
+							"defaultdesc": "same as `volume.lvm.stripes`",
+							"longdesc": "",
+							"shortdesc": "Number of stripes to use for new volumes (or thin pool volume)",
+							"type": "string"
+						}
+					},
+					{
+						"lvm.stripes.size": {
+							"defaultdesc": "same as `volume.lvm.stripes.size`",
+							"longdesc": "The size must be at least 4096 bytes, and a multiple of 512 bytes.",
+							"shortdesc": "Size of stripes to use",
+							"type": "string"
+						}
+					},
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"storage-zfs": {
+			"bucket-conf": {
+				"keys": [
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage bucket",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"pool-conf": {
+				"keys": [
+					{
+						"size": {
+							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
+							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"shortdesc": "Size of the storage pool (for loop-based pools)",
+							"type": "string"
+						}
+					},
+					{
+						"source": {
+							"longdesc": "",
+							"shortdesc": "Path to an existing block device, loop file, or ZFS dataset/pool",
+							"type": "string"
+						}
+					},
+					{
+						"source.wipe": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"shortdesc": "Whether to wipe the block device before creating the pool",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.clone_copy": {
+							"defaultdesc": "`true`",
+							"longdesc": "Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather\nthan full dataset copies.\nSet the option to `rebase` to copy based on the initial image.",
+							"shortdesc": "Whether to use ZFS lightweight clones",
+							"type": "string"
+						}
+					},
+					{
+						"zfs.export": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Disable zpool export while an unmount is being performed",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.pool_name": {
+							"defaultdesc": "name of the pool",
+							"longdesc": "",
+							"shortdesc": "Name of the zpool",
+							"type": "string"
+						}
+					}
+				]
+			},
+			"volume-conf": {
+				"keys": [
+					{
+						"block.filesystem": {
+							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",
+							"defaultdesc": "same as `volume.block.filesystem`",
+							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"shortdesc": "File system of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"block.mount_options": {
+							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",
+							"defaultdesc": "same as `volume.block.mount_options`",
+							"longdesc": "",
+							"shortdesc": "Mount options for block-backed file system volumes",
+							"type": "string"
+						}
+					},
+					{
+						"security.shifted": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.shifted` or `false`",
+							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"shortdesc": "Enable ID shifting overlay",
+							"type": "bool"
+						}
+					},
+					{
+						"security.unmapped": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.security.unmappped` or `false`",
+							"longdesc": "",
+							"shortdesc": "Disable ID mapping for the volume",
+							"type": "bool"
+						}
+					},
+					{
+						"size": {
+							"condition": "appropriate driver",
+							"defaultdesc": "same as `volume.size`",
+							"longdesc": "",
+							"shortdesc": "Size/quota of the storage volume",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.expiry": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.expiry`",
+							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"shortdesc": "When snapshots are to be deleted",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.pattern": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"shortdesc": "Template for the snapshot name",
+							"type": "string"
+						}
+					},
+					{
+						"snapshots.schedule": {
+							"condition": "custom volume",
+							"defaultdesc": "same as `snapshots.schedule`",
+							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"zfs.block_mode": {
+							"defaultdesc": "same as `volume.zfs.block_mode`",
+							"longdesc": "`zfs.block_mode` can be set only for custom storage volumes.\nTo enable ZFS block mode for all storage volumes in the pool, including instance volumes,\nuse `volume.zfs.block_mode`.",
+							"shortdesc": "Whether to use a formatted `zvol` rather than a dataset",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.blocksize": {
+							"defaultdesc": "same as `volume.zfs.blocksize`",
+							"longdesc": "The size must be between 512 bytes and 16 MiB and must be a power of 2.\nFor a block volume, a maximum value of 128 KiB will be used even if a higher value is set.\n\nDepending on the value of {config:option}`storage-zfs-volume-conf:zfs.block_mode`,\nthe specified size is used to set either `volblocksize` or `recordsize` in ZFS.",
+							"shortdesc": "Size of the ZFS block",
+							"type": "string"
+						}
+					},
+					{
+						"zfs.delegate": {
+							"condition": "ZFS 2.2 or higher",
+							"defaultdesc": "same as `volume.zfs.delegate`",
+							"longdesc": "This option controls whether to delegate the ZFS dataset and anything underneath it to the\ncontainer or containers that use it. This allows using the `zfs` command in the container.",
+							"shortdesc": "Whether to delegate the ZFS dataset",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.remove_snapshots": {
+							"defaultdesc": "same as `volume.zfs.remove_snapshots` or `false`",
+							"longdesc": "",
+							"shortdesc": "Remove snapshots as needed",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.reserve_space": {
+							"defaultdesc": "same as `volume.zfs.reserve_space` or `false`",
+							"longdesc": "",
+							"shortdesc": "Use `reservation`/`refreservation` along with `quota`/`refquota`",
+							"type": "bool"
+						}
+					},
+					{
+						"zfs.use_refquota": {
+							"defaultdesc": "same as `volume.zfs.use_refquota` or `false`",
+							"longdesc": "",
+							"shortdesc": "Use `refquota` instead of `quota` for space",
+							"type": "bool"
+						}
+					}
+				]
+			}
 		}
 	}
 }

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -315,7 +315,13 @@ func (d *btrfs) Delete(op *operations.Operation) error {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *btrfs) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"size":                validate.Optional(validate.IsSize),
+		"size": validate.Optional(validate.IsSize),
+		// lxdmeta:generate(entities=storage-btrfs; group=pool-conf; key=btrfs.mount_options)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `user_subvol_rm_allowed`
+		//  shortdesc: Mount options for block devices
 		"btrfs.mount_options": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -289,16 +289,69 @@ func (d *ceph) Delete(op *operations.Operation) error {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *ceph) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"ceph.cluster_name":       validate.IsAny,
-		"ceph.osd.force_reuse":    validate.Optional(validate.IsBool), // Deprecated, should not be used.
-		"ceph.osd.pg_num":         validate.IsAny,
-		"ceph.osd.pool_name":      validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.cluster_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `ceph`
+		//  shortdesc: Name of the Ceph cluster in which to create new storage pools
+		"ceph.cluster_name":    validate.IsAny,
+		"ceph.osd.force_reuse": validate.Optional(validate.IsBool), // Deprecated, should not be used.
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pg_num)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `32`
+		//  shortdesc: Number of placement groups for the OSD storage pool
+		"ceph.osd.pg_num": validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pool_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: name of the pool
+		//  shortdesc: Name of the OSD storage pool
+		"ceph.osd.pool_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.data_pool_name)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Name of the OSD data pool
 		"ceph.osd.data_pool_name": validate.IsAny,
-		"ceph.rbd.clone_copy":     validate.Optional(validate.IsBool),
-		"ceph.rbd.du":             validate.Optional(validate.IsBool),
-		"ceph.rbd.features":       validate.IsAny,
-		"ceph.user.name":          validate.IsAny,
-		"volatile.pool.pristine":  validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.clone_copy)
+		// Enable this option to use RBD lightweight clones rather than full dataset copies.
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Whether to use RBD lightweight clones
+		"ceph.rbd.clone_copy": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.du)
+		// This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Whether to use RBD `du`
+		"ceph.rbd.du": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.features)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `layering`
+		//  shortdesc: Comma-separated list of RBD features to enable on the volumes
+		"ceph.rbd.features": validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.user.name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `admin`
+		//  shortdesc: The Ceph user to use when creating storage pools and volumes
+		"ceph.user.name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=volatile.pool.pristine)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `true`
+		//  shortdesc: Whether the pool was empty on creation time
+		"volatile.pool.pristine": validate.IsAny,
 	}
 
 	return d.validatePool(config, rules, d.commonVolumeRules())

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -833,7 +833,22 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 // commonVolumeRules returns validation rules which are common for pool and volume.
 func (d *ceph) commonVolumeRules() map[string]func(value string) error {
 	return map[string]func(value string) error{
-		"block.filesystem":    validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
+		// lxdmeta:generate(entities=storage-ceph,storage-lvm; group=volume-conf; key=block.filesystem)
+		// Valid options are: `btrfs`, `ext4`, `xfs`
+		// If not set, `ext4` is assumed.
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.filesystem`
+		//  shortdesc: File system of the storage volume
+		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
+		// lxdmeta:generate(entities=storage-ceph,storage-lvm; group=volume-conf; key=block.mount_options)
+		//
+		// ---
+		//  type: string
+		//  condition: block-based volume with content type `filesystem`
+		//  defaultdesc: same as `volume.block.mount_options`
+		//  shortdesc: Mount options for block-backed file system volumes
 		"block.mount_options": validate.IsAny,
 	}
 }

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -365,14 +365,69 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *cephfs) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"cephfs.cluster_name":    validate.IsAny,
-		"cephfs.fscache":         validate.Optional(validate.IsBool),
-		"cephfs.path":            validate.IsAny,
-		"cephfs.user.name":       validate.IsAny,
-		"cephfs.create_missing":  validate.Optional(validate.IsBool),
-		"cephfs.osd_pg_num":      validate.Optional(validate.IsInt64),
-		"cephfs.meta_pool":       validate.IsAny,
-		"cephfs.data_pool":       validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.cluster_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `ceph`
+		//  shortdesc: Name of the Ceph cluster that contains the CephFS file system
+		"cephfs.cluster_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.fscache)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  shortdesc: Enable use of kernel `fscache` and `cachefilesd`
+		"cephfs.fscache": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.path)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `/`
+		//  shortdesc: The base path for the CephFS mount
+		"cephfs.path": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.user.name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `admin`
+		//  shortdesc: The Ceph user to use
+		"cephfs.user.name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.create_missing)
+		// Use this option if the CephFS file system does not exist yet.
+		// LXD will then automatically create the file system and the missing data and metadata OSD pools.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  shortdesc: Automatically create the CephFS file system
+		"cephfs.create_missing": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.osd_pg_num)
+		// This option specifies the number of OSD pool placement groups (`pg_num`) to use
+		// when creating a missing OSD pool.
+		// ---
+		//  type: string
+		//  shortdesc: Number of placement groups when creating missing OSD pools
+		"cephfs.osd_pg_num": validate.Optional(validate.IsInt64),
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.meta_pool)
+		// This option specifies the name for the file metadata OSD pool that should be used when
+		// creating a file system automatically.
+		// ---
+		//  type: string
+		//  shortdesc: Metadata OSD pool name
+		"cephfs.meta_pool": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.data_pool)
+		// This option specifies the name for the data OSD pool that should be used when creating
+		// a file system automatically.
+		// ---
+		//  type: string
+		//  shortdesc: Data OSD pool name
+		"cephfs.data_pool": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=volatile.pool.pristine)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `true`
+		//  shortdesc: Whether the CephFS file system was empty on creation time
 		"volatile.pool.pristine": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -96,12 +96,44 @@ func (d *cephobject) Info() Info {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *cephobject) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"cephobject.cluster_name":               validate.IsAny,
-		"cephobject.user.name":                  validate.IsAny,
-		"cephobject.radosgw.endpoint":           validate.Optional(validate.IsRequestURL),
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.cluster_name)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: The Ceph cluster to use
+		"cephobject.cluster_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.user.name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `admin`
+		//  shortdesc: The Ceph user to use
+		"cephobject.user.name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.radosgw.endpoint)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: URL of the `radosgw` gateway process
+		"cephobject.radosgw.endpoint": validate.Optional(validate.IsRequestURL),
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.radosgw.endpoint_cert_file)
+		// Specify the path to the file that contains the TLS client certificate.
+		// ---
+		//  type: string
+		//  shortdesc: TLS client certificate to use for endpoint communication
 		"cephobject.radosgw.endpoint_cert_file": validate.Optional(validate.IsAbsFilePath),
-		"cephobject.bucket.name_prefix":         validate.Optional(validate.IsAny),
-		"volatile.pool.pristine":                validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.bucket.name_prefix)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Prefix to add to bucket names in Ceph
+		"cephobject.bucket.name_prefix": validate.Optional(validate.IsAny),
+		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=volatile.pool.pristine)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `true`
+		//  shortdesc: Whether the `radosgw` `lxd-admin` user existed at creation time
+		"volatile.pool.pristine": validate.Optional(validate.IsBool),
 	}
 
 	return d.validatePool(config, rules, nil)

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -505,12 +505,42 @@ func (d *lvm) Delete(op *operations.Operation) error {
 
 func (d *lvm) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"size":                       validate.Optional(validate.IsSize),
-		"lvm.vg_name":                validate.IsAny,
-		"lvm.thinpool_name":          validate.IsAny,
+		"size": validate.Optional(validate.IsSize),
+		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.vg_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: name of the pool
+		//  shortdesc: Name of the volume group to create
+		"lvm.vg_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.thinpool_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `LXDThinPool`
+		//  shortdesc: Thin pool where volumes are created
+		"lvm.thinpool_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.thinpool_metadata_size)
+		// By default, LVM calculates an appropriate size.
+		// ---
+		//  type: string
+		//  defaultdesc: `0` (auto)
+		//  shortdesc: The size of the thin pool metadata volume
 		"lvm.thinpool_metadata_size": validate.Optional(validate.IsSize),
-		"lvm.use_thinpool":           validate.Optional(validate.IsBool),
-		"lvm.vg.force_reuse":         validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.use_thinpool)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Whether the storage pool uses a thin pool for logical volumes
+		"lvm.use_thinpool": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.vg.force_reuse)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  shortdesc: Force using an existing non-empty volume group
+		"lvm.vg.force_reuse": validate.Optional(validate.IsBool),
 	}
 
 	err := d.validatePool(config, rules, d.commonVolumeRules())

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -294,8 +294,20 @@ func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 	return map[string]func(value string) error{
 		"block.mount_options": validate.IsAny,
 		"block.filesystem":    validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
-		"lvm.stripes":         validate.Optional(validate.IsUint32),
-		"lvm.stripes.size":    validate.Optional(validate.IsSize),
+		// lxdmeta:generate(entities=storage-lvm; group=volume-conf; key=lvm.stripes)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: same as `volume.lvm.stripes`
+		//  shortdesc: Number of stripes to use for new volumes (or thin pool volume)
+		"lvm.stripes": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=storage-lvm; group=volume-conf; key=lvm.stripes.size)
+		// The size must be at least 4096 bytes, and a multiple of 512 bytes.
+		// ---
+		//  type: string
+		//  defaultdesc: same as `volume.lvm.stripes.size`
+		//  shortdesc: Size of stripes to use
+		"lvm.stripes.size": validate.Optional(validate.IsSize),
 	}
 }
 

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -431,8 +431,22 @@ func (d *zfs) Delete(op *operations.Operation) error {
 // Validate checks that all provide keys are supported and that no conflicting or missing configuration is present.
 func (d *zfs) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"size":          validate.Optional(validate.IsSize),
+		"size": validate.Optional(validate.IsSize),
+		// lxdmeta:generate(entities=storage-zfs; group=pool-conf; key=zfs.pool_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: name of the pool
+		//  shortdesc: Name of the zpool
 		"zfs.pool_name": validate.IsAny,
+		// lxdmeta:generate(entities=storage-zfs; group=pool-conf; key=zfs.clone_copy)
+		// Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather
+		// than full dataset copies.
+		// Set the option to `rebase` to copy based on the initial image.
+		// ---
+		//  type: string
+		//  defaultdesc: `true`
+		//  shortdesc: Whether to use ZFS lightweight clones
 		"zfs.clone_copy": validate.Optional(func(value string) error {
 			if value == "rebase" {
 				return nil
@@ -440,6 +454,12 @@ func (d *zfs) Validate(config map[string]string) error {
 
 			return validate.IsBool(value)
 		}),
+		// lxdmeta:generate(entities=storage-zfs; group=pool-conf; key=zfs.export)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `true`
+		//  shortdesc: Disable zpool export while an unmount is being performed
 		"zfs.export": validate.Optional(validate.IsBool),
 	}
 


### PR DESCRIPTION
Fix the [Storage drivers](https://documentation.ubuntu.com/lxd/en/latest/reference/storage_drivers/)  configuration to be generated from the code. This means, for all storage drivers:

* Move the descriptions to the code
* Replace the table in the docs with an include from the generated options file
* Search and replace any links to those properties with a config reference

JIRA ticket: https://warthogs.atlassian.net/browse/LXD-441

blocked by: https://github.com/canonical/lxd/pull/12642