### PR TITLE
github: Pin MinIO to the version before ServiceV2 API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,7 +256,9 @@ jobs:
           sudo apt-get clean
 
           mkdir -p "$(go env GOPATH)/bin"
-          curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "$(go env GOPATH)/bin/minio"
+          # Pin MinIO to the latest release before https://github.com/minio/minio/releases/tag/RELEASE.2024-01-28T22-35-53Z
+          #curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "$(go env GOPATH)/bin/minio"
+          curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2024-01-18T22-51-28Z --output "$(go env GOPATH)/bin/minio"
           chmod +x "$(go env GOPATH)/bin/minio"
 
       - name: Download go dependencies


### PR DESCRIPTION
Pin the version of MinIO in the pipeline until https://github.com/minio/madmin-go/issues/266 is addressed and we know how to proceed with https://github.com/canonical/lxd/pull/12779.