### PR TITLE
Doc improvements (config option index and build speedup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ doc: doc-setup doc-incremental doc-objects
 .PHONY: doc-incremental
 doc-incremental:
 	@echo "Build the documentation"
-	. $(SPHINXENV) ; LOCAL_SPHINX_BUILD=True sphinx-build -c doc/ -b dirhtml doc/ doc/html/ -d doc/.sphinx/.doctrees -w doc/.sphinx/warnings.txt
+	. $(SPHINXENV) ; LOCAL_SPHINX_BUILD=True sphinx-build -c doc/ -b dirhtml doc/ doc/html/ -d doc/.sphinx/.doctrees -w doc/.sphinx/warnings.txt -j auto
 
 .PHONY: doc-objects
 doc-objects:
@@ -159,7 +159,7 @@ doc-spellcheck: doc
 
 .PHONY: doc-linkcheck
 doc-linkcheck: doc-setup
-	. $(SPHINXENV) ; LOCAL_SPHINX_BUILD=True sphinx-build -c doc/ -b linkcheck doc/ doc/html/ -d doc/.sphinx/.doctrees
+	. $(SPHINXENV) ; LOCAL_SPHINX_BUILD=True sphinx-build -c doc/ -b linkcheck doc/ doc/html/ -d doc/.sphinx/.doctrees -j auto
 
 .PHONY: doc-lint
 doc-lint:

--- a/doc/.sphinx/_templates/domainindex.html
+++ b/doc/.sphinx/_templates/domainindex.html
@@ -52,7 +52,14 @@
         {% if page %}<a href="{{ pathto(page)|e }}#{{ anchor }}">{% endif -%}
             <code class="xref">{{ name|e }}</code>
             {%- if page %}</a>{% endif %}
-        {%- if extra %} <em>({{ extra|e }})</em>{% endif -%}
+      <!-- ru-fu: extra has HTML for config options -->
+      {%- if extra %}
+        {% if indextitle == "Configuration options" %}
+          ({{ extra|safe }})
+        {% else %}
+          <em>({{ extra|e }})</em>
+        {% endif -%}
+      {% endif -%}
     </td><td>{% if qualifier %}<strong>{{ qualifier|e }}:</strong>{% endif %}
     <em>{{ description|e }}</em></td>
   </tr>


### PR DESCRIPTION
Combining two different improvements into one PR because both rely on an update to https://github.com/canonical/canonical-sphinx-extensions/pull/33.

- Add some context to the output of the configuration option index to distinguish duplicate options (see https://canonical-ubuntu-documentation-library--12770.com.readthedocs.build/lxd/en/12770/config-options/#cap-storage)
- Speed up the build by enabling parallel processing