### PR TITLE
AppArmor: allow more read-only bind remounts

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -265,6 +265,23 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   mount options=(ro,remount,bind,nosuid,noexec,strictatime) /sy[^s]*{,/**},
   mount options=(ro,remount,bind,nosuid,noexec,strictatime) /sys?*{,/**},
 
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /[^spd]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /d[^e]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /de[^v]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.[^l]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.l[^x]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.lx[^c]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/.lxc?*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/[^.]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev?*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /p[^r]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /pr[^o]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /pro[^c]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /proc?*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /s[^y]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /sy[^s]*{,/**},
+  mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /sys?*{,/**},
+
   # Allow bind-mounts of anything except /proc, /sys and /dev/.lxc
   mount options=(rw,bind) /[^spd]*{,/**},
   mount options=(rw,bind) /d[^e]*{,/**},


### PR DESCRIPTION
There is already a set of rules to allow mounts with

  options=(ro,remount,bind,nosuid,noexec,nodev).

Expand on this slightly by also allowing mounts with

  options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow).

Without this change, systemd hits an AppArmor denial when attempting to setup credentials for a service[1].

[1] https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/2046486

**Note:** The version of `apparmor_parser` in the core22 snap does not understand the `nosymfollow` mount option. E.g., if I try to expand the policy manually:

```
$ lxc config set systemd-lxc raw.apparmor "mount options=(ro,remount,bind,nosuid,noexec,nodev,nosymfollow) /dev/shm,"
Error: Parse AppArmor profile: Failed to run: apparmor_parser -QWL /var/snap/lxd/common/lxd/security/apparmor/cache /var/snap/lxd/common/lxd/security/apparmor/profiles/lxd-systemd-lxc: exit status 1 (unsupported mount options)
```

So I guess this couldn't actually be included until the lxd snap is based on core24? 