### PR TITLE
simplestreams: Fix regression when parsing indexes that contain both combined and non-combined variants

### DIFF
--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -279,8 +279,6 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 					if err != nil {
 						continue
 					}
-
-					break // Stop at first compatible item found.
 				} else if shared.ValueInSlice(item.FileType, lxdCompatItems) {
 					// Locate the root files
 					for _, subItem := range version.Items {
@@ -291,8 +289,6 @@ func (s *Products) ToLXD() ([]api.Image, map[string][][]string) {
 							}
 						}
 					}
-
-					break // Stop at first compatible item found.
 				}
 			}
 		}

--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -377,7 +377,7 @@ func (s *SimpleStreams) GetFiles(fingerprint string) (map[string]DownloadableFil
 		}
 	}
 
-	return nil, fmt.Errorf("Couldn't find the requested image")
+	return nil, fmt.Errorf("Couldn't find the requested image for fingerprint %q", fingerprint)
 }
 
 // ListAliases returns a list of image aliases for the provided image fingerprint.
@@ -501,9 +501,9 @@ func (s *SimpleStreams) GetImage(fingerprint string) (*api.Image, error) {
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("The requested image couldn't be found")
+		return nil, fmt.Errorf("The requested image couldn't be found for fingerprint %q", fingerprint)
 	} else if len(matches) > 1 {
-		return nil, fmt.Errorf("More than one match for the provided partial fingerprint")
+		return nil, fmt.Errorf("More than one match for the provided partial fingerprint %q", fingerprint)
 	}
 
 	return &matches[0], nil


### PR DESCRIPTION
When support for Incus images was added in https://github.com/canonical/lxd/pull/12260 at the time the LinuxContainers remote contained both LXD and Incus entries and so a fix was added to stop searching for a file when a compatible one had been found during the parsing of the simplestreams index.

However this caused a bug when parsing the remote index for https://cloud-images.ubuntu.com/buildd/daily/streams/v1/com.ubuntu.cloud:daily:download.json because it contains both combined and non-combined image files for LXD.

In principle stopping after the first compatible image was found makes sense and is more efficient.
However LXD parses the simplestreams index (albeit cached) multiple times during a single image resolution process (once to convert alias to fingerprint and again to find the files for the fingerprint) and this causes LXD to call `(s *Products) ToLXD() ` multiple times.

Compounding this issue is that Go iterates maps in random order and so the issue only presented itself intermittently, depending on how Go iterate the simplestreams `version` map on each call to `(s *Products) ToLXD() `.

Since then the LinuxContainers remote has started blocking LXD users anyway, so support for Incus images was removed in https://github.com/canonical/lxd/pull/12748 and so we have no need for the original fix.

This PR reverts the fix and improves the logging.

