### PR TITLE
golangci: Remove/update some overly-pedantic revive lint rules.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,14 +32,10 @@ linters-settings:
           - "checkPrivateReceivers"
           - "disableStutteringCheck"
 
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unused-receiver
-      - name: unused-receiver
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#import-shadowing
-      - name: import-shadowing
-
       # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
       - name: unchecked-type-assertion
+        arguments:
+          - { "acceptIgnoredAssertionResult": true }
 
       # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
       - name: var-naming


### PR DESCRIPTION
- Removes the "unused-receiver" rule. These are quite innocuous and more of a code smell than an indicator of a problem.
- Removes the "import-shadowing" rule. I think it's fine to shadow an import name especially in small scopes.
- Allows unchecked type assertions if the assertion result is explicitly ignored, e.g. v, _ := variable.(T). As this is enough to avoid a panic.