### PR TITLE
lxdmetadata: connect a substitution database 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ endif
 .PHONY: update-metadata
 update-metadata: build
 	@echo "Generating golang documentation metadata"
-	$(GOPATH)/bin/lxd-metadata . --json ./lxd/metadata/configuration.json --txt ./doc/config_options.txt
+	$(GOPATH)/bin/lxd-metadata . --json ./lxd/metadata/configuration.json --txt ./doc/config_options.txt --substitution-db ./doc/substitutions.yaml
 
 .PHONY: doc-setup
 doc-setup: client

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1935,7 +1935,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-btrfs-volume-conf
@@ -2074,7 +2083,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-ceph-volume-conf
@@ -2198,7 +2216,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-cephfs-volume-conf
@@ -2321,7 +2348,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-dir-volume-conf
@@ -2491,7 +2527,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-lvm-volume-conf
@@ -2620,7 +2665,16 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
 
-{{snapshot_pattern_detail}}
+The `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.
+
+To add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.
+Make sure to format the date in your template string to avoid forbidden characters in the snapshot name.
+For example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.
+
+Another way to avoid name collisions is to use the placeholder `%d` in the pattern.
+For the first snapshot, the placeholder is replaced with `0`.
+For subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.
+This number is then incremented by one for the new name.
 ```
 
 ```{config:option} snapshots.schedule storage-zfs-volume-conf

--- a/lxd/lxd-metadata/main.go
+++ b/lxd/lxd-metadata/main.go
@@ -11,6 +11,7 @@ import (
 var exclude []string
 var jsonOutput string
 var txtOutput string
+var substitutionDBPath string
 var rootCmd = &cobra.Command{
 	Use:   "lxd-metadata",
 	Short: "lxd-metadata - a simple tool to generate configuration metadata and documentation for LXD",
@@ -22,7 +23,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		path := args[0]
-		_, err := parse(path, jsonOutput, exclude)
+		_, err := parse(path, jsonOutput, exclude, substitutionDBPath)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -40,6 +41,7 @@ func main() {
 	rootCmd.Flags().StringSliceVarP(&exclude, "exclude", "e", []string{}, "Path to exclude from the process")
 	rootCmd.Flags().StringVarP(&jsonOutput, "json", "j", "configuration.json", "Output JSON file containing the generated configuration")
 	rootCmd.Flags().StringVarP(&txtOutput, "txt", "t", "", "Output TXT file containing the generated documentation")
+	rootCmd.Flags().StringVarP(&substitutionDBPath, "substitution-db", "s", "", "Path to a YAML file containing substitution rules")
 	err := rootCmd.Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "lxd-metadata failed: %v", err)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2119,7 +2119,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -2279,7 +2279,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -2419,7 +2419,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -2567,7 +2567,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -2757,7 +2757,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -2899,7 +2899,7 @@
 						"snapshots.pattern": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
-							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\n{{snapshot_pattern_detail}}",
+							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}


### PR DESCRIPTION
This fix enables the `lxd-metadata` tool to be able to do simple template rendering operations.

Any `{{(.*?)}}` in a longdesc field will now be rendered with its substitution value, if the inner substitution key is found. Else, this template will not be rendered.