### PR TITLE
Auth: Add OIDC identities to identity cache and extract identity provider groups

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2322,3 +2322,9 @@ mounted.
 
 The API extension adds indication whether the LXD version is an LTS release.
 This is indicated when command `lxc version` is executed or when `/1.0` endpoint is queried.
+
+## `oidc_groups_claim`
+
+This API extension enables setting an `oidc.groups.claim` configuration key.
+If OIDC authentication is configured and this claim is set, LXD will request this claim in the scope of OIDC flow.
+The value of the claim will be extracted and might be used to make authorization decisions.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1760,6 +1760,16 @@ This value is required by some providers.
 
 ```
 
+```{config:option} oidc.groups.claim server-oidc
+:scope: "global"
+:shortdesc: "Expected audience value for the application"
+:type: "string"
+Specify a custom claim to be requested when performing OIDC flows.
+Configure a corresponding custom claim in your identity provider and
+add organization level groups to it. These can be mapped to LXD groups
+for automatic access control.
+```
+
 ```{config:option} oidc.issuer server-oidc
 :scope: "global"
 :shortdesc: "OpenID Connect Discovery URL for the provider"

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -841,7 +841,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			acmeCAURLChanged = true
 		case "acme.domain":
 			acmeDomainChanged = true
-		case "oidc.issuer", "oidc.client.id", "oidc.audience":
+		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim":
 			oidcChanged = true
 		}
 	}
@@ -985,13 +985,13 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcAudience := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, nil)
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -210,7 +210,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
 
@@ -61,6 +62,14 @@ type Verifier struct {
 	configExpiryInterval time.Duration
 }
 
+// AuthenticationResult represents an authenticated OIDC client.
+type AuthenticationResult struct {
+	IdentityType           string
+	Subject                string
+	Email                  string
+	IdentityProviderGroups []string
+}
+
 // AuthError represents an authentication error.
 type AuthError struct {
 	Err error
@@ -77,10 +86,10 @@ func (e AuthError) Unwrap() error {
 }
 
 // Auth extracts OIDC tokens from the request, verifies them, and returns the subject.
-func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Request) (string, error) {
+func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Request) (*AuthenticationResult, error) {
 	err := o.ensureConfig(r.Host)
 	if err != nil {
-		return "", fmt.Errorf("Authorization failed: %w", err)
+		return nil, fmt.Errorf("Authorization failed: %w", err)
 	}
 
 	authorizationHeader := r.Header.Get("Authorization")
@@ -90,93 +99,121 @@ func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		// Cookies are present but we failed to decrypt them. They may have been tampered with, so delete them to force
 		// the user to log in again.
 		_ = o.setCookies(w, nil, uuid.UUID{}, "", "", true)
-		return "", fmt.Errorf("Failed to retrieve login information: %w", err)
+		return nil, fmt.Errorf("Failed to retrieve login information: %w", err)
 	}
 
+	var result *AuthenticationResult
 	if authorizationHeader != "" {
 		// When a command line client wants to authenticate, it needs to set the Authorization HTTP header like this:
 		//    Authorization Bearer <access_token>
 		parts := strings.Split(authorizationHeader, "Bearer ")
 		if len(parts) != 2 {
-			return "", &AuthError{fmt.Errorf("Bad authorization token, expected a Bearer token")}
+			return nil, &AuthError{fmt.Errorf("Bad authorization token, expected a Bearer token")}
 		}
 
 		// Bearer tokens should always be access tokens.
-		return o.authenticateAccessToken(ctx, parts[1])
+		result, err = o.authenticateAccessToken(ctx, parts[1])
+		if err != nil {
+			return nil, err
+		}
 	} else if idToken != "" || refreshToken != "" {
 		// When authenticating via the UI, we expect that there will be ID and refresh tokens present in the request cookies.
-		return o.authenticateIDToken(ctx, w, idToken, refreshToken)
+		result, err = o.authenticateIDToken(ctx, w, idToken, refreshToken)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return "", AuthError{Err: errors.New("No OIDC tokens provided")}
+	return result, nil
 }
 
 // authenticateAccessToken verifies the access token and checks that the configured audience is present the in access
 // token claims. We do not attempt to refresh access tokens as this is performed client side. The access token subject
 // is returned if no error occurs.
