### PR TITLE
doc: decode the objects.inv file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,12 +138,17 @@ doc-setup: client
 	rm -Rf doc/.sphinx/.doctrees
 
 .PHONY: doc
-doc: doc-setup doc-incremental
+doc: doc-setup doc-incremental doc-objects
 
 .PHONY: doc-incremental
 doc-incremental:
 	@echo "Build the documentation"
 	. $(SPHINXENV) ; LOCAL_SPHINX_BUILD=True sphinx-build -c doc/ -b dirhtml doc/ doc/html/ -d doc/.sphinx/.doctrees -w doc/.sphinx/warnings.txt
+
+.PHONY: doc-objects
+doc-objects:
+	# provide a decoded version of objects.inv to the UI
+	. $(SPHINXENV); cd doc/html; python3 -m sphinx.ext.intersphinx 'objects.inv' > objects.inv.txt
 
 .PHONY: doc-serve
 doc-serve:

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -14,6 +14,8 @@ build:
   jobs:
     pre_build:
       - go build -o lxc.bin ./lxc
+    post_build:
+      - cd _readthedocs/html; python -m sphinx.ext.intersphinx 'objects.inv' > objects.inv.txt
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Sphinx creates an objects.inv file that contains a mapping of IDs and locations in the docs. The UI needs this mapping to be able to resolve links within the descriptions of config options.

The UI would require additional dependencies to decode the objects.inv file, so providing the decoded version with the documentation is easier.