### PR TITLE
Cluster-wide locking mechanism

### DIFF
--- a/lxd/db/cluster/operations.go
+++ b/lxd/db/cluster/operations.go
@@ -11,25 +11,30 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t operations.mapper.go
 //go:generate mapper reset -i -b "//go:build linux && cgo && !agent"
 //
+//go:generate mapper stmt -e operation id
 //go:generate mapper stmt -e operation objects
 //go:generate mapper stmt -e operation objects-by-NodeID
 //go:generate mapper stmt -e operation objects-by-ID
 //go:generate mapper stmt -e operation objects-by-UUID
 //go:generate mapper stmt -e operation create-or-replace
+//go:generate mapper stmt -e operation create
 //go:generate mapper stmt -e operation delete-by-UUID
 //go:generate mapper stmt -e operation delete-by-NodeID
 //
 //go:generate mapper method -i -e operation GetMany
 //go:generate mapper method -i -e operation CreateOrReplace
+//go:generate mapper method -i -e operation ID
+//go:generate mapper method -i -e operation Exists
+//go:generate mapper method -i -e operation Create
 //go:generate mapper method -i -e operation DeleteOne-by-UUID
 //go:generate mapper method -i -e operation DeleteMany-by-NodeID
 
 // Operation holds information about a single LXD operation running on a node
 // in the cluster.
 type Operation struct {
-	ID          int64              `db:"primary=yes"`                               // Stable database identifier
-	UUID        string             `db:"primary=yes"`                               // User-visible identifier
-	NodeAddress string             `db:"join=nodes.address&omit=create-or-replace"` // Address of the node the operation is running on
+	ID          int64              // Stable database identifier
+	UUID        string             `db:"primary=yes"`                                      // User-visible identifier
+	NodeAddress string             `db:"join=nodes.address&omit=create-or-replace,create"` // Address of the node the operation is running on
 	ProjectID   *int64             // ID of the project for the operation.
 	NodeID      int64              // ID of the node the operation is running on
 	Type        operationtype.Type // Type of the operation

--- a/lxd/db/cluster/operations.interface.mapper.go
+++ b/lxd/db/cluster/operations.interface.mapper.go
@@ -17,6 +17,18 @@ type OperationGenerated interface {
 	// generator: operation CreateOrReplace
 	CreateOrReplaceOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, error)
 
+	// GetOperationID return the ID of the operation with the given key.
+	// generator: operation ID
+	GetOperationID(ctx context.Context, tx *sql.Tx, uuid string) (int64, error)
+
+	// OperationExists checks if a operation with the given key exists.
+	// generator: operation Exists
+	OperationExists(ctx context.Context, tx *sql.Tx, uuid string) (bool, error)
+
+	// CreateOperation adds a new operation to the database.
+	// generator: operation Create
+	CreateOperation(ctx context.Context, tx *sql.Tx, object Operation) (int64, error)
+
 	// DeleteOperation deletes the operation matching the given key parameters.
 	// generator: operation DeleteOne-by-UUID
 	DeleteOperation(ctx context.Context, tx *sql.Tx, uuid string) error

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -75,6 +75,7 @@ const (
 	RenewServerCertificate
 	RemoveExpiredTokens
 	ClusterHeal
+	ClusterLock
 )
 
 // Description return a human-readable description of the operation type.
@@ -198,6 +199,8 @@ func (t Type) Description() string {
 		return "Remove expired tokens"
 	case ClusterHeal:
 		return "Healing cluster"
+	case ClusterLock:
+		return "Cluster is locked"
 	default:
 		return "Executing operation"
 	}

--- a/lxd/locking/cluster_lock.go
+++ b/lxd/locking/cluster_lock.go
@@ -1,0 +1,111 @@
+package locking
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/db/operationtype"
+	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/revert"
+)
+
+// ClusterLock acquires the local lock, then attempts to create a ClusterLock operation.
+// This operation will remain running until the UnlockFunc is called.
+// If such an operation already exists, we will wait until the operation is finished and then retry.
+func ClusterLock(ctx context.Context, s *state.State, lockName string) (UnlockFunc, error) {
+	var localUnlocker UnlockFunc
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	// If the system isn't clustered, then just return a local lock.
+	if !s.ServerClustered {
+		reverter.Success()
+
+		return Lock(ctx, lockName)
+	}
+
+	// clusterUnlockChan is used to notify the running operation that we have requested to release the lock, ending the operation.
+	clusterUnlockChan := make(chan struct{})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("Failed to acquire %q cluster lock: %w", lockName, ctx.Err())
+		default:
+			// Acquire a local lock.
+			if localUnlocker == nil {
+				var err error
+				localUnlocker, err = Lock(ctx, lockName)
+				if err != nil {
+					return nil, err
+				}
+
+				// Release the local lock if we run into trouble.
+				reverter.Add(func() {
+					localUnlocker()
+					close(clusterUnlockChan)
+				})
+			}
+
+			// The operation will run until the clusterUnlockChan is closed, at which point we can close the local lock as well.
+			onRun := func(o *operations.Operation) error {
+				logger.Debugf("Cluster lock %q acquired by system %q", lockName, s.ServerName)
+				select {
+				case <-ctx.Done():
+					return fmt.Errorf("%q cluster lock operation failed to persist: %w", lockName, ctx.Err())
+				case <-clusterUnlockChan:
+					localUnlocker()
+					return nil
+				}
+			}
+
+			// Actually try creating the operation.
+			opMetadata := operations.ClusterLockMetadata{Name: lockName}
+			op, err := operations.OperationCreate(s, api.ProjectDefaultName, operations.OperationClassTask, operationtype.ClusterLock, nil, opMetadata, onRun, nil, nil, nil)
+			if err == nil {
+				// We successfully created the operation which means we acquired the lock, so initiate the operation.
+				err = op.Start()
+				if err != nil {
+					return nil, fmt.Errorf("Failed to start %q cluster lock operation: %w", lockName, err)
+				}
+
+				// If we didn't run into an error, don't unlock the local lock until we call the UnlockFunc.
+				reverter.Success()
+
+				// Return an UnlockFunc which closes the channel that keeps the operation running.
+				return func() {
+					if locks[lockName] != nil {
+						close(clusterUnlockChan)
+					}
+				}, nil
+			}
+
+			// A 409 (conflict) error means the lock has already been grabbed, so we have to wait for it. Any other error means we ran into a problem.
+			if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
+				return nil, fmt.Errorf("Failed to create %q cluster lock operation: %w", lockName, err)
+			}
+
+			d, err := lxd.ConnectLXDUnixWithContext(ctx, "", nil)
+			if err != nil {
+				return nil, err
+			}
+
+			// Block until whoever has the lock releases it.
+			_, _, err = d.GetOperationWait(uuid.NewSHA1(uuid.Nil, []byte(lockName)).String(), 600)
+			if err != nil {
+				logger.Error("Failed to wait for cluster lock operation", logger.Ctx{"error": err, "name": lockName, "server": s.ServerName})
+			}
+
+			// Sleep a bit between checks.
+			time.Sleep(1 * time.Second)
+		}
+	}
+}

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -188,14 +188,13 @@ func OperationCreate(s *state.State, projectName string, opClass OperationClass,
 		op.SetRequestor(r)
 	}
 
-	operationsLock.Lock()
-	operations[op.id] = &op
-	operationsLock.Unlock()
-
 	err = registerDBOperation(&op, opType)
 	if err != nil {
 		return nil, err
 	}
+	operationsLock.Lock()
+	operations[op.id] = &op
+	operationsLock.Unlock()
 
 	op.logger.Debug("New operation")
 	_, md, _ := op.Render()


### PR DESCRIPTION
Adds a cluster-wide locking mechanism to synchonize actions that shouldn't take place while a particular operation or task is running.

It spawns a special `ClusterLock` operation, which is distinct from other operations in that it can only be inserted into the database once for each UUID, and the UUIDs are generated from the name of the lock.

When attempting to acquire the lock, while the operation exists, other nodes will consider the lock to have been acquired by another node and will wait for the operation to complete before trying again to create one themselves.