### PR TITLE
Use rsync flags consistently for local and remote copy

### DIFF
--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -78,8 +78,9 @@ func LocalCopy(source string, dest string, bwlimit string, xattrs bool, rsyncArg
 		"--sparse",
 		"--devices",
 		"--delete",
-		"--checksum",
 		"--numeric-ids",
+		// Checks for file modifications on nanoseconds granularity.
+		"--modify-window=-1",
 	}
 
 	if xattrs {
@@ -316,6 +317,9 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 		"--devices",
 		"--partial",
 		"--sparse",
+		// This flag is only required on the receiving end.
+		// Checks for file modifications on nanoseconds granularity.
+		"--modify-window=-1",
 	}
 
 	if len(features) > 0 {

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -292,6 +292,7 @@ migration() {
   lxc_remote copy l1:c1 l2:c2 --refresh
   lxc_remote start l2:c2
   lxc_remote file pull l2:c2/root/testfile1 .
+  [ "$(cat testfile1)" = "test" ]
   rm testfile1
   lxc_remote stop -f l2:c2
 

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -296,6 +296,45 @@ migration() {
   rm testfile1
   lxc_remote stop -f l2:c2
 
+  # Change the files modification time by adding one nanosecond.
+  # Perform the change on the test runner since the busybox instances `touch` doesn't support setting nanoseconds.
+  lxc_remote start l1:c1
+  c1_pid="$(lxc_remote query l1:/1.0/instances/c1?recursion=1 | jq -r .state.pid)"
+  mtime_old="$(stat -c %y "/proc/${c1_pid}/root/root/testfile1")"
+  mtime_old_ns="$(date -d "$mtime_old" +%N | sed 's/^0*//')"
+
+  # Ensure the final nanoseconds are padded with zeros to create a valid format.
+  mtime_new_ns="$(printf "%09d\n" "$((mtime_old_ns+1))")"
+  mtime_new="$(date -d "$mtime_old" "+%Y-%m-%d %H:%M:%S.${mtime_new_ns} %z")"
+  lxc_remote stop -f l1:c1
+
+  # Before setting the new mtime create a local copy too.
+  lxc_remote copy l1:c1 l1:c2
+
+  # Change the modification time.
+  lxc_remote start l1:c1
+  c1_pid="$(lxc_remote query l1:/1.0/instances/c1?recursion=1 | jq -r .state.pid)"
+  touch -m -d "$mtime_new" "/proc/${c1_pid}/root/root/testfile1"
+  lxc_remote stop -f l1:c1
+
+  # Starting from rsync 3.1.3 it should discover the change of +1 nanosecond.
+  # Check if the file got refreshed to a different remote.
+  lxc_remote copy l1:c1 l2:c2 --refresh
+  lxc_remote start l1:c1 l2:c2
+  c1_pid="$(lxc_remote query l1:/1.0/instances/c1?recursion=1 | jq -r .state.pid)"
+  c2_pid="$(lxc_remote query l2:/1.0/instances/c2?recursion=1 | jq -r .state.pid)"
+  [ "$(stat "/proc/${c1_pid}/root/root/testfile1" -c %y)" = "$(stat "/proc/${c2_pid}/root/root/testfile1" -c %y)" ]
+  lxc_remote stop -f l1:c1 l2:c2
+
+  # Check if the file got refreshed locally.
+  lxc_remote copy l1:c1 l1:c2 --refresh
+  lxc_remote start l1:c1 l1:c2
+  c1_pid="$(lxc_remote query l1:/1.0/instances/c1?recursion=1 | jq -r .state.pid)"
+  c2_pid="$(lxc_remote query l1:/1.0/instances/c2?recursion=1 | jq -r .state.pid)"
+  [ "$(stat "/proc/${c1_pid}/root/root/testfile1" -c %y)" = "$(stat "/proc/${c2_pid}/root/root/testfile1" -c %y)" ]
+  lxc_remote rm -f l1:c2
+  lxc_remote stop -f l1:c1
+
   # This will create snapshot c1/snap0 with test device and expiry date.
   lxc_remote config device add l1:c1 testsnapdev none
   lxc_remote config set l1:c1 snapshots.expiry '1d'


### PR DESCRIPTION
The rsync `--checksum` flag has a history in LXD which ultimately led to the fact that remote container copies can be faster than local ones:

1. https://github.com/canonical/lxd/commit/64fd7f913a5aa87ec074b5a89ae7eefd2dd0f147 initially added it in with the note `TODO: Not sure we need this option`.
2. https://github.com/canonical/lxd/commit/a88e667ccb09a2a00c95cbf5ff43ae79d9f69988 removed it since it is causing significant IO
3. https://github.com/canonical/lxd/commit/6518166f441269843a0c17250ce517c23af73341 added it back in since the rsync version 3.1.1 back then didn't had support for checking the files modification times on nanoseconds granularity
4. https://github.com/canonical/lxd/commit/47f4509457056b6011e2076288f43ebf2aac9a89 moved it into `lxd/rsync.go` without any changes

Today rsync still doesn't check for nanoseconds by default but you can now set `--modify-window=-1` to a negative value which will cause a check for nanoseconds starting from version 3.1.3 (from `man rsync`):

> When comparing two timestamps, rsync treats the timestamps as being equal if they differ by no more than the modify-window value.  The default is  0,  which
              matches  just  integer  seconds.   If you specify a negative value (and the receiver is at least version 3.1.3) then nanoseconds will also be taken into ac‐
              count.  Specifying 1 is useful for copies to/from MS Windows FAT filesystems, because FAT represents times with a 2-second  resolution  (allowing  times  to
              differ from the original by up to 1 second).

The LXD snap uses rsync version 3.2.7. This was discovered in https://github.com/canonical/lxd/issues/12668