### PR TITLE
Use `cloud-init` to enable `lxd-agent` on Ubuntu releases before `20.04`

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -94,6 +94,7 @@ hotplug
 hotplugged
 hotplugging
 HTTPS
+HWE
 ICMP
 IPAM
 idmap

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -33,6 +33,7 @@ Rebooting the instance does not re-trigger the actions.
 To use `cloud-init`, you must base your instance on an image that has `cloud-init` installed:
 
 * All images from the `ubuntu` and `ubuntu-daily` {ref}`image servers <remote-image-servers>` have `cloud-init` support.
+  However, images for Ubuntu releases prior to `20.04` require special handling to integrate properly with `cloud-init`, so that `lxc exec` works correctly with virtual machines that use those images. Refer to {ref}`vm-cloud-init-config`.
 * Images from the [`images` remote](https://images.linuxcontainers.org/) have `cloud-init`-enabled variants, which are usually bigger in size than the default variant.
   The cloud variants use the `/cloud` suffix, for example, `images:ubuntu/22.04/cloud`.
 

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -71,21 +71,25 @@ VM `cloud-init`
 
       lxc config device add <instance_name> <device_name> disk source=cloud-init:config
 
-  Adding such configuration disk might be needed if the VM image used includes `cloud-init` but not the `lxd-agent`. This is the case of official Ubuntu images prior to `20.04`. On such images, the following steps will enable the LXD agent and thus provide the ability to `lxc exec` into the VM:
+  Adding such a configuration disk might be needed if the VM image that is used includes `cloud-init` but not the `lxd-agent`. This is the case for official Ubuntu images prior to `20.04`. On such images, the following steps enable the LXD agent and thus provide the ability to use `lxc exec` to access the VM:
 
-    lxc init ubuntu-daily:18.04 --vm u1
-    lxc config device add u1 config disk source=cloud-init:config
-    lxc config set u1 cloud-init.user-data - << EOF
-    #cloud-config
-    runcmd:
-      - mount -t 9p config /mnt
-      - cd /mnt
-      - ./install.sh
-      - cd /
-      - umount /mnt
-      - systemctl start lxd-agent  # XXX: causes a reboot
-    EOF
-    lxc start --console u1
+      lxc init ubuntu-daily:18.04 --vm u1
+      lxc config device add u1 config disk source=cloud-init:config
+      lxc config set u1 cloud-init.user-data - << EOF
+      #cloud-config
+      #packages:
+      #  - linux-image-virtual-hwe-16.04  # 16.04 GA kernel as a problem with vsock
+      runcmd:
+        - mount -t 9p config /mnt
+        - cd /mnt
+        - ./install.sh
+        - cd /
+        - umount /mnt
+        - systemctl start lxd-agent  # XXX: causes a reboot
+      EOF
+      lxc start --console u1
+
+  Note that for `16.04`, the HWE kernel is required to work around a problem with `vsock` (see the commented out section in the above `cloud-config`).
 
 (devices-disk-initial-config)=
 ## Initial volume configuration for instance root disk devices

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -60,6 +60,7 @@ ISO file
 
       lxc config device add <instance_name> <device_name> disk source=<file_path_on_host>
 
+(vm-cloud-init-config)=
 VM `cloud-init`
 : You can generate a `cloud-init` configuration ISO from the {config:option}`instance-cloud-init:cloud-init.vendor-data` and {config:option}`instance-cloud-init:cloud-init.user-data` configuration keys and attach it to a virtual machine.
   The `cloud-init` that is running inside the VM then detects the drive on boot and applies the configuration.
@@ -69,6 +70,22 @@ VM `cloud-init`
   To add such a device, use the following command:
 
       lxc config device add <instance_name> <device_name> disk source=cloud-init:config
+
+  Adding such configuration disk might be needed if the VM image used includes `cloud-init` but not the `lxd-agent`. This is the case of official Ubuntu images prior to `20.04`. On such images, the following steps will enable the LXD agent and thus provide the ability to `lxc exec` into the VM:
+
+    lxc init ubuntu-daily:18.04 --vm u1
+    lxc config device add u1 config disk source=cloud-init:config
+    lxc config set u1 cloud-init.user-data - << EOF
+    #cloud-config
+    runcmd:
+      - mount -t 9p config /mnt
+      - cd /mnt
+      - ./install.sh
+      - cd /
+      - umount /mnt
+      - systemctl start lxd-agent  # XXX: causes a reboot
+    EOF
+    lxc start --console u1
 
 (devices-disk-initial-config)=
 ## Initial volume configuration for instance root disk devices

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2769,7 +2769,6 @@ cp udev/99-lxd-agent.rules /lib/udev/rules.d/
 cp systemd/lxd-agent.service /lib/systemd/system/
 cp systemd/lxd-agent-setup /lib/systemd/
 systemctl daemon-reload
-systemctl enable lxd-agent.service
 
 echo ""
 echo "LXD agent has been installed, reboot to confirm setup."


### PR DESCRIPTION
This adds a workaround for the lack of `lxd-agent-loader` package in official (`ubuntu:` and `ubuntu-daily:`) images for releases before `20.04`.

This also document another workaround needed to have `lxd-agent` working on `16.04` images, namely use the `-hwe` kernel.