### PR TITLE
GitHub push event base ref

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,8 @@ jobs:
           make
 
       - name: Run static analysis
+        env:
+          GITHUB_BEFORE: ${{ github.event.before }}
         run: |
           make static-analysis
 

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,9 +1,12 @@
 #!/bin/sh -eu
 
 target_branch=""
-if [ -n "${GITHUB_ACTIONS:-}" ]; then
-  # Target branch when running in github actions (see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  # Target branch when scanning a Github pull request
   target_branch="${GITHUB_BASE_REF}"
+elif [ -n "${GITHUB_BEFORE:-}" ]; then
+  # Target branch when scanning a Github merge
+  target_branch="${GITHUB_BEFORE}"
 elif [ -n "${1:-}" ]; then
   # Allow a target branch parameter.
   target_branch="${1}"

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -7,6 +7,9 @@ if [ -n "${GITHUB_BASE_REF:-}" ]; then
 elif [ -n "${GITHUB_BEFORE:-}" ]; then
   # Target branch when scanning a Github merge
   target_branch="${GITHUB_BEFORE}"
+
+  # Attempt to fetch the reference (Github uses a shallow clone).
+  git fetch -q origin "${GITHUB_BEFORE}" || true
 elif [ -n "${1:-}" ]; then
   # Allow a target branch parameter.
   target_branch="${1}"

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,13 +1,26 @@
 #!/bin/sh -eu
 
-# Default target branch.
-target_branch="main"
+target_branch=""
 if [ -n "${GITHUB_ACTIONS:-}" ]; then
   # Target branch when running in github actions (see https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).
   target_branch="${GITHUB_BASE_REF}"
 elif [ -n "${1:-}" ]; then
   # Allow a target branch parameter.
   target_branch="${1}"
+else
+  # Default target branch.
+  for branch in main origin; do
+    if git show-ref --quiet "refs/heads/${branch}" >/dev/null 2>&1; then
+        target_branch="${branch}"
+        break
+    fi
+  done
+fi
+
+# Check if we found a target branch.
+if [ -z "${target_branch}" ]; then
+  echo "The target branch for golangci couldn't be found, skipping."
+  return
 fi
 
 # Gets the most recent commit hash from the target branch.


### PR DESCRIPTION
Our CI is failing on push events because the `GITHUB_BASE_REF` only exists when running the action on a pull request. This adds some commits from incus which set a `GITHUB_BEFORE` environment variable from [github.event.before](https://docs.github.com/en/webhooks/webhook-events-and-payloads#push) to be used instead.