### PR TITLE
Improve `test/lint/golangci` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ endif
 	flake8 test/deps/import-busybox
 	shellcheck --shell sh test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh
 	shellcheck test/extras/*.sh
-	run-parts --exit-on-error --regex '.sh' test/lint
+	run-parts --verbose --exit-on-error --regex '.sh' test/lint
 
 .PHONY: staticcheck
 staticcheck:

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -eu
 
-target_branch=""
+# Default target branch.
+target_branch="main"
 if [ -n "${GITHUB_BASE_REF:-}" ]; then
   # Target branch when scanning a Github pull request
   target_branch="${GITHUB_BASE_REF}"
@@ -10,30 +11,17 @@ elif [ -n "${GITHUB_BEFORE:-}" ]; then
 elif [ -n "${1:-}" ]; then
   # Allow a target branch parameter.
   target_branch="${1}"
-else
-  # Default target branch.
-  for branch in main origin; do
-    if git show-ref --quiet "refs/heads/${branch}" >/dev/null 2>&1; then
-        target_branch="${branch}"
-        break
-    fi
-  done
-fi
-
-# Check if we found a target branch.
-if [ -z "${target_branch}" ]; then
-  echo "The target branch for golangci couldn't be found, aborting."
-  false
-fi
-
-# Fetch the reference if it doesn't exist (Github uses a shallow clone).
-if ! git show-ref --quiet "refs/heads/${target_branch}" >/dev/null 2>&1; then
-    echo "Convert shallow clone into treeless clone"
-    git fetch --filter=tree:0 origin "${target_branch}"
 fi
 
 # Gets the most recent commit hash from the target branch.
-rev="$(git log --max-count=1 --format=%H "origin/${target_branch}")"
+rev="$(git log --max-count=1 --format=%H "origin/${target_branch}" || true)"
+if [ -z "${rev}" ]; then
+    # actions/checkout creates shallow clones by default
+    echo "Convert shallow clone into treeless clone"
+    git fetch --filter=tree:0 origin "${target_branch}"
+    rev="$(git log --max-count=1 --format=%H "origin/${target_branch}")"
+fi
+
 if [ -z "${rev}" ]; then
   echo "No revision found for the tip of the target branch, aborting."
   false

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -28,7 +28,8 @@ fi
 
 # Fetch the reference if it doesn't exist (Github uses a shallow clone).
 if ! git show-ref --quiet "refs/heads/${target_branch}" >/dev/null 2>&1; then
-    git fetch origin "${target_branch}"
+    echo "Convert shallow clone into treeless clone"
+    git fetch --filter=tree:0 origin "${target_branch}"
 fi
 
 # Gets the most recent commit hash from the target branch.

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -32,7 +32,7 @@ if ! git show-ref --quiet "refs/heads/${target_branch}" --quiet >/dev/null 2>&1;
 fi
 
 # Gets the most recent commit hash from the target branch.
-rev="$(git log "origin/${target_branch}" --oneline --no-abbrev-commit -n1 | cut -d' ' -f1)"
+rev="$(git log --max-count=1 --format=%H "origin/${target_branch}")"
 if [ -z "${rev}" ]; then
   echo "No revision found for the tip of the target branch, aborting."
   false

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -27,7 +27,7 @@ if [ -z "${target_branch}" ]; then
 fi
 
 # Fetch the reference if it doesn't exist (Github uses a shallow clone).
-if ! git show-ref --quiet "refs/heads/${target_branch}" --quiet >/dev/null 2>&1; then
+if ! git show-ref --quiet "refs/heads/${target_branch}" >/dev/null 2>&1; then
     git fetch origin "${target_branch}"
 fi
 


### PR DESCRIPTION
For a nice explanation on various types of git clones: https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

In our case, since we want `git log` to work, we need at least a treeless clone.

> git clone --filter=tree:0 <url> creates a treeless clone. These clones download all reachable commits while fetching trees and blobs on-demand. These clones are best for build environments where the repository will be deleted after a single build, but you still need access to commit history.