### PR TITLE
Revert database on joining node if cluster join fails

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,12 @@ linters:
     - revive
 issues:
   exclude-use-default: false
+  exclude-rules:
+    # When removing a node from a cluster, we try to re-exec its daemon to clear its state, but
+    # if LXD is using systemd socket activation then we just want to call os.Exit() directly.
+    # In this case the socket FDs and environment vars may be different, so we can't re-exec.
+    - path: lxd/api_cluster.go
+      text: "deep-exit"
 linters-settings:
   gci:
     sections:

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -705,7 +705,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 					return nil
 				})
-				if err != nil && err.Error() != "This certificate already exists" {
+				if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
 					return fmt.Errorf("Failed adding local trusted certificate %q (%s): %w", trustedCert.Name, trustedCert.Fingerprint, err)
 				}
 			}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -909,11 +909,11 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 
 		// Send the response before replacing the LXD daemon process.
 		f, ok := w.(http.Flusher)
-		if ok {
-			f.Flush()
-		} else {
+		if !ok {
 			return fmt.Errorf("http.ResponseWriter is not type http.Flusher")
 		}
+
+		f.Flush()
 
 		return nil
 	})
@@ -1993,11 +1993,11 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 			// Send the response before replacing the LXD daemon process.
 			f, ok := w.(http.Flusher)
-			if ok {
-				f.Flush()
-			} else {
+			if !ok {
 				return fmt.Errorf("http.ResponseWriter is not type http.Flusher")
 			}
+
+			f.Flush()
 
 			return nil
 		})


### PR DESCRIPTION
Closes #12624 

Joining dqlite happens in the `Join` function under `lxd/cluster/membership.go` where we lock the global database, create raft node entries in the local database, and reload the gateway. If there's an issue on the dqlite end that prevents us from joining the cluster, we error out and return, but the database is still locked, and the gateway will still behave as though the node has joined the cluster. This leaves the node in an unrecoverable state as the node will perpetually wait for for connections to a cluster that it's not a part of.

To fix that, this adds some revert hooks that ensure the node returns to a state where we can tell it to re-join the cluster with a new join token. In particular, the revert hooks clear out the raft nodes in the local database, refresh the gateway again to pick this up, and unlocks the global database.