### PR TITLE
client: Discard non-interactive stdout/stderr output if writer(s) not supplied in ExecInstance

### DIFF
--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1276,6 +1276,11 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 					return nil, err
 				}
 
+				// Discard Stdout from remote command if output writer not supplied.
+				if args.Stdout == nil {
+					args.Stdout = io.Discard
+				}
+
 				conns = append(conns, conn)
 				dones[1] = ws.MirrorWrite(conn, args.Stdout)
 				waitConns++
@@ -1286,6 +1291,11 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 				conn, err := r.GetOperationWebsocket(opAPI.ID, fds["2"])
 				if err != nil {
 					return nil, err
+				}
+
+				// Discard Stderr from remote command if output writer not supplied.
+				if args.Stderr == nil {
+					args.Stderr = io.Discard
 				}
 
 				conns = append(conns, conn)

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1207,8 +1207,7 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 			}
 		}
 
-		// Call the control handler with a connection to the control socket
-		if args.Control != nil && fds[api.SecretNameControl] != "" {
+		if fds[api.SecretNameControl] != "" {
 			conn, err := r.GetOperationWebsocket(opAPI.ID, fds[api.SecretNameControl])
 			if err != nil {
 				return nil, err
@@ -1218,7 +1217,10 @@ func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPos
 				_, _, _ = conn.ReadMessage() // Consume pings from server.
 			}()
 
-			go args.Control(conn)
+			if args.Control != nil {
+				// Call the control handler with a connection to the control socket
+				go args.Control(conn)
+			}
 		}
 
 		if exec.Interactive {

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1099,6 +1099,11 @@ func (r *ProtocolLXD) DeleteInstance(name string) (Operation, error) {
 
 // ExecInstance requests that LXD spawns a command inside the instance.
 func (r *ProtocolLXD) ExecInstance(instanceName string, exec api.InstanceExecPost, args *InstanceExecArgs) (Operation, error) {
+	// Ensure args are equivalent to empty InstanceExecArgs.
+	if args == nil {
+		args = &InstanceExecArgs{}
+	}
+
 	if exec.RecordOutput {
 		if !r.HasExtension("container_exec_recording") {
 			return nil, fmt.Errorf("The server is missing the required \"container_exec_recording\" API extension")


### PR DESCRIPTION
Inspired by @MusicDin #12633 but with some changes.

Fixes #12636
Closes #12633