### PR TITLE
Golangci whole files

### DIFF
--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -16,9 +16,15 @@ elif [ -n "${1:-}" ]; then
   target_branch="${1}"
 fi
 
-# If we don't already have a target revision. Try to get one from the branch.
 if [ -z "${target_revision}" ]; then
-  target_revision="$(git log --max-count=1 --format=%H "origin/${target_branch}" || true)"
+  # If we don't already have a target revision. Try to get one from the branch.
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    # If we're in CI, just attempt and continue, we may be in a shallow clone.
+    target_revision="$(git log --max-count=1 --format=%H "origin/${target_branch}" || true)"
+  else
+    # If we're local, fail if we don't find a revision (and don't prefix with "origin").
+    target_revision="$(git log --max-count=1 --format=%H "${target_branch}")"
+  fi
 fi
 
 # If we still don't have a target revision, we need to fetch the branch as actions/checkout performs a shallow clone by default.

--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -39,4 +39,4 @@ elif ! git log --max-count=1 --format=%H "${target_revision}" >/dev/null 2>&1; t
 fi
 
 echo "Checking for golangci-lint errors between HEAD and ${target_branch} (${target_revision})..."
-golangci-lint run --timeout 5m --new --new-from-rev "${target_revision}"
+golangci-lint run --timeout 5m --new --new-from-rev "${target_revision}" --whole-files


### PR DESCRIPTION
This PR updates the `test/lint/golangci.sh` script to:
- Handle running locally more cleanly.
- Add the `--whole-files` flag (https://golangci-lint.run/usage/configuration/#command-line-options) which will help us incrementally fix existing lint errors.