### PR TITLE
Force SeaBIOS instead of OVMF-based firmware & some firmware lookup logic changes

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -311,3 +311,5 @@ ZFS
 zpool
 zpools
 qdisc
+firmware
+SeaBIOS

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -36,6 +36,7 @@ Name                            | Description
 `LXD_LXC_TEMPLATE_CONFIG`       | Path to the LXC template configuration directory
 `LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off
 `LXD_UNPRIVILEGED_ONLY`         | If set to `true`, enforces that only unprivileged containers can be created. Note that any privileged containers that have been created before setting LXD_UNPRIVILEGED_ONLY will continue to be privileged. To use this option effectively it should be set when the LXD daemon is first set up.
-`LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
+`LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd` (deprecated, please use `LXD_QEMU_FW_PATH` instead)
+`LXD_QEMU_FW_PATH`              | Path (or `:` separated list of paths) to firmware (OVMF, SeaBIOS) to be used by QEMU
 `LXD_IDMAPPED_MOUNTS_DISABLE`   | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `LXD_DEVMONITOR_DIR`            | Path to be monitored by the device monitor. This is primarily for testing.

--- a/lxd/apparmor/instance.go
+++ b/lxd/apparmor/instance.go
@@ -182,12 +182,7 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			return "", err
 		}
 
-		ovmfPath := "/usr/share/OVMF"
-		if os.Getenv("LXD_OVMF_PATH") != "" {
-			ovmfPath = os.Getenv("LXD_OVMF_PATH")
-		}
-
-		ovmfPath, err = filepath.EvalSymlinks(ovmfPath)
+		qemuFwPathsArr, err := util.GetQemuFwPaths()
 		if err != nil {
 			return "", err
 		}
@@ -209,7 +204,7 @@ func instanceProfile(sysOS *sys.OS, inst instance) (string, error) {
 			"rootPath":    rootPath,
 			"snap":        shared.InSnap(),
 			"userns":      sysOS.RunningInUserNS,
-			"ovmfPath":    ovmfPath,
+			"qemuFwPaths": qemuFwPathsArr,
 		})
 		if err != nil {
 			return "", err

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -39,8 +39,6 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /sys/module/vhost/**                      r,
   /tmp/lxd_sev_*                            r,
   /{,usr/}bin/qemu-system-*                 mrix,
-  {{ .ovmfPath }}/OVMF_CODE.fd              kr,
-  {{ .ovmfPath }}/OVMF_CODE.*.fd            kr,
   /usr/share/qemu/**                        kr,
   /usr/share/seabios/**                     kr,
   owner @{PROC}/@{pid}/cpuset               r,
@@ -91,6 +89,15 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # Entries from LD_LIBRARY_PATH
 {{range $index, $element := .libraryPath}}
   {{$element}}/** mr,
+{{- end }}
+{{- end }}
+
+{{if .qemuFwPaths -}}
+  # Entries from LXD_OVMF_PATH or LXD_QEMU_FW_PATH
+{{range $index, $element := .qemuFwPaths}}
+  {{$element}}/OVMF_CODE.fd   kr,
+  {{$element}}/OVMF_CODE.*.fd kr,
+  {{$element}}/*bios*.bin     kr,
 {{- end }}
 {{- end }}
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -128,7 +128,7 @@ var vmSecurebootFirmwares = []vmFirmware{
 
 // Only valid for x86_64.
 var vmLegacyFirmwares = []vmFirmware{
-	{code: "seabios.bin", vars: "seabios.bin"},
+	{code: "bios-256k.bin", vars: "bios-256k.bin"},
 	{code: "OVMF_CODE.4MB.CSM.fd", vars: "OVMF_VARS.4MB.CSM.fd"},
 	{code: "OVMF_CODE.2MB.CSM.fd", vars: "OVMF_VARS.2MB.CSM.fd"},
 	{code: "OVMF_CODE.CSM.fd", vars: "OVMF_VARS.CSM.fd"},

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -3,7 +3,9 @@
 package util
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -62,4 +64,41 @@ func ReplaceDaemon() error {
 	}
 
 	return nil
+}
+
+// GetQemuFwPaths returns a list of directory paths to search for QEMU firmware files.
+func GetQemuFwPaths() ([]string, error) {
+	var qemuFwPaths []string
+
+	for _, v := range []string{"LXD_QEMU_FW_PATH", "LXD_OVMF_PATH"} {
+		searchPaths := os.Getenv(v)
+		if searchPaths == "" {
+			continue
+		}
+
+		qemuFwPaths = append(qemuFwPaths, strings.Split(searchPaths, ":")...)
+	}
+
+	// Append default paths after ones extracted from env vars so they take precedence.
+	qemuFwPaths = append(qemuFwPaths, "/usr/share/OVMF", "/usr/share/seabios")
+
+	count := 0
+	for i, path := range qemuFwPaths {
+		var err error
+		resolvedPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			// don't fail, just skip as some search paths can be optional
+			continue
+		}
+
+		count++
+		qemuFwPaths[i] = resolvedPath
+	}
+
+	// We want to have at least one valid path to search for firmware.
+	if count == 0 {
+		return nil, fmt.Errorf("Failed to find a valid search path for firmware")
+	}
+
+	return qemuFwPaths, nil
 }


### PR DESCRIPTION
- We want our users to step out from EDK2-based CSM firmwares to SeaBIOS as these firmwares were removed from upstream (see https://bugzilla.tianocore.org/show_bug.cgi?id=4588).

- @tomponline suggested to extend firmware lookup algorithm to handle multiple paths specified in the `LXD_OVMF_PATH`.

- Do some renaming

- Forbid `security.csm` for arches except `x86_64`