### PR TITLE
lxc/move: Only use server-side move when dealing with a single server (stable-5.0)

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -195,7 +195,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 
 	// Support for server-side move. Currently, such migration can only move an instance to different project
 	// or storage pool. If specific profile, device or config is provided, the instance should be copied (move using copy).
-	if sourceRemote == destRemote && c.flagStorage != "" || c.flagTargetProject != "" {
+	if sourceRemote == destRemote && (c.flagStorage != "" || c.flagTargetProject != "") {
 		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
 			return err


### PR DESCRIPTION
Contributed under Apache-2.0 License

Signed-off-by: Stéphane Graber <stgraber@stgraber.org>
Signed-off-by: Din Music <din.music@canonical.com>
(cherry picked from commit 6df2cd00c48834dab78710ccdc448f28b137d1c2)