### PR TITLE
test/lint: Always fetch the target branch if it cannot be found.

### DIFF
--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -22,17 +22,21 @@ fi
 
 # Check if we found a target branch.
 if [ -z "${target_branch}" ]; then
-  echo "The target branch for golangci couldn't be found, skipping."
-  return
+  echo "The target branch for golangci couldn't be found, aborting."
+  false
 fi
 
+# Fetch the reference if it doesn't exist (Github uses a shallow clone).
 if ! git show-ref --quiet "refs/heads/${target_branch}" --quiet >/dev/null 2>&1; then
-    # Attempt to fetch the reference (Github uses a shallow clone).
-    git fetch -q origin "${target_branch}"
+    git fetch origin "${target_branch}"
 fi
 
 # Gets the most recent commit hash from the target branch.
-rev="$(git log "${target_branch}" --oneline --no-abbrev-commit -n1 | cut -d' ' -f1)"
+rev="$(git log "origin/${target_branch}" --oneline --no-abbrev-commit -n1 | cut -d' ' -f1)"
+if [ -z "${rev}" ]; then
+  echo "No revision found for the tip of the target branch, aborting."
+  false
+fi
 
-echo "Checking for golangci-lint errors between HEAD and ${target_branch}..."
+echo "Checking for golangci-lint errors between HEAD and ${target_branch} (${rev})..."
 golangci-lint run --timeout 5m --new --new-from-rev "${rev}"

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -7,9 +7,6 @@ if [ -n "${GITHUB_BASE_REF:-}" ]; then
 elif [ -n "${GITHUB_BEFORE:-}" ]; then
   # Target branch when scanning a Github merge
   target_branch="${GITHUB_BEFORE}"
-
-  # Attempt to fetch the reference (Github uses a shallow clone).
-  git fetch -q origin "${GITHUB_BEFORE}" || true
 elif [ -n "${1:-}" ]; then
   # Allow a target branch parameter.
   target_branch="${1}"
@@ -27,6 +24,11 @@ fi
 if [ -z "${target_branch}" ]; then
   echo "The target branch for golangci couldn't be found, skipping."
   return
+fi
+
+if ! git show-ref --quiet "refs/heads/${target_branch}" --quiet >/dev/null 2>&1; then
+    # Attempt to fetch the reference (Github uses a shallow clone).
+    git fetch -q origin "${target_branch}"
 fi
 
 # Gets the most recent commit hash from the target branch.


### PR DESCRIPTION
Previously this was only performed when the GITHUB_BEFORE environment variable was set.