### PR TITLE
lxd: Add support for apparmor unconfined profile mode

### DIFF
--- a/lxd/apparmor/archive.go
+++ b/lxd/apparmor/archive.go
@@ -24,7 +24,7 @@ profile "{{.name}}" {
   {{ .backupsPath }}/** rw,
   {{ .imagesPath }}/** r,
 
-  signal (receive) set=("term") peer=unconfined,
+  signal (receive) set=("term"),
 
   # Capabilities
   capability chown,

--- a/lxd/apparmor/network_dnsmasq.go
+++ b/lxd/apparmor/network_dnsmasq.go
@@ -34,6 +34,9 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .varPath }}/networks/{{ .networkName }}/dnsmasq.leases rw,
   {{ .varPath }}/networks/{{ .networkName }}/dnsmasq.raw r,
 
+  # Allow to restart dnsmasq
+  signal (receive) set=("hup","kill"),
+
   # Logging path
   {{ .logPath }}/dnsmasq.{{ .networkName }}.log rw,
 

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -71,6 +71,13 @@ func (s *OS) initAppArmor() []cluster.Warning {
 
 	/* Detect AppArmor confinment */
 	profile := util.AppArmorProfile()
+	/* if AppArmor is enabled on the system but there is no profile then
+	   the application has the profile name "unconfined", or if AppArmor
+	   is not supported then the label will be empty and finally newer
+	   AppArmor releases support a profile mode "unconfined" where an
+	   application can have a profile defined for it which effectively
+	   is equivalent to the traditional "unconfined" label - in this case
+	   the label will have the suffix " (unconfined)" */
 	if profile != "unconfined" && profile != "" && !strings.HasSuffix(profile, "(unconfined)") {
 		if s.AppArmorAvailable {
 			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor via profile %q", profile)

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -71,9 +71,9 @@ func (s *OS) initAppArmor() []cluster.Warning {
 
 	/* Detect AppArmor confinment */
 	profile := util.AppArmorProfile()
-	if profile != "unconfined" && profile != "" {
+	if profile != "unconfined" && profile != "" && !strings.HasSuffix(profile, "(unconfined)") {
 		if s.AppArmorAvailable {
-			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor")
+			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor via profile %q", profile)
 		}
 
 		s.AppArmorConfined = true


### PR DESCRIPTION
The unconfined profile mode adds ` (unconfined)` to the profile label and is now used in snapd for lxd since https://github.com/snapcore/snapd/pull/13333 was merged recently. lxd needs to treat this the same as the "unconfined" label used previously AND we also add a couple required signal rules and remove any peer restriction - this allows LXD to work as expected again in snapd.