### PR TITLE
Add patch to remove `block.*` settings from LVM and Ceph RBD block volumes

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -227,7 +227,8 @@ func patchClusteringServerCertTrust(name string, d *Daemon) error {
 
 		for _, c := range dbCerts {
 			if c.Type == certificate.TypeServer {
-				trustedServerCerts[c.Name] = &c
+				cCopy := c
+				trustedServerCerts[c.Name] = &cCopy
 			}
 		}
 
@@ -806,11 +807,11 @@ func patchStorageRenameCustomISOBlockVolumes(name string, d *Daemon) error {
 	leaderAddress, err := d.gateway.LeaderAddress()
 	if err != nil {
 		// If we're not clustered, we're the leader.
-		if errors.Is(err, cluster.ErrNodeIsNotClustered) {
-			isLeader = true
-		} else {
+		if !errors.Is(err, cluster.ErrNodeIsNotClustered) {
 			return err
 		}
+
+		isLeader = true
 	} else if localConfig.ClusterAddress() == leaderAddress {
 		isLeader = true
 	}


### PR DESCRIPTION
This adds a patch to remove the `block.*` settings from VMs and custom volumes of type block in the LVM and Ceph driver. 

That is required after https://github.com/canonical/lxd/pull/12805 and follows the same procedure as in https://github.com/canonical/lxd/pull/12390.