### PR TITLE
doc/api-extensions: `security.devlxd` applies to both containers and VMs

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -435,7 +435,7 @@ This adds support to interact with the container console device and console log.
 ## `restrict_devlxd`
 
 A new `security.devlxd` container configuration key was introduced.
-The key controls whether the `/dev/lxd` interface is made available to the container.
+The key controls whether the `/dev/lxd` interface is made available to the instance.
 If set to `false`, this effectively prevents the container from interacting with the LXD daemon.
 
 ## `migration_pre_copy`


### PR DESCRIPTION
It was likely introduced back when LXD only knew about containers.

This was tested by toggling `security.devlxd` on a VM and an container. In both cases, `/dev/lxd/sock` vanishes when `security.devlxd=false`.