### PR TITLE
Adds the revive linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,117 @@ linters:
     - gofmt
     - misspell
     - whitespace
+    - revive
+issues:
+  exclude-use-default: false
 linters-settings:
   gci:
     sections:
       - standard
       - default
       - prefix(github.com/canonical/lxd)
+  errcheck:
+    exclude-functions:
+      - (io.ReadCloser).Close
+      - (io.WriteCloser).Close
+      - (io.ReadWriteCloser).Close
+      - (*os.File).Close
+      - (*github.com/gorilla/websocket.Conn).Close
+      - (*github.com/mdlayher/vsock.Listener).Close
+      - os.Remove
+      - (*compress/gzip.Writer).Close
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
+      - name: exported
+        arguments:
+          - "checkPrivateReceivers"
+          - "disableStutteringCheck"
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+      - name: unchecked-type-assertion
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
+      - name: var-naming
+        arguments: # The arguments here are quite odd looking. See the rule description.
+          - [ ]
+          - [ ]
+          - [ { "upperCaseConst": true } ]
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
+      - name: early-return
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
+      - name: redundant-import-alias
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
+      - name: redefines-builtin-id
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
+      - name: struct-tag
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
+      - name: receiver-naming
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
+      - name: deep-exit
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
+      - name: defer
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+      - name: bool-literal-in-expr
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
+      - name: comment-spacings
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#confusing-results
+      - name: confusing-results
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
+      - name: use-any
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
+      - name: bare-return
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
+      - name: empty-block
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
+      - name: range-val-address
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
+      - name: range-val-in-closure
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
+      - name: var-declaration
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
+      - name: useless-break
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
+      - name: error-naming
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
+      - name: indent-error-flow
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
+      - name: datarace
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
+      - name: modifies-value-receiver
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
+      - name: empty-lines
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+
+      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
+      - name: error-return

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,6 @@ ifeq ($(shell command -v flake8),)
 	echo "Please install flake8"
 	exit 1
 endif
-	golangci-lint run --timeout 5m
 	flake8 test/deps/import-busybox
 	shellcheck --shell sh test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh
 	shellcheck test/extras/*.sh

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -992,10 +992,8 @@ func (d Nftables) NetworkApplyForwards(networkName string, rules []AddressForwar
 				rule.TargetPorts = rule.ListenPorts
 			case 1:
 				// Single target port specified, OK.
-				break
 			case len(rule.ListenPorts):
 				// One-to-one match with listen ports, OK.
-				break
 			default:
 				return fmt.Errorf("Invalid rule %d, mismatch between listen port(s) and target port(s) count", ruleIndex)
 			}

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,0 +1,17 @@
+#!/bin/sh -eu
+
+# Default target branch.
+target_branch="main"
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  # Target branch when running in github actions (see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).
+  target_branch="${GITHUB_BASE_REF}"
+elif [ -n "${1:-}" ]; then
+  # Allow a target branch parameter.
+  target_branch="${1}"
+fi
+
+# Gets the most recent commit hash from the target branch.
+rev="$(git log "${target_branch}" --oneline --no-abbrev-commit -n1 | cut -d' ' -f1)"
+
+echo "Checking for golangci-lint errors between HEAD and ${target_branch}..."
+golangci-lint run --timeout 5m --new --new-from-rev "${rev}"


### PR DESCRIPTION
This PR adds the [`revive`](https://github.com/mgechev/revive) linter to our golangci-lint configuration.

Unfortunately there are thousands of lint errors. To ensure that no new errors enter the code base I have added a script to invoke golangci-lint so that it only evaluates commits between HEAD and revision of the most recent commit in the target branch.

We should still strive to fix the existing lint errors, but it's quite a time sink.

Creating as draft so I can ensure it all works in CI. Will mark as ready when it's all passing and request a review.

Edit: Note that this change will mean that invoking `golangci-lint run` directly in the repo will fail.