-func (o *Verifier) authenticateAccessToken(ctx context.Context, accessToken string) (string, error) {
+func (o *Verifier) authenticateAccessToken(ctx context.Context, accessToken string) (*AuthenticationResult, error) {
 	claims, err := op.VerifyAccessToken[*oidc.AccessTokenClaims](ctx, accessToken, o.accessTokenVerifier)
 	if err != nil {
-		return "", AuthError{Err: fmt.Errorf("Failed to verify access token: %w", err)}
+		return nil, AuthError{Err: fmt.Errorf("Failed to verify access token: %w", err)}
 	}
 
 	// Check that the token includes the configured audience.
 	audience := claims.GetAudience()
 	if o.audience != "" && !shared.ValueInSlice(o.audience, audience) {
-		return "", AuthError{Err: fmt.Errorf("Provided OIDC token doesn't allow the configured audience")}
+		return nil, AuthError{Err: fmt.Errorf("Provided OIDC token doesn't allow the configured audience")}
 	}
 
-	return claims.Subject, nil
+	var email string
+	emailAny, ok := claims.Claims[oidc.ScopeEmail]
+	if ok {
+		email, _ = emailAny.(string)
+	}
+
+	return &AuthenticationResult{
+		IdentityType:           api.IdentityTypeOIDCClient,
+		Subject:                claims.Subject,
+		Email:                  email,
+		IdentityProviderGroups: o.getGroupsFromClaims(claims.Claims),
+	}, nil
 }
 
 // authenticateIDToken verifies the identity token and returns the ID token subject. If no identity token is given (or
 // verification fails) it will attempt to refresh the ID token.
-func (o *Verifier) authenticateIDToken(ctx context.Context, w http.ResponseWriter, idToken string, refreshToken string) (string, error) {
+func (o *Verifier) authenticateIDToken(ctx context.Context, w http.ResponseWriter, idToken string, refreshToken string) (*AuthenticationResult, error) {
 	var claims *oidc.IDTokenClaims
 	var err error
 	if idToken != "" {
 		// Try to verify the ID token.
 		claims, err = rp.VerifyIDToken[*oidc.IDTokenClaims](ctx, idToken, o.relyingParty.IDTokenVerifier())
 		if err == nil {
-			return claims.Subject, nil
+			return &AuthenticationResult{
+				IdentityType:           api.IdentityTypeOIDCClient,
+				Subject:                claims.Subject,
+				Email:                  claims.Email,
+				IdentityProviderGroups: o.getGroupsFromClaims(claims.Claims),
+			}, nil
 		}
 	}
 
 	// If ID token verification failed (or it wasn't provided, try refreshing the token).
 	tokens, err := rp.RefreshAccessToken(o.relyingParty, refreshToken, "", "")
 	if err != nil {
-		return "", AuthError{Err: fmt.Errorf("Failed to refresh ID tokens: %w", err)}
+		return nil, AuthError{Err: fmt.Errorf("Failed to refresh ID tokens: %w", err)}
 	}
 
 	idTokenAny := tokens.Extra("id_token")
 	if idTokenAny == nil {
-		return "", AuthError{Err: errors.New("ID tokens missing from OIDC refresh response")}
+		return nil, AuthError{Err: errors.New("ID tokens missing from OIDC refresh response")}
 	}
 
 	idToken, ok := idTokenAny.(string)
 	if !ok {
-		return "", AuthError{Err: errors.New("Malformed ID tokens in OIDC refresh response")}
+		return nil, AuthError{Err: errors.New("Malformed ID tokens in OIDC refresh response")}
 	}
 
 	// Verify the refreshed ID token.
 	claims, err = rp.VerifyIDToken[*oidc.IDTokenClaims](ctx, idToken, o.relyingParty.IDTokenVerifier())
 	if err != nil {
-		return "", AuthError{Err: fmt.Errorf("Failed to verify refreshed ID token: %w", err)}
+		return nil, AuthError{Err: fmt.Errorf("Failed to verify refreshed ID token: %w", err)}
 	}
 
 	sessionID := uuid.New()
 	secureCookie, err := o.secureCookieFromSession(sessionID)
 	if err != nil {
-		return "", AuthError{Err: fmt.Errorf("Failed to create new session with refreshed token: %w", err)}
+		return nil, AuthError{Err: fmt.Errorf("Failed to create new session with refreshed token: %w", err)}
 	}
 
 	// Update the cookies.
 	err = o.setCookies(w, secureCookie, sessionID, idToken, tokens.RefreshToken, false)
 	if err != nil {
-		return "", fmt.Errorf("Failed to update login cookies: %w", err)
+		return nil, fmt.Errorf("Failed to update login cookies: %w", err)
 	}
 
-	return claims.Subject, nil
+	return &AuthenticationResult{
+		IdentityType:           api.IdentityTypeOIDCClient,
+		Subject:                claims.Subject,
+		Email:                  claims.Email,
+		IdentityProviderGroups: o.getGroupsFromClaims(claims.Claims),
+	}, nil
 }
 
 // getGroupsFromClaims attempts to get the configured groups claim from the token claims and warns if it is not present

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -70,7 +70,8 @@ type AuthenticationResult struct {
 	IdentityProviderGroups []string
 }
 
-// AuthError represents an authentication error.
+// AuthError represents an authentication error. If an error of this type is returned, the caller should call
+// WriteHeaders on the response so that the client has the necessary information to log in using the device flow.
 type AuthError struct {
 	Err error
 }
@@ -108,7 +109,7 @@ func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		//    Authorization Bearer <access_token>
 		parts := strings.Split(authorizationHeader, "Bearer ")
 		if len(parts) != 2 {
-			return nil, &AuthError{fmt.Errorf("Bad authorization token, expected a Bearer token")}
+			return nil, AuthError{fmt.Errorf("Bad authorization token, expected a Bearer token")}
 		}
 
 		// Bearer tokens should always be access tokens.
@@ -205,7 +206,7 @@ func (o *Verifier) authenticateIDToken(ctx context.Context, w http.ResponseWrite
 	// Update the cookies.
 	err = o.setCookies(w, secureCookie, sessionID, idToken, tokens.RefreshToken, false)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to update login cookies: %w", err)
+		return nil, AuthError{fmt.Errorf("Failed to update login cookies: %w", err)}
 	}
 
 	return &AuthenticationResult{

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -236,6 +236,7 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	w.Header().Set("X-LXD-OIDC-issuer", o.issuer)
 	w.Header().Set("X-LXD-OIDC-clientid", o.clientID)
 	w.Header().Set("X-LXD-OIDC-audience", o.audience)
+	w.Header().Set("X-LXD-OIDC-groups-claim", o.groupsClaim)
 
 	return nil
 }

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -46,6 +46,7 @@ type Verifier struct {
 	clientID    string
 	issuer      string
 	audience    string
+	groupsClaim string
 	clusterCert func() *shared.CertInfo
 
 	// host is used for setting a valid callback URL when setting the relyingParty.
@@ -504,6 +505,7 @@ func (o *Verifier) secureCookieFromSession(sessionID uuid.UUID) (*securecookie.S
 // Opts contains optional configurable fields for the Verifier.
 type Opts struct {
 	ConfigExpiryInterval time.Duration
+	GroupsClaim          string
 }
 
 // NewVerifier returns a Verifier.
@@ -514,12 +516,14 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 
 	if options != nil {
 		opts.ConfigExpiryInterval = options.ConfigExpiryInterval
+		opts.GroupsClaim = options.GroupsClaim
 	}
 
 	verifier := &Verifier{
 		issuer:               issuer,
 		clientID:             clientID,
 		audience:             audience,
+		groupsClaim:          opts.GroupsClaim,
 		clusterCert:          clusterCert,
 		configExpiryInterval: opts.ConfigExpiryInterval,
 	}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -318,6 +318,9 @@ func (o *Verifier) setRelyingParty(host string) error {
 	}
 
 	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail}
+	if o.groupsClaim != "" {
+		oidcScopes = append(oidcScopes, o.groupsClaim)
+	}
 
 	relyingParty, err := rp.NewRelyingPartyOIDC(o.issuer, o.clientID, "", fmt.Sprintf("https://%s/oidc/callback", host), oidcScopes, options...)
 	if err != nil {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -410,7 +410,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check if the user is already trusted.
-	trusted, _, _, err := d.Authenticate(nil, r)
+	trusted, _, _, _, err := d.Authenticate(nil, r)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -227,8 +227,8 @@ func (c *Config) RemoteTokenExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, audience string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience")
+func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string) {
+	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the
@@ -674,6 +674,16 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: Expected audience value for the application
 	"oidc.audience": {},
 
+	// lxdmeta:generate(entities=server; group=oidc; key=oidc.groups.claim)
+	// Specify a custom claim to be requested when performing OIDC flows.
+	// Configure a corresponding custom claim in your identity provider and
+	// add organization level groups to it. These can be mapped to LXD groups
+	// for automatic access control.
+	// ---
+	//  type: string
+	//  scope: global
+	//  shortdesc: Expected audience value for the application
+	"oidc.groups.claim": {},
 	// OVN networking global keys.
 
 	// lxdmeta:generate(entities=server; group=miscellaneous; key=network.ovn.integration_bridge)

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -65,6 +66,17 @@ func Connect(address string, networkCert *shared.CertInfo, serverCert *shared.Ce
 			}
 
 			req.Header.Add(request.HeaderForwardedAddress, r.RemoteAddr)
+
+			identityProviderGroupsAny := ctx.Value(request.CtxIdentityProviderGroups)
+			if ok {
+				identityProviderGroups, ok := identityProviderGroupsAny.([]string)
+				if ok {
+					b, err := json.Marshal(identityProviderGroups)
+					if err == nil {
+						req.Header.Add(request.HeaderForwardedIdentityProviderGroups, string(b))
+					}
+				}
+			}
 
 			return shared.ProxyFromEnvironment(req)
 		}

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -160,22 +160,22 @@ func ConnectIfVolumeIsRemote(s *state.State, poolName string, projectName string
 			return nil, fmt.Errorf("Failed checking if volume %q is available: %w", volumeName, err)
 		}
 
-		if remoteInstance != nil {
-			var instNode db.NodeInfo
-			err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-				instNode, err = tx.GetNodeByName(ctx, remoteInstance.Node)
-				return err
-			})
-			if err != nil {
-				return nil, fmt.Errorf("Failed getting cluster member info for %q: %w", remoteInstance.Node, err)
-			}
-
-			// Replace node list with instance's cluster member node (which might be local member).
-			nodes = []db.NodeInfo{instNode}
-		} else {
+		if remoteInstance == nil {
 			// Volume isn't exclusively attached to an instance. Use local cluster member.
 			return nil, nil
 		}
+
+		var instNode db.NodeInfo
+		err = s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+			instNode, err = tx.GetNodeByName(ctx, remoteInstance.Node)
+			return err
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting cluster member info for %q: %w", remoteInstance.Node, err)
+		}
+
+		// Replace node list with instance's cluster member node (which might be local member).
+		nodes = []db.NodeInfo{instNode}
 	}
 
 	nodeCount := len(nodes)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1264,7 +1264,7 @@ func (d *Daemon) init() error {
 	maasAPIURL, maasAPIKey = d.globalConfig.MAASController()
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiLabels, lokiLoglevel, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcAudience := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
 
@@ -1288,7 +1288,7 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, nil)
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -514,6 +515,16 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 				ctx = context.WithValue(ctx, request.CtxForwardedAddress, r.Header.Get(request.HeaderForwardedAddress))
 				ctx = context.WithValue(ctx, request.CtxForwardedUsername, r.Header.Get(request.HeaderForwardedUsername))
 				ctx = context.WithValue(ctx, request.CtxForwardedProtocol, r.Header.Get(request.HeaderForwardedProtocol))
