### PR TITLE
Ceph RBD: Regenerate the FS UUID for filesystem volumes only

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1694,7 +1694,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	return nil
 }
 
-// UnmountVolume simulates unmounting a volume snapshot.
+// UnmountVolumeSnapshot simulates unmounting a volume snapshot.
 func (d *ceph) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error) {
 	unlock, err := snapVol.MountLock()
 	if err != nil {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1822,9 +1822,11 @@ func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 	defer func() { _ = d.rbdUnmapVolume(vol, true) }()
 
 	// Re-generate the UUID.
-	err = d.generateUUID(vol.ConfigBlockFilesystem(), devPath)
-	if err != nil {
-		return err
+	if vol.contentType == ContentTypeFS {
+		err = d.generateUUID(vol.ConfigBlockFilesystem(), devPath)
+		if err != nil {
+			return err
+		}
 	}
 
 	// For VM images, restore the filesystem volume too.

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -111,6 +111,16 @@ test_storage_volume_snapshots() {
   lxc storage volume delete "${storage_pool}" "vol1"
   lxc storage volume delete "${storage_pool}" "vol1-snap0"
 
+  # Check snapshot restore of type block volumes.
+  lxc storage volume create "${storage_pool}" "vol1" --type block
+  lxc storage volume snapshot "${storage_pool}" "vol1" "snap0"
+  lxc storage volume restore "${storage_pool}" "vol1" "snap0"
+  lxc storage volume delete "${storage_pool}" "vol1"
+
+  # Check filesystem specific config keys cannot be applied on type block volumes.
+  ! lxc storage volume create "${storage_pool}" "vol1" --type block block.filesystem=btrfs || false
+  ! lxc storage volume create "${storage_pool}" "vol1" --type block block.mount_options=xyz || false
+
   # Check snapshot copy (mode pull).
   lxc launch testimage "c1"
   lxc storage volume create "${storage_pool}" "vol1"


### PR DESCRIPTION
See https://github.com/canonical/lxd/pull/12743#issuecomment-1920746200

Due to https://github.com/canonical/lxd/pull/12745 that issue didn't surface.