### PR TITLE
github: Replace commit signed-off check

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -33,13 +33,5 @@ jobs:
     - name: Check if CLA signed
       uses: simondeziel/has-signed-canonical-cla@implicit-approval-from-licenses
 
-    - name: Get PR Commits
-      id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Check that all commits are signed-off
-      uses: tim-actions/dco@master
-      with:
-        commits: ${{ steps.get-pr-commits.outputs.commits }}
+      uses: live627/check-pr-signoff-action@v1


### PR DESCRIPTION
This allows checking PRs with an abundance of commits. Passing the commit information between the actions might hit the "Argument list too long" limit of GitHub.

See https://github.com/canonical/lxd/actions/runs/7738528181/job/21099523929?pr=12743
