### PR TITLE
Advertise snap sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Linux               | [Snap](https://snapcraft.io/lxd)                  | `snap 
 Windows             | [Chocolatey](https://chocolatey.org/packages/lxc) | `choco install lxc`
 macOS               | [Homebrew](https://formulae.brew.sh/formula/lxc)  | `brew install lxc`
 
+The LXD snap packaging repository is available [here](https://github.com/canonical/lxd-pkg-snap).
+
 For more instructions on installing LXD for a wide variety of Linux distributions and operating systems, and to install LXD from source, see [How to install LXD](https://documentation.ubuntu.com/lxd/en/latest/installing/) in the documentation.
 
 ## Client SDK packages

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    golang: "1.20"
+    golang: "1.21"
     python: "3.11"
   jobs:
     pre_build:

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -48,7 +48,7 @@ Complete the following steps to install the snap:
    If it is not, use one of the {ref}`installing-other`.
 
 1. Install `snapd`.
-   See the [installation instructions](https://snapcraft.io/docs/core/install) in the Snapcraft documentation.
+   See the [installation instructions](https://snapcraft.io/docs/installing-snapd) in the Snapcraft documentation.
 
 1. Install the snap package.
    For the latest feature release, use:


### PR DESCRIPTION
While at it, update readthedocs config to use Go 1.21 (https://github.com/readthedocs/readthedocs.org/issues/10884)