### PR TITLE
Indicate supported instance types when querying /1.0

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2340,3 +2340,9 @@ This API extension provides the ability to configure storage volumes in preseed 
 ## `metrics_instances_count`
 
 This extends the metrics to include the containers and virtual machines counts. Instances are counted irrespective of their state.
+
+## `server_instance_type_info`
+
+This API extension enables querying a server's supported instance types.
+When querying the `/1.0` endpoint, a new field named `instance_types` is added to the retrieved data.
+This field indicates which instance types are supported by the server.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5292,6 +5292,15 @@ definitions:
                 example: nftables
                 type: string
                 x-go-name: Firewall
+            instance_types:
+                description: List of supported instance types
+                example:
+                    - container
+                    - virtual-machine
+                items:
+                    type: string
+                type: array
+                x-go-name: InstanceTypes
             kernel:
                 description: OS kernel name
                 example: Linux

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -343,6 +343,12 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		} else {
 			env.DriverVersion = driver.Info.Version
 		}
+
+		// Add supported instance types.
+		instType := driver.Info.Type.String()
+		if !shared.ValueInSlice(instType, env.InstanceTypes) {
+			env.InstanceTypes = append(env.InstanceTypes, instType)
+		}
 	}
 
 	if s.OS.LXCFeatures != nil {

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -26,6 +26,12 @@ type ServerEnvironment struct {
 	// Example: 4.0.7 | 5.2.0
 	DriverVersion string `json:"driver_version" yaml:"driver_version"`
 
+	// List of supported instance types
+	// Example: ["container", "virtual-machine"]
+	//
+	// API extension: server_instance_type_info
+	InstanceTypes []string `json:"instance_types" yaml:"instance_types"`
+
 	// Current firewall driver
 	// Example: nftables
 	//

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -394,6 +394,7 @@ var APIExtensions = []string{
 	"ovn_ssl_config",
 	"init_preseed_storage_volumes",
 	"metrics_instances_count",
+	"server_instance_type_info",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -205,6 +205,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_oidc "OpenID Connect"
     run_test test_certificate_edit "Certificate edit"
     run_test test_basic_usage "basic usage"
+    run_test test_server_info "server info"
     run_test test_remote_url "remote url handling"
     run_test test_remote_admin "remote administration"
     run_test test_remote_usage "remote usage"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -669,3 +669,8 @@ test_basic_usage() {
   remaining_instances="$(lxc list --format csv)"
   [ -z "${remaining_instances}" ]
 }
+
+test_server_info() {
+  # Ensure server always reports support for containers.
+  lxc query /1.0 | jq -e '.environment.instance_types | contains(["container"])'
+}


### PR DESCRIPTION
Add ServerEnvironment field for `instance_type` indicating which instance types are supported by the server.

```sh
node-1:~# lxc query /1.0 | jq '.environment | {server_name, instance_types}'
{
  "server_name": "node-1",
  "instance_types": [
    "virtual-machine",
    "container"
  ]
}


node-1:~# lxc query /1.0?target=node-2 | jq '.environment | {server_name, instance_types}'
{
  "server_name": "node-2",
  "instance_types": [
    "virtual-machine",
    "container"
  ]
}

c2:~# lxc query /1.0 | jq '.environment | {server_name, instance_types}'
{
  "server_name": "c2",
  "instance_types": [
    "container"
  ]
}

```

API extension is named `server_instance_type_info`.
