### PR TITLE
Restore the VM's filesystem volume on LVM and Ceph RBD

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1827,6 +1827,15 @@ func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 		return err
 	}
 
+	// For VM images, restore the filesystem volume too.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		err := d.RestoreVolume(fsVol, snapshotName, op)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds missing functionality to also restore the VM block filesystem volumes during restore on LVM thinpools and Ceph RBD.

A bit of refactoring was required to ensure the reverter can also be applied when restoring on the LVM thinpool.