### PR TITLE
doc/storage/cephfs: specify that you can automatically create pools

### DIFF
--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -128,8 +128,7 @@ Use the existing OSD erasure-coded pool `ecpool` and the OSD replicated pool `rp
 ````{group-tab} CephFS
 
 ```{note}
-When using the CephFS driver, you must create a CephFS file system beforehand.
-This file system consists of two OSD storage pools, one for the actual data and one for the file metadata.
+Each CephFS file system consists of two OSD storage pools, one for the actual data and one for the file metadata.
 ```
 
 Use the existing CephFS file system `my-filesystem` for `pool1`:
@@ -139,6 +138,10 @@ Use the existing CephFS file system `my-filesystem` for `pool1`:
 Use the sub-directory `my-directory` from the `my-filesystem` file system for `pool2`:
 
     lxc storage create pool2 cephfs source=my-filesystem/my-directory
+
+Create a CephFS file system `my-filesystem` with a data pool called `my-data` and a metadata pool called `my-metadata` for `pool3`:
+
+    lxc storage create pool3 cephfs source=my-filesystem cephfs.create_missing=true cephfs.data_pool=my-data cephfs.meta_pool=my-metadata
 
 ````
 ````{group-tab} Ceph Object

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -42,7 +42,7 @@ That driver can also be used for custom storage volumes with content type `files
     :end-before: <!-- Include end Ceph driver cluster -->
 ```
 
-You must create the CephFS file system that you want to use beforehand and specify it through the [`source`](storage-cephfs-pool-config) option.
+You can either create the CephFS file system that you want to use beforehand and specify it through the [`source`](storage-cephfs-pool-config) option, or specify the [`cephfs.create_missing`](storage-cephfs-pool-config) option to automatically create the file system and the data and metadata OSD pools (with the names given in [`cephfs.data_pool`](storage-cephfs-pool-config) and [`cephfs.meta_pool`](storage-cephfs-pool-config)).
 
 % Include content from [storage_ceph.md](storage_ceph.md)
 ```{include} storage_ceph.md
@@ -68,13 +68,13 @@ The following configuration options are available for storage pools that use the
 Key                           | Type                          | Default                                 | Description
 :--                           | :---                          | :------                                 | :----------
 `cephfs.cluster_name`         | string                        | `ceph`                                  | Name of the Ceph cluster that contains the CephFS file system
+`cephfs.create_missing`       | bool                          | `false`                                 | Create the file system and the missing data and metadata OSD pools
+`cephfs.data_pool`            | string                        | -                                       | Data OSD pool name to create for the file system
 `cephfs.fscache`              | bool                          | `false`                                 | Enable use of kernel `fscache` and `cachefilesd`
+`cephfs.meta_pool`            | string                        | -                                       | Metadata OSD pool name to create for the file system
+`cephfs.osd_pg_num`           | string                        | -                                       | OSD pool `pg_num` to use when creating missing OSD pools
 `cephfs.path`                 | string                        | `/`                                     | The base path for the CephFS mount
 `cephfs.user.name`            | string                        | `admin`                                 | The Ceph user to use
-`cephfs.create_missing`       | bool                          | `false`                                 | Create the file-system and missing data and metadata OSD pools
-`cephfs.osd_pg_num`           | string                        | -                                       | OSD pool `pg_num` to use when creating missing OSD pools
-`cephfs.meta_pool`            | string                        | -                                       | Metadata OSD pool name to create for the file-system
-`cephfs.data_pool`            | string                        | -                                       | Data OSD pool name to create for the file-system
 `source`                      | string                        | -                                       | Existing CephFS file system or file system path to use
 `volatile.pool.pristine`      | string                        | `true`                                  | Whether the CephFS file system was empty on creation time
 


### PR DESCRIPTION
You can now automatically create the required file system and pools when setting up a CephFS storage pool.