+				forwardedIdentityProviderGroupsJSON := r.Header.Get(request.HeaderForwardedIdentityProviderGroups)
+				if forwardedIdentityProviderGroupsJSON != "" {
+					var forwardedIdentityProviderGroups []string
+					err = json.Unmarshal([]byte(forwardedIdentityProviderGroupsJSON), &forwardedIdentityProviderGroups)
+					if err != nil {
+						logger.Error("Failed unmarshalling identity provider groups from forwarded request header", logger.Ctx{"error": err})
+					} else {
+						ctx = context.WithValue(ctx, request.CtxForwardedIdentityProviderGroups, forwardedIdentityProviderGroups)
+					}
+				}
 			}
 
 			r = r.WithContext(ctx)

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -109,6 +109,7 @@ const (
 	identityTypeCertificateClientUnrestricted int64 = 2
 	identityTypeCertificateServer             int64 = 3
 	identityTypeCertificateMetrics            int64 = 4
+	identityTypeOIDCClient                    int64 = 5
 )
 
 // Scan implements sql.Scanner for IdentityType. This converts the integer value back into the correct API constant or
@@ -137,6 +138,8 @@ func (i *IdentityType) Scan(value any) error {
 		*i = api.IdentityTypeCertificateServer
 	case identityTypeCertificateMetrics:
 		*i = api.IdentityTypeCertificateMetrics
+	case identityTypeOIDCClient:
+		*i = api.IdentityTypeOIDCClient
 	default:
 		return fmt.Errorf("Unknown identity type `%d`", identityTypeInt)
 	}
