### PR TITLE
Indicate LTS version in `lxc version`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2351,3 +2351,8 @@ This field indicates which instance types are supported by the server.
 
 Adds a `mounted` field to disk resources that LXD discovers on the system, reporting whether that disk or partition is
 mounted.
+
+## `server_version_lts`
+
+The API extension adds indication whether the LXD version is an LTS release.
+This is indicated when command `lxc version` is executed or when `/1.0` endpoint is queried.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5377,6 +5377,11 @@ definitions:
                 example: full-mesh
                 type: string
                 x-go-name: ServerEventMode
+            server_lts:
+                description: Whether the version is an LTS release
+                example: false
+                type: boolean
+                x-go-name: ServerLTS
             server_name:
                 description: Server hostname
                 example: castiana

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -106,6 +106,9 @@ For help with any of those, simply call them with --help.`))
 	// Version handling
 	app.SetVersionTemplate("{{.Version}}\n")
 	app.Version = version.Version
+	if version.IsLTSVersion {
+		app.Version = fmt.Sprintf("%s LTS", version.Version)
+	}
 
 	// alias sub-command
 	aliasCmd := cmdAlias{global: &globalCmd}

--- a/lxc/version.go
+++ b/lxc/version.go
@@ -34,7 +34,11 @@ func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf(i18n.G("Client version: %s\n"), version.Version)
+	// Client version
+	clientVersion := version.Version
+	if version.IsLTSVersion {
+		clientVersion = fmt.Sprintf("%s LTS", clientVersion)
+	}
 
 	// Remote version
 	remote := ""
@@ -45,17 +49,21 @@ func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	version := i18n.G("unreachable")
+	serverVersion := i18n.G("unreachable")
 	resources, err := c.global.ParseServers(remote)
 	if err == nil {
 		resource := resources[0]
 		info, _, err := resource.server.GetServer()
 		if err == nil {
-			version = info.Environment.ServerVersion
+			serverVersion = info.Environment.ServerVersion
+			if info.Environment.ServerLTS {
+				serverVersion = fmt.Sprintf("%s LTS", serverVersion)
+			}
 		}
 	}
 
-	fmt.Printf(i18n.G("Server version: %s\n"), version)
+	fmt.Printf(i18n.G("Client version: %s\n"), clientVersion)
+	fmt.Printf(i18n.G("Server version: %s\n"), serverVersion)
 
 	return nil
 }

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -309,6 +309,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		Server:                 "lxd",
 		ServerPid:              os.Getpid(),
 		ServerVersion:          version.Version,
+		ServerLTS:              version.IsLTSVersion,
 		ServerClustered:        s.ServerClustered,
 		ServerEventMode:        string(cluster.ServerEventMode()),
 		ServerName:             serverName,

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 
 	"github.com/canonical/go-dqlite"
@@ -104,6 +105,9 @@ func main() {
 	// Version handling
 	app.SetVersionTemplate("{{.Version}}\n")
 	app.Version = version.Version
+	if version.IsLTSVersion {
+		app.Version = fmt.Sprintf("%s LTS", version.Version)
+	}
 
 	// activateifneeded sub-command
 	activateifneededCmd := cmdActivateifneeded{global: &globalCmd}

--- a/lxd/main_version.go
+++ b/lxd/main_version.go
@@ -26,7 +26,11 @@ func (c *cmdVersion) Command() *cobra.Command {
 }
 
 func (c *cmdVersion) Run(cmd *cobra.Command, args []string) error {
-	fmt.Println(version.Version)
+	if version.IsLTSVersion {
+		fmt.Println(version.Version, "LTS")
+	} else {
+		fmt.Println(version.Version)
+	}
 
 	return nil
 }

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5592,7 +5592,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6990,7 +6990,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1268,7 +1268,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2930,7 +2930,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3158,7 +3158,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4560,7 +4560,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -5289,7 +5289,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5639,7 +5639,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -6169,7 +6169,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6207,7 +6207,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -8243,7 +8243,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -978,7 +978,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2563,7 +2563,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2784,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4105,7 +4105,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4799,7 +4799,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5136,7 +5136,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5643,7 +5643,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5679,7 +5679,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7094,7 +7094,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1224,7 +1224,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Versión del cliente: %s\n"
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3051,7 +3051,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4391,7 +4391,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -5098,7 +5098,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5435,7 +5435,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5946,7 +5946,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5982,7 +5982,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7537,7 +7537,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1263,7 +1263,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, fuzzy, c-format
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
@@ -2967,7 +2967,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3202,7 +3202,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -4660,7 +4660,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5412,7 +5412,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5764,7 +5764,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6306,7 +6306,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6344,7 +6344,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
@@ -8514,7 +8514,7 @@ msgstr ""
 msgid "total space"
 msgstr "espace total"
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr "inaccessible"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4739,7 +4739,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5062,7 +5062,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5560,7 +5560,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5596,7 +5596,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6994,7 +6994,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1219,7 +1219,7 @@ msgstr "Il nome del container è: %s"
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2817,7 +2817,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3042,7 +3042,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -5096,7 +5096,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5942,7 +5942,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5978,7 +5978,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7533,7 +7533,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1239,7 +1239,7 @@ msgstr "クライアント %s の証明書追加トークン:"
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
@@ -2883,7 +2883,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3119,7 +3119,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -4598,7 +4598,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5301,7 +5301,7 @@ msgstr "認証後、サーバが我々を信用していません"
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
@@ -5691,7 +5691,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6197,7 +6197,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6245,7 +6245,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7833,7 +7833,7 @@ msgstr ""
 msgid "total space"
 msgstr "総容量"
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr "サーバに接続できません"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5592,7 +5592,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6990,7 +6990,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-01-24 18:09-0500\n"
+        "POT-Creation-Date: 2024-01-30 11:57+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -934,7 +934,7 @@ msgstr  ""
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid   "Client version: %s\n"
 msgstr  ""
@@ -2300,7 +2300,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2517,7 +2517,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -3717,7 +3717,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -4375,7 +4375,7 @@ msgstr  ""
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid   "Server version: %s\n"
 msgstr  ""
@@ -4670,7 +4670,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -5161,7 +5161,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5193,7 +5193,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
@@ -6493,7 +6493,7 @@ msgstr  ""
 msgid   "total space"
 msgstr  ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid   "unreachable"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1191,7 +1191,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2968,7 +2968,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4268,7 +4268,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4955,7 +4955,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5278,7 +5278,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5776,7 +5776,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5812,7 +5812,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7210,7 +7210,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1225,7 +1225,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4302,7 +4302,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4989,7 +4989,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5312,7 +5312,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5810,7 +5810,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5846,7 +5846,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7244,7 +7244,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5592,7 +5592,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6990,7 +6990,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1246,7 +1246,7 @@ msgstr "Nome de membro do cluster"
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
@@ -2882,7 +2882,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3106,7 +3106,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4451,7 +4451,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -5169,7 +5169,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5517,7 +5517,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -6034,7 +6034,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6070,7 +6070,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7561,7 +7561,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1243,7 +1243,7 @@ msgstr "Копирование образа: %s"
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4455,7 +4455,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -5164,7 +5164,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5505,7 +5505,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -6020,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -8028,7 +8028,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4739,7 +4739,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5062,7 +5062,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5560,7 +5560,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5596,7 +5596,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6994,7 +6994,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4739,7 +4739,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5062,7 +5062,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5560,7 +5560,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5596,7 +5596,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6994,7 +6994,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5556,7 +5556,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5592,7 +5592,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6990,7 +6990,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2752,7 +2752,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4052,7 +4052,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4739,7 +4739,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5062,7 +5062,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5560,7 +5560,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5596,7 +5596,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6994,7 +6994,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2680,7 +2680,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4888,7 +4888,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5211,7 +5211,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5709,7 +5709,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5745,7 +5745,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -7143,7 +7143,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-01-24 18:09-0500\n"
+"POT-Creation-Date: 2024-01-30 11:57+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
-#: lxc/version.go:37
+#: lxc/version.go:65
 #, c-format
 msgid "Client version: %s\n"
 msgstr ""
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:390
+#: lxc/main.go:393
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2751,7 +2751,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:487
+#: lxc/main.go:490
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -4051,7 +4051,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:353
+#: lxc/main.go:356
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
-#: lxc/version.go:58
+#: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
@@ -5061,7 +5061,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:265 lxc/main.go:266
+#: lxc/main.go:268 lxc/main.go:269
 msgid "Show less common commands"
 msgstr ""
 
@@ -5559,7 +5559,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:290
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -5595,7 +5595,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:395
+#: lxc/main.go:398
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6993,7 +6993,7 @@ msgstr ""
 msgid "total space"
 msgstr ""
 
-#: lxc/version.go:48
+#: lxc/version.go:52
 msgid "unreachable"
 msgstr ""
 

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -111,6 +111,10 @@ type ServerEnvironment struct {
 	// Example: 4.11
 	ServerVersion string `json:"server_version" yaml:"server_version"`
 
+	// Whether the version is an LTS release
+	// Example: false
+	ServerLTS bool `json:"server_lts" yaml:"server_lts"`
+
 	// List of active storage drivers (separate by " | ")
 	// Example: dir | zfs
 	Storage string `json:"storage" yaml:"storage"`

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -396,6 +396,7 @@ var APIExtensions = []string{
 	"metrics_instances_count",
 	"server_instance_type_info",
 	"resources_disk_mounted",
+	"server_version_lts",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/shared/version/flex.go
+++ b/shared/version/flex.go
@@ -2,3 +2,6 @@ package version
 
 // Version contains the LXD version number.
 var Version = "5.20"
+
+// IsLTSVersion indicates this is an LTS version of LXD.
+var IsLTSVersion = false


### PR DESCRIPTION
Indicates LTS version when running `lxc version`.

Fixes #12768