### PR TITLE
github: Pin microceph to quincy edge

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -284,7 +284,7 @@ jobs:
             exit 1
           fi
 
-          sudo snap install microceph --edge
+          sudo snap install microceph --channel=quincy/edge
           sudo apt-get install --no-install-recommends -y ceph-common
           sudo microceph cluster bootstrap
           sudo microceph.ceph config set global osd_pool_default_size 1


### PR DESCRIPTION
Using `--edge` is getting us reef which seems to be breaking on ubuntu 22.04 GH runners.

https://discourse.canonical.com/t/microceph-default-channel-update/3030