@@ -155,6 +158,8 @@ func (i IdentityType) Value() (driver.Value, error) {
 		return identityTypeCertificateServer, nil
 	case api.IdentityTypeCertificateMetrics:
 		return identityTypeCertificateMetrics, nil
+	case api.IdentityTypeOIDCClient:
+		return identityTypeOIDCClient, nil
 	}
 
 	return nil, fmt.Errorf("Invalid identity type %q", i)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1923,6 +1923,14 @@
 						}
 					},
 					{
+						"oidc.groups.claim": {
+							"longdesc": "Specify a custom claim to be requested when performing OIDC flows.\nConfigure a corresponding custom claim in your identity provider and\nadd organization level groups to it. These can be mapped to LXD groups\nfor automatic access control.",
+							"scope": "global",
+							"shortdesc": "Expected audience value for the application",
+							"type": "string"
+						}
+					},
+					{
 						"oidc.issuer": {
 							"longdesc": "",
 							"scope": "global",

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -915,7 +915,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 
 	secret := r.FormValue("secret")
 
-	trusted, _, _, _ := d.Authenticate(nil, r)
+	trusted, _, _, _, _ := d.Authenticate(nil, r)
 	if !trusted && secret == "" {
 		return response.Forbidden(nil)
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1014,6 +1014,7 @@ type operationWebSocket struct {
 	op  *operations.Operation
 }
 
+// Render implements response.Response for operationWebSocket.
 func (r *operationWebSocket) Render(w http.ResponseWriter) error {
 	chanErr, err := r.op.Connect(r.req, w)
 	if err != nil {
@@ -1024,6 +1025,7 @@ func (r *operationWebSocket) Render(w http.ResponseWriter) error {
 	return err
 }
 
+// String implements fmt.Stringer for operationWebSocket.
 func (r *operationWebSocket) String() string {
 	_, md, err := r.op.Render()
 	if err != nil {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -65,7 +65,7 @@ func waitForOperations(ctx context.Context, cluster *db.Cluster, consoleShutdown
 				logger.Error("Failed cleaning up operations")
 			}
 
-			return nil
+			return nil //nolint:revive // False positive: raises "return in a defer function has no effect".
 		})
 	}()
 

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -20,6 +20,10 @@ const (
 	// CtxProtocol is the protocol field in request context.
 	CtxProtocol CtxKey = "protocol"
 
+	// CtxIdentityProviderGroups is the identity provider groups field in the request context.
+	// This contains groups defined by the identity provider if the identity authenticated with OIDC.
+	CtxIdentityProviderGroups CtxKey = "identity_provider_groups"
+
 	// CtxForwardedAddress is the forwarded address field in request context.
 	CtxForwardedAddress CtxKey = "forwarded_address"
 
@@ -28,6 +32,11 @@ const (
 
 	// CtxForwardedProtocol is the forwarded protocol field in request context.
 	CtxForwardedProtocol CtxKey = "forwarded_protocol"
+
+	// CtxForwardedIdentityProviderGroups is the identity provider groups field in the request context.
+	// This contains groups defined by the identity provider if the identity authenticated with OIDC on another cluster
+	// member.
+	CtxForwardedIdentityProviderGroups CtxKey = "identity_provider_groups"
 )
 
 // Headers.
@@ -40,4 +49,8 @@ const (
 
 	// HeaderForwardedProtocol is the forwarded protocol field in request header.
 	HeaderForwardedProtocol = "X-LXD-forwarded-protocol"
+
+	// HeaderForwardedIdentityProviderGroups is the forwarded identity provider groups field in request header.
+	// This will be a JSON marshalled []string.
+	HeaderForwardedIdentityProviderGroups = "X-LXD-forwarded-identity-provider-groups"
 )

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -20,4 +20,7 @@ const (
 
 	// IdentityTypeCertificateMetrics represents identities that may only view metrics.
 	IdentityTypeCertificateMetrics = "Metrics certificate"
+
+	// IdentityTypeOIDCClient represents an identity that authenticates with OIDC..
+	IdentityTypeOIDCClient = "OIDC client"
 )

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -392,6 +392,7 @@ var APIExtensions = []string{
 	"server_instance_type_info",
 	"resources_disk_mounted",
 	"server_version_lts",
+	"oidc_groups_claim",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -11,12 +11,14 @@ test_oidc() {
 
   BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
   [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "unknown" ]
+  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'unknown' AND auth_method = 2" | wc -l)" = 5 ]
   lxc remote remove oidc
 
   set_oidc test-user
 
   BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
   [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "test-user" ]
+  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'test-user' AND auth_method = 2" | wc -l)" = 5 ]
   lxc remote remove oidc
 
   # Cleanup OIDC


### PR DESCRIPTION
This PR adds a new server configuration key `oidc.groups_claim`. If set, the value of this config key is:
1. Added to the `scope` of the Authorization Code Flow (UI).
2. Sent to the client as an `X-LXD-OIDC-groups-claim` header, to be added to the scope for the Device Authorization Grant Flow (CLI).
3. The value of the claim represents the groups that the identity is a member of at the identity provider level. It is extracted from both identity tokens (UI) and access tokens (CLI) and is expected to be a string slice.
4. Identity provider groups are added to the request context.
5. Identity provider groups are forwarded to other cluster members in the `X-LXD-forwarded-identity-provider-groups` header. The value of this header is a JSON encoded string.
6. Forwarded identity provider groups are also added to the request context.

#12816 must be merged first.