### PR TITLE
shared: Add helper for obtaining a CertInfo struct

### DIFF
--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -36,7 +36,7 @@ func (e *Endpoints) NetworkCert() *shared.CertInfo {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	return e.cert
+	return shared.NewCertInfo(e.cert.KeyPair(), e.cert.CA(), e.cert.CRL())
 }
 
 // NetworkAddress returns the network address of the network endpoint, or an

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -124,6 +124,15 @@ type CertInfo struct {
 	crl     *x509.RevocationList
 }
 
+// NewCertInfo returns a CertInfo struct populated with the given TLS certificate information.
+func NewCertInfo(keypair tls.Certificate, ca *x509.Certificate, crl *x509.RevocationList) *CertInfo {
+	return &CertInfo{
+		keypair: keypair,
+		ca:      ca,
+		crl:     crl,
+	}
+}
+
 // KeyPair returns the public/private key pair.
 func (c *CertInfo) KeyPair() tls.Certificate {
 	return c.keypair


### PR DESCRIPTION
CertInfo is used across several LXD-adjacent projects to store certs, but it really only allows populating from a filesystem or from a slice of bytes which results in a lot of back-and-forth conversions: https://github.com/canonical/lxd/blob/1f42fd0d4737210ad8447cef01580e968472f360/shared/cert.go#L48

This introduces a function that instantiates a new CertInfo with the given keypair/ca/crl parameters.