### PR TITLE
Device: Don't remove an existing target directory when unmounting a `disk` device if the original dir hasn't been created by LXD 

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2557,3 +2557,7 @@ disk devices.
 
 Introduces per-project uplink IP limits for each available uplink network, adding `limits.networks.uplink_ips.ipv4.NETWORK_NAME` and `limits.networks.uplink_ips.ipv6.NETWORK_NAME` configuration keys for projects with `features.networks` enabled.
 These keys define the maximum value of IPs made available on a network named NETWORK_NAME to be assigned as uplink IPs for entities inside a certain project. These entities can be other networks, network forwards or load balancers.
+
+## `disk_state_created`
+
+This API extension provides the ability to check if a target directory was created within the instance file system at mount time. If a host directory is mounted to an existing container directory (e.g., `/opt`), the target directory won't be removed upon unmounting. However, if LXD creates a target directory during the mount, like `/new_dir`, it will be deleted when the device is unmounted.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2425,6 +2425,14 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 <!-- config group instance-snapshots end -->
 <!-- config group instance-volatile start -->
+```{config:option} volatile.<disk_dev_name>.last_state.created instance-volatile
+:shortdesc: "Path of the directory created from mounting a `disk` device"
+:type: "string"
+If mounting a host directory through a `disk` device creates the target directory, this option contains the path of this newly created target directory.
+For example, if the target directory is `/opt` and `/opt` already exists in the instance, this key is not set.
+However, if the target directory is `/opt/foo` and `/opt/foo` doesn't exist in the instance, this key is set to `/opt/foo`.
+```
+
 ```{config:option} volatile.<name>.apply_quota instance-volatile
 :shortdesc: "Disk quota"
 :type: "string"

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1,4 +1,29 @@
 definitions:
+    AgentDeviceRemove:
+        properties:
+            config:
+                additionalProperties:
+                    type: string
+                description: Device configuration map
+                type: object
+                x-go-name: Config
+            name:
+                description: Device name
+                type: string
+                x-go-name: Name
+            type:
+                description: Type of device ('disk', 'nic', etc.)
+                type: string
+                x-go-name: Type
+            volatile:
+                additionalProperties:
+                    type: string
+                description: Optional device volatile configuration keys
+                type: object
+                x-go-name: Volatile
+        title: AgentDeviceRemove represents the fields of an device removal request that needs to occur inside the VM agent.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     AuthGroup:
         properties:
             description:

--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -29,6 +29,7 @@ var api10 = []APIEndpoint{
 	api10Cmd,
 	execCmd,
 	eventsCmd,
+	devicesCmd,
 	metricsCmd,
 	operationsCmd,
 	operationCmd,

--- a/lxd-agent/devices.go
+++ b/lxd-agent/devices.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+)
+
+var devicesCmd = APIEndpoint{
+	Path: "devices",
+
+	Delete: APIEndpointAction{Handler: deviceDelete},
+}
+
+// deviceDelete handles the removal of a device from the VM agent.
+// e.g, if the device is a disk mount, this will cleanly unmount it and remove it if necessary.
+func deviceDelete(d *Daemon, r *http.Request) response.Response {
+	var device api.AgentDeviceRemove
+
+	err := json.NewDecoder(r.Body).Decode(&device)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// We only support disk devices for now
+	if device.Type != "disk" {
+		return response.BadRequest(fmt.Errorf("Device type %q not supported for removal within VM agent", device.Type))
+	}
+
+	targetPath := device.Config["path"]
+
+	if !filepath.IsAbs(targetPath) {
+		return response.SmartError(fmt.Errorf("The device path must be absolute: %q", device.Config["path"]))
+	}
+
+	file, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Error opening /proc/self/mountinfo: %v", err))
+	}
+
+	defer file.Close()
+
+	var mountPoints []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 10 && strings.HasPrefix(fields[4], strings.TrimSuffix(targetPath, "/")) {
+			mountPoints = append(mountPoints, fields[4])
+		}
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Error reading /proc/self/mountinfo: %v", err))
+	}
+
+	if len(mountPoints) == 0 {
+		return response.SmartError(fmt.Errorf("No mount points found for %s", targetPath))
+	}
+
+	// Reverse the slice to unmount in reverse order.
+	// This is needed to unmount potential over-mounts first.
+	for i, j := 0, len(mountPoints)-1; i < j; i, j = i+1, j-1 {
+		mountPoints[i], mountPoints[j] = mountPoints[j], mountPoints[i]
+	}
+
+	for _, mountPoint := range mountPoints {
+		err = unix.Unmount(mountPoint, unix.MNT_DETACH)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Error unmounting %s: %v", mountPoint, err))
+		}
+	}
+
+	// Now that the unmount has occurred,
+	// check if we need to remove the target path.
+	if device.Volatile != nil {
+		path, ok := device.Volatile["last_state.created"]
+		if ok {
+			if filepath.Clean(targetPath) == filepath.Clean(path) {
+				// Check if the path stored for the `last_state.created` volatile key
+				// contains the '/./' marker, which indicates that the left part of the path
+				// exists and the right part did not exist at the time of its creation during the mount.
+				// In this case, we should remove <left_part>/<first_component_of_right_part> instead of the full path.
+				if strings.Contains(path, "/./") {
+					formerlyExistingPathPart, formerlyNonExistingPart := shared.DecodeRemoteAbsPathWithNonExistingDir(path)
+					// Take the first component of the non-existing part.
+					parts := strings.Split(formerlyNonExistingPart, "/")
+					if len(parts) > 0 {
+						if formerlyExistingPathPart == "" {
+							formerlyExistingPathPart = "/"
+						}
+					}
+
+					if len(parts) > 0 {
+						if formerlyExistingPathPart == "" {
+							formerlyExistingPathPart = "/"
+						}
+
+						// Remove the directory tree from the deepest level to the top.
+						// This will fail if the chain of directories contains files/directories other than the ones in the chain.
+						for i := 0; i < len(parts); i++ {
+							pathToRemove := filepath.Clean(filepath.Join(formerlyExistingPathPart, strings.Join(parts[:len(parts)-i], "/")))
+							if strings.HasPrefix(pathToRemove, "/") {
+								err = os.Remove(pathToRemove)
+								if err != nil {
+									return response.SmartError(fmt.Errorf("Failed to remove directory during device deletion: %v", err))
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return response.EmptySyncResponse
+}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -2049,6 +2049,7 @@ func (d *disk) Stop() (*deviceConfig.RunConfig, error) {
 
 	// Request an unmount of the device inside the instance.
 	runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
+		DevName:    d.Name(),
 		TargetPath: relativeDestPath,
 	})
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1497,7 +1497,7 @@ func (d *lxc) deviceStart(dev device.Device, instanceRunning bool) (*deviceConfi
 func (d *lxc) deviceStaticShiftMounts(mounts []deviceConfig.MountEntryItem) error {
 	idmapSet, err := d.CurrentIdmap()
 	if err != nil {
-		return fmt.Errorf("Failed to get idmap for device: %s", err)
+		return fmt.Errorf("Failed to get idmap for device: %w", err)
 	}
 
 	// If there is an idmap being applied and LXD not running in a user namespace then shift the
@@ -1757,7 +1757,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 			// Mount it into the container.
 			err = d.insertMount(mount.DevPath, mount.TargetPath, mount.FSType, flags, idmapType)
 			if err != nil {
-				return fmt.Errorf("Failed to add mount for device inside container: %s", err)
+				return fmt.Errorf("Failed to add mount for device inside container: %w", err)
 			}
 		} else {
 			_, err = files.Lstat(mount.TargetPath)
@@ -4253,7 +4253,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	if args.Architecture != 0 {
 		_, err = osarch.ArchitectureName(args.Architecture)
 		if err != nil {
-			return fmt.Errorf("Invalid architecture id: %s", err)
+			return fmt.Errorf("Invalid architecture id: %w", err)
 		}
 	}
 
@@ -7711,12 +7711,12 @@ func (d *lxc) insertMountLXD(source, target, fstype string, flags int, mntnsPID 
 	if shared.IsDir(source) {
 		tmpMount, err = os.MkdirTemp(d.ShmountsPath(), "lxdmount_")
 		if err != nil {
-			return fmt.Errorf("Failed to create shmounts path: %s", err)
+			return fmt.Errorf("Failed to create shmounts path: %w", err)
 		}
 	} else {
 		f, err := os.CreateTemp(d.ShmountsPath(), "lxdmount_")
 		if err != nil {
-			return fmt.Errorf("Failed to create shmounts path: %s", err)
+			return fmt.Errorf("Failed to create shmounts path: %w", err)
 		}
 
 		tmpMount = f.Name()
@@ -7728,7 +7728,7 @@ func (d *lxc) insertMountLXD(source, target, fstype string, flags int, mntnsPID 
 	// Mount the filesystem
 	err = unix.Mount(source, tmpMount, fstype, uintptr(flags), "")
 	if err != nil {
-		return fmt.Errorf("Failed to setup temporary mount: %s", err)
+		return fmt.Errorf("Failed to setup temporary mount: %w", err)
 	}
 
 	defer func() { _ = unix.Unmount(tmpMount, unix.MNT_DETACH) }()
@@ -7970,7 +7970,7 @@ func (d *lxc) InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid 
 
 	dev, err := device.UnixDeviceCreate(d.state, idmapSet, d.DevicesPath(), prefix, m, true)
 	if err != nil {
-		return fmt.Errorf("Failed to setup device: %s", err)
+		return fmt.Errorf("Failed to setup device: %w", err)
 	}
 
 	devPath := dev.HostPath

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8623,6 +8623,34 @@ func (d *qemu) devlxdEventSend(eventType string, eventMessage map[string]any) er
 	return nil
 }
 
+func (d *qemu) devlxdDeviceRemove(deviceType string, deviceName string, deviceConfig map[string]string, deviceVolatile map[string]string) error {
+	agentDevice := shared.Jmap{}
+	agentDevice["type"] = deviceType
+	agentDevice["config"] = deviceConfig
+	agentDevice["name"] = deviceName
+	agentDevice["volatile"] = deviceVolatile
+
+	client, err := d.getAgentClient()
+	if err != nil {
+		return err
+	}
+
+	agent, err := lxd.ConnectLXDHTTP(nil, client)
+	if err != nil {
+		d.logger.Error("Failed to connect to lxd-agent", logger.Ctx{"err": err})
+		return fmt.Errorf("Failed to connect to lxd-agent")
+	}
+
+	defer agent.Disconnect()
+
+	_, _, err = agent.RawQuery("DELETE", "/1.0/devices", &agentDevice, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Info returns "qemu" and the currently loaded qemu version.
 func (d *qemu) Info() instance.Info {
 	data := instance.Info{

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1245,6 +1245,17 @@ func ConfigKeyChecker(key string, instanceType Type) (func(value string) error, 
 			return validate.IsAny, nil
 		}
 
+		// lxdmeta:generate(entities=instance; group=volatile; key=volatile.<disk_dev_name>.last_state.created)
+		// If mounting a host directory through a `disk` device creates the target directory, this option contains the path of this newly created target directory.
+		// For example, if the target directory is `/opt` and `/opt` already exists in the instance, this key is not set.
+		// However, if the target directory is `/opt/foo` and `/opt/foo` doesn't exist in the instance, this key is set to `/opt/foo`.
+		// ---
+		//  type: string
+		//  shortdesc: Path of the directory created from mounting a `disk` device
+		if strings.HasSuffix(key, ".last_state.created") {
+			return validate.IsAny, nil
+		}
+
 		if strings.HasSuffix(key, ".driver") {
 			return validate.IsAny, nil
 		}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2728,6 +2728,13 @@
 			"volatile": {
 				"keys": [
 					{
+						"volatile.\u003cdisk_dev_name\u003e.last_state.created": {
+							"longdesc": "If mounting a host directory through a `disk` device creates the target directory, this option contains the path of this newly created target directory.\nFor example, if the target directory is `/opt` and `/opt` already exists in the instance, this key is not set.\nHowever, if the target directory is `/opt/foo` and `/opt/foo` doesn't exist in the instance, this key is set to `/opt/foo`.",
+							"shortdesc": "Path of the directory created from mounting a `disk` device",
+							"type": "string"
+						}
+					},
+					{
 						"volatile.\u003cname\u003e.apply_quota": {
 							"longdesc": "The disk quota is applied the next time the instance starts.",
 							"shortdesc": "Disk quota",

--- a/shared/api/agent_device.go
+++ b/shared/api/agent_device.go
@@ -1,0 +1,17 @@
+package api
+
+// AgentDeviceRemove represents the fields of an device removal request that needs to occur inside the VM agent.
+//
+// swagger:model
+//
+// API extension: disk_state_created.
+type AgentDeviceRemove struct {
+	// Type of device ('disk', 'nic', etc.)
+	Type string `json:"type" yaml:"type"`
+	// Device configuration map
+	Config map[string]string `json:"config" yaml:"config"`
+	// Device name
+	Name string `json:"name" yaml:"name"`
+	// Optional device volatile configuration keys
+	Volatile map[string]string `json:"volatile" yaml:"volatile"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -432,6 +432,7 @@ var APIExtensions = []string{
 	"network_zones_all_projects",
 	"instance_root_volume_attachment",
 	"projects_limits_uplink_ips",
+	"disk_state_created",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
closes #12648 
closes #12716
____

# Overall description

When a disk device is removed while relying on a host directory and mapped to a target within a container or a VM,
we detect if the target directory has been created by LXD or not in order to not delete the content of a target
directory during the unmount. Additionaly, with the VM case, we cleanly unmount the target path inside the VM.  

# Container case

Example:

- Let say we mounted a custom host empty directory (`test`) on the existing `/opt` directory of the container,
when unmounted (`lxc device remove ...`), the target `/opt` won't be removed, because we marked it as NOT being created
by LXD at mount time.

- If, however, we created a custom empty target directory at mount time:
`lxc config device add u1 test disk source=/home/user/test path=/new_dir`,
the directory `new_dir` will be created on the target instance and if we decide to unmount `test`,
the target `/new_dir` will be removed because is has been created by LXD

# Particular case for VMs

In addition to that, this fix also cleanly unmount the target directory inside the VM through an new LXD-agent API call. Before that, here is what would have happened:

```bash
mkdir /tmp/empty-dir
lxc launch ubuntu:jammy v1 --vm
lxc config device add v1 empty-dir disk source=/tmp/empty-dir path=/opt
lxc config device remove v1 empty-dir

lxc shell v1 -- stat /opt
stat: cannot statx '/opt': Transport endpoint is not connected
``` 

This happens because the mounted device and its associated char device were removed using QEMU's QMP without unmounting the target.

Now, we inspect for the mounts and the over-mounts if any on the VM, and unmount them in the right order. 

## Benchmark

Each time, there are 10 runs on each benchmark case (10 starts, 10 stops)

`master` branch (CONTAINER):

Startup time with:                   Stop time (`--force`) with:

* 0 disk:    `598.2 ms ±  14.3 ms`   * 0 disk:    `883.5 ms ±  37.1 ms`
* 5 disk:    `595.0 ms ±   8.2 ms`   * 5 disk:    `892.6 ms ±  23.3 ms`
* 10 disks:  `601.0 ms ±   8.5 ms`   * 10 disks:  `900.1 ms ±  22.0 ms`
* 20 disks:  `606.9 ms ±  12.7 ms`   * 20 disks:  `886.8 ms ±  23.4 ms`
* 100 disks: `634.3 ms ±  10.1 ms`   * 100 disks: `934.1 ms ±  16.4 ms`

Our fix branch (CONTAINER):

Startup time with:                   Stop time (`--force`) with:

* 0 disk:    `632.8 ms ±  21.3 ms`   * 0 disk:    `870.3 ms ±  25.6 ms`
* 5 disk:    `624.4 ms ±  15.4 ms`   * 5 disk:    `879.9 ms ±  23.6 ms`
* 10 disks:  `626.6 ms ±  17.2 ms`   * 10 disks:  `877.1 ms ±  19.7 ms`
* 20 disks:  `641.0 ms ±  23.3 ms`   * 20 disks:  `932.0 ms ± 148.6 ms`
* 100 disks: `660.0 ms ±  18.3 ms`   * 100 disks: `942.7 ms ±  16.9 ms`
