### PR TITLE
Instance: Consistently use unix timestamps when comparing snapshots

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5886,7 +5886,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 			targetSnapshotsComparable = append(targetSnapshotsComparable, storagePools.ComparableSnapshot{
 				Name:         targetSnapName,
-				CreationDate: targetSnap.CreationDate(),
+				CreationDate: time.Unix(targetSnap.CreationDate().Unix(), 0),
 			})
 		}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6962,7 +6962,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 			targetSnapshotsComparable = append(targetSnapshotsComparable, storagePools.ComparableSnapshot{
 				Name:         targetSnapName,
-				CreationDate: targetSnap.CreationDate(),
+				CreationDate: time.Unix(targetSnap.CreationDate().Unix(), 0),
 			})
 		}
 


### PR DESCRIPTION
When syncing instances to a remote LXD the source and target snapshots creation times get compared. If the times don't match, the snapshot gets retransmitted.

In https://github.com/canonical/lxd/issues/12668 we found that refreshing an instance and switching between using a remote/no remote is causing retransmission of all the instances snapshots:

```bash
lxc init ubuntu:jammy v1 --vm && lxc snapshot v1 && lxc snapshot v1
lxc cp v1 v2 --refresh
lxc cp v1 remote:v2 --refresh # will refresh snap0, snap1 and v1 and set the non unix timestamp as creation date
lxc cp v1 remote:v2 --refresh # refreshes only v1
lxc cp v1 v2 --refresh # will refresh snap0, snap1 and v1 and set the unix timestamp as creation date
lxc cp v1 v2 --refresh # refreshes only v1
```

This change ensures that the unix timestamp is always used so that a user can switch between using a remote/no remote without having to retransmit the snapshots.
