### PR TITLE
Document that the `certificate` field is base64 on `POST /1.0/certificates`

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3,7 +3,7 @@ definitions:
         description: Certificate represents a LXD certificate
         properties:
             certificate:
-                description: The certificate itself, as PEM encoded X509
+                description: The certificate itself, as PEM encoded X509 (or as base64 encoded X509 on POST)
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
@@ -78,7 +78,7 @@ definitions:
         description: CertificatePut represents the modifiable fields of a LXD certificate
         properties:
             certificate:
-                description: The certificate itself, as PEM encoded X509
+                description: The certificate itself, as PEM encoded X509 (or as base64 encoded X509 on POST)
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate
@@ -113,7 +113,7 @@ definitions:
         description: CertificatesPost represents the fields of a new LXD certificate
         properties:
             certificate:
-                description: The certificate itself, as PEM encoded X509
+                description: The certificate itself, as PEM encoded X509 (or as base64 encoded X509 on POST)
                 example: X509 PEM certificate
                 type: string
                 x-go-name: Certificate

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -61,7 +61,7 @@ type CertificatePut struct {
 	// API extension: certificate_project
 	Projects []string `json:"projects" yaml:"projects"`
 
-	// The certificate itself, as PEM encoded X509
+	// The certificate itself, as PEM encoded X509 (or as base64 encoded X509 on POST)
 	// Example: X509 PEM certificate
 	//
 	// API extension: certificate_self_renewal

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -81,8 +81,8 @@ type Certificate struct {
 }
 
 // Writable converts a full Certificate struct into a CertificatePut struct (filters read-only fields).
-func (cert *Certificate) Writable() CertificatePut {
-	return cert.CertificatePut
+func (c *Certificate) Writable() CertificatePut {
+	return c.CertificatePut
 }
 
 // URL returns the URL for the certificate.


### PR DESCRIPTION
The swagger documentation is currently incorrect. To generate slightly different examples in each case I had to duplicate the `Certificate` field on `CertificatesPost`. Please let me know if there is a better way to do this :grimacing: 