### PR TITLE
OIDC fixes (without encryption)

### DIFF
--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -164,30 +164,15 @@ func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 	handler(w, r)
 }
 
+// Logout deletes the ID and refresh token cookies and redirects the user to the login page.
 func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
-	// Access token.
-	accessCookie := http.Cookie{
-		Name:     "oidc_access",
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: false,
-		SameSite: http.SameSiteStrictMode,
-		Expires:  time.Unix(0, 0),
+	err := o.setCookies(w, "", "", true)
+	if err != nil {
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to delete login information: %w", err).Error()).Render(w)
+		return
 	}
 
-	http.SetCookie(w, &accessCookie)
-
-	// Refresh token.
-	refreshCookie := http.Cookie{
-		Name:     "oidc_refresh",
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: false,
-		SameSite: http.SameSiteStrictMode,
-		Expires:  time.Unix(0, 0),
-	}
-
-	http.SetCookie(w, &refreshCookie)
+	http.Redirect(w, r, "/ui/login/", http.StatusFound)
 }
 
 // Callback is a http.HandlerFunc which implements the code exchange required on the /oidc/callback endpoint.

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -153,14 +153,15 @@ func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	return claims.Subject, nil
 }
 
+// Login is a http.Handler than initiates the login flow for the UI.
 func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
-	// Get the provider.
-	provider, err := o.getProvider(r)
+	err := o.ensureConfig(r.Host)
 	if err != nil {
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Login failed: %w", err).Error()).Render(w)
 		return
 	}
 
-	handler := rp.AuthURLHandler(func() string { return uuid.New().String() }, provider, rp.WithURLParam("audience", o.audience))
+	handler := rp.AuthURLHandler(func() string { return uuid.New().String() }, o.relyingParty, rp.WithURLParam("audience", o.audience))
 	handler(w, r)
 }
 

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -56,102 +56,39 @@ func (e AuthError) Unwrap() error {
 	return e.Err
 }
 
-// Auth extracts the token, validates it and returns the user information.
+// Auth extracts OIDC tokens from the request, verifies them, and returns the subject.
 func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Request) (string, error) {
-	var token string
+	err := o.ensureConfig(r.Host)
+	if err != nil {
+		return "", fmt.Errorf("Authorization failed: %w", err)
+	}
 
-	auth := r.Header.Get("Authorization")
-	if auth != "" {
-		// When a client wants to authenticate, it needs to set the Authorization HTTP header like this:
+	authorizationHeader := r.Header.Get("Authorization")
+
+	idToken, refreshToken, err := o.getCookies(r)
+	if err != nil {
+		// Cookies are present but we failed to decrypt them. They may have been tampered with, so delete them to force
+		// the user to log in again.
+		_ = o.setCookies(w, "", "", true)
+		return "", fmt.Errorf("Failed to retrieve login information: %w", err)
+	}
+
+	if authorizationHeader != "" {
+		// When a command line client wants to authenticate, it needs to set the Authorization HTTP header like this:
 		//    Authorization Bearer <access_token>
-		// If set correctly, LXD will attempt to verify the access token, and grant access if it's valid.
-		// If the verification fails, LXD will return an InvalidToken error. The client should then either use its refresh token to get a new valid access token, or log in again.
-		// If the Authorization header is missing, LXD returns an AuthenticationRequired error.
-		// Both returned errors contain information which are needed for the client to authenticate.
-		parts := strings.Split(auth, "Bearer ")
+		parts := strings.Split(authorizationHeader, "Bearer ")
 		if len(parts) != 2 {
 			return "", &AuthError{fmt.Errorf("Bad authorization token, expected a Bearer token")}
 		}
 
-		token = parts[1]
-	} else {
-		// When not using a Bearer token, fetch the equivalent from a cookie and move on with it.
-		cookie, err := r.Cookie("oidc_access")
-		if err != nil {
-			return "", &AuthError{err}
-		}
-
-		token = cookie.Value
+		// Bearer tokens should always be access tokens.
+		return o.authenticateAccessToken(ctx, parts[1])
+	} else if idToken != "" || refreshToken != "" {
+		// When authenticating via the UI, we expect that there will be ID and refresh tokens present in the request cookies.
+		return o.authenticateIDToken(ctx, w, idToken, refreshToken)
 	}
 
-	if o.accessTokenVerifier == nil {
-		var err error
-
-		o.accessTokenVerifier, err = getAccessTokenVerifier(o.issuer)
-		if err != nil {
-			return "", &AuthError{err}
-		}
-	}
-
-	claims, err := o.VerifyAccessToken(ctx, token)
-	if err != nil {
-		// See if we can refresh the access token.
-		cookie, cookieErr := r.Cookie("oidc_refresh")
-		if cookieErr != nil {
-			return "", &AuthError{err}
-		}
-
-		// Get the provider.
-		provider, err := o.getProvider(r)
-		if err != nil {
-			return "", &AuthError{err}
-		}
-
-		// Attempt the refresh.
-		tokens, err := rp.RefreshAccessToken(provider, cookie.Value, "", "")
-		if err != nil {
-			return "", &AuthError{err}
-		}
-
-		// Validate the refreshed token.
-		claims, err = o.VerifyAccessToken(ctx, tokens.AccessToken)
-		if err != nil {
-			return "", &AuthError{err}
-		}
-
-		// Update the access token cookie.
-		accessCookie := http.Cookie{
-			Name:     "oidc_access",
-			Value:    tokens.AccessToken,
-			Path:     "/",
-			Secure:   true,
-			HttpOnly: false,
-			SameSite: http.SameSiteStrictMode,
-		}
-
-		http.SetCookie(w, &accessCookie)
-
-		// Update the refresh token cookie.
-		if tokens.RefreshToken != "" {
-			refreshCookie := http.Cookie{
-				Name:     "oidc_refresh",
-				Value:    tokens.RefreshToken,
-				Path:     "/",
-				Secure:   true,
-				HttpOnly: false,
-				SameSite: http.SameSiteStrictMode,
-			}
-
-			http.SetCookie(w, &refreshCookie)
-		}
-	}
-
-	user, ok := claims.Claims["email"]
-	if ok && user != nil && user.(string) != "" {
-		return user.(string), nil
-	}
-
-	return claims.Subject, nil
+	return "", AuthError{Err: errors.New("No OIDC tokens provided")}
 }
 
 // authenticateAccessToken verifies the access token and checks that the configured audience is present the in access

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -17,6 +17,14 @@ import (
 	"github.com/canonical/lxd/shared"
 )
 
+const (
+	// cookieNameIDToken is the identifier used to set and retrieve the identity token.
+	cookieNameIDToken = "oidc_identity"
+
+	// cookieNameRefreshToken is the identifier used to set and retrieve the refresh token.
+	cookieNameRefreshToken = "oidc_refresh"
+)
+
 // Verifier holds all information needed to verify an access token offline.
 type Verifier struct {
 	accessTokenVerifier op.AccessTokenVerifier

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -266,14 +266,20 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	return nil
 }
 
-// IsRequest checks if the request is using OIDC authentication.
+// IsRequest checks if the request is using OIDC authentication. We check for the presence of the Authorization header
+// or one of the ID or refresh tokens.
 func (o *Verifier) IsRequest(r *http.Request) bool {
 	if r.Header.Get("Authorization") != "" {
 		return true
 	}
 
-	cookie, err := r.Cookie("oidc_access")
-	if err == nil && cookie != nil {
+	idTokenCookie, err := r.Cookie(cookieNameIDToken)
+	if err == nil && idTokenCookie != nil {
+		return true
+	}
+
+	refreshTokenCookie, err := r.Cookie(cookieNameRefreshToken)
+	if err == nil && refreshTokenCookie != nil {
 		return true
 	}
 

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -48,10 +48,12 @@ type AuthError struct {
 	Err error
 }
 
+// Error implements the error interface for AuthError.
 func (e AuthError) Error() string {
 	return fmt.Sprintf("Failed to authenticate: %s", e.Err.Error())
 }
 
+// Unwrap implements the xerrors.Wrapper interface for AuthError.
 func (e AuthError) Unwrap() error {
 	return e.Err
 }


### PR DESCRIPTION
This PR implements the OIDC fixes that can be found in https://github.com/canonical/lxd/pull/12628 except for encryption of identity and refresh tokens when accessing LXD via the UI. This is because we are awaiting a security review (https://warthogs.atlassian.net/browse/SECQ-60?atlOrigin=eyJpIjoiMGM5MzRlZTc1ZTc2NDQ4ODkyYjc0ZGFiMGIyODZkNzMiLCJwIjoiaiJ9). 

Related to https://github.com/canonical/lxd/issues/12531