### PR TITLE
lxd/instance/qemu: Start using seabios as CSM firmware

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -127,6 +127,7 @@ var ovmfSecurebootFirmwares = []ovmfFirmware{
 }
 
 var ovmfCSMFirmwares = []ovmfFirmware{
+	{code: "seabios.bin", vars: "seabios.bin"},
 	{code: "OVMF_CODE.4MB.CSM.fd", vars: "OVMF_VARS.4MB.CSM.fd"},
 	{code: "OVMF_CODE.2MB.CSM.fd", vars: "OVMF_VARS.2MB.CSM.fd"},
 	{code: "OVMF_CODE.CSM.fd", vars: "OVMF_VARS.CSM.fd"},


### PR DESCRIPTION
It was discovered (https://bugzilla.tianocore.org/show_bug.cgi?id=4588) that CSM module was removed from the edk2 which means that we have to switch on the scheme with using SeaBIOS firmware directly.

Recently we have been doing some debugging around edk2/CSM module issue that was preventing some Linux distros from booting (CentOS/Fedora ones). It was found, that issue lays in the BIOS call (INT 13h / 02h) that reads sectors from the disk. Just after this bios call gets called from the Linux kernel earlyboot code (https://github.com/torvalds/linux/blob/052d534373b7ed33712a63d5e17b2b6cdbce84fd/arch/x86/boot/edd.c#L33) something terribly wrong happens with the memory which makes Linux kernel execution to fail later on during the uncompression. It was also discovered that Debian/Ubuntu has no this problem because EDD-related 16-bit code is getting skipped somehow which is a matter of some GRUB code/configuration differences between GRUB builds in RHEL-like distros and Debian-like ones. (I was able to boot Fedora kernel without any problems by using GRUB binary from Debian, and inversely, I was able to see Debian kernel boot failure by booting it from the Fedora's GRUB!). And yes, when SeaBIOS is used directly without edk2 then everything works flawlessly.

Anyways, with this PR we effectively fixing this issue and also stepping out from (surprisingly) abandoned edk2/CSM module.

```
lxd/instance/qemu: Start using seabios as CSM firmware

This adds support for directly using seabios as the CSM firmware rather
than using EDK2's chain boot feature. It also makes this behavior be the
preferred one for new CSM-enabled VMs.

The reason for this change is the removal of CSM support from recent EDK2.

Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
(cherry picked from commit 1fcae668f6f000c2f44c9a9d76a6f8e80897d418)
Signed-off-by: Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com>
License: Apache-2.0
```

Fixes https://github.com/canonical/lxd/issues/12730