### PR TITLE
Doc: Add API instructions to instances how-tos

### DIFF
--- a/doc/.sphinx/spellingcheck.yaml
+++ b/doc/.sphinx/spellingcheck.yaml
@@ -26,3 +26,4 @@ matrix:
       - div.visually-hidden
       - img
       - a.p-navigation__link
+      - kbd

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -67,7 +67,7 @@ To configure `cloud-init` for an instance, add the corresponding configuration o
 
 When configuring `cloud-init` directly for an instance, keep in mind that `cloud-init` runs only on the first start of the instance.
 That means that you must configure `cloud-init` before you start the instance.
-To do so, create the instance with [`lxc init`](lxc_init.md) instead of [`lxc launch`](lxc_launch.md), and then start it after completing the configuration.
+If you are using the CLI client, create the instance with [`lxc init`](lxc_init.md) instead of [`lxc launch`](lxc_launch.md), and then start it after completing the configuration.
 
 ### YAML format for `cloud-init` configuration
 
@@ -91,6 +91,35 @@ config:
 ```{tip}
 See {ref}`How to validate user data <cloud-init:check_user_data_cloud_config>` for information on how to check whether the syntax is correct.
 ```
+
+### Configure `cloud-init` through the API
+
+If you are using the API to configure your instance, provide the `cloud-init` configuration as a string with escaped newline characters.
+
+For example:
+
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "config": {
+        "cloud-init.user-data": "#cloud-config\npackage_upgrade: true\npackages:\n  - package1\n  - package2"
+      }
+    }'
+
+Alternatively, to avoid mistakes, write the configuration to a file and include that in your request.
+For example, create `cloud-init.txt` with the following content:
+
+    #cloud-config
+    package_upgrade: true
+    packages:
+      - package1
+      - package2
+
+Then send the following request:
+
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+    "config": {
+      "cloud-init.user-data": "'"$(awk -v ORS='\\n' '1' cloud-init.txt)"'"
+      }
+    }'
 
 ## How to check the `cloud-init` status
 

--- a/doc/howto/instances_access_files.md
+++ b/doc/howto/instances_access_files.md
@@ -10,27 +10,49 @@ For virtual machines, the `lxd-agent` process must be running inside of the virt
 
 ## Edit instance files
 
+`````{tabs}
+````{group-tab} CLI
 To edit an instance file from your local machine, enter the following command:
 
     lxc file edit <instance_name>/<path_to_file>
 
 For example, to edit the `/etc/hosts` file in the instance, enter the following command:
 
-    lxc file edit my-container/etc/hosts
+    lxc file edit my-instance/etc/hosts
 
 ```{note}
 The file must already exist on the instance.
 You cannot use the `edit` command to create a file on the instance.
 ```
+````
+````{group-tab} API
+There is no API endpoint that lets you edit files directly on an instance.
+Instead, you need to {ref}`pull the content of the file from the instance <instances-access-files-pull>`, edit it, and then {ref}`push the modified content back to the instance <instances-access-files-push>`.
+````
+`````
 
 ## Delete files from the instance
 
+````{tabs}
+```{group-tab} CLI
 To delete a file from your instance, enter the following command:
 
     lxc file delete <instance_name>/<path_to_file>
+```
+```{group-tab} API
+Send the following DELETE request to delete a file from your instance:
 
+    lxc query --request DELETE /1.0/instances/<instance_name>/files?path=<path_to_file>
+
+See [`DELETE /1.0/instances/{name}/files`](swagger:/instances/instance_files_delete) for more information.
+```
+````
+
+(instances-access-files-pull)=
 ## Pull files from the instance to the local machine
 
+````{tabs}
+```{group-tab} CLI
 To pull a file from your instance to your local machine, enter the following command:
 
     lxc file pull <instance_name>/<path_to_file> <local_file_path>
@@ -47,9 +69,37 @@ This can be useful, for example, to check a log file:
 To pull a directory with all contents, enter the following command:
 
     lxc file pull -r <instance_name>/<path_to_directory> <local_location>
+```
+```{group-tab} API
+Send the following request to pull the contents of a file from your instance to your local machine:
 
+    lxc query --request GET /1.0/instances/<instance_name>/files?path=<path_to_file>
+
+You can then write the contents to a local file, or pipe them to stdin of another command.
+
+For example, to pull the contents of the `/etc/hosts` file and write them to a `my-instance-hosts` file in the current directory, enter the following command:
+
+    lxc query --request GET /1.0/instances/my-instance/files?path=/etc/hosts > my-instance-hosts
+
+To examine a log file, enter the following command:
+
+    lxc query --request GET /1.0/instances/<instance_name>/files?path=<file_path> | less
+
+To pull the contents of a directory, send the following request:
+
+    lxc query --request GET /1.0/instances/<instance_name>/files?path=<path_to_directory>
+
+This request returns a list of files in the directory, and you can then pull the contents of each file.
+
+See [`GET /1.0/instances/{name}/files`](swagger:/instances/instance_files_get) for more information.
+```
+````
+
+(instances-access-files-push)=
 ## Push files from the local machine to the instance
 
+````{tabs}
+```{group-tab} CLI
 To push a file from your local machine to your instance, enter the following command:
 
     lxc file push <local_file_path> <instance_name>/<path_to_file>
@@ -57,9 +107,27 @@ To push a file from your local machine to your instance, enter the following com
 To push a directory with all contents, enter the following command:
 
     lxc file push -r <local_location> <instance_name>/<path_to_directory>
+```
+```{group-tab} API
+Send the following request to write content to a file on your instance:
+
+    lxc query --request POST /1.0/instances/<instance_name>/files?path=<path_to_file> --data <content>
+
+See [`POST /1.0/instances/{name}/files`](swagger:/instances/instance_files_post) for more information.
+
+To push content directly from a file, you must use a tool that can send raw data from a file, which [`lxc query`](lxc_query.md) does not support.
+For example, with curl:
+
+    curl -X POST -H "Content-Type: application/octet-stream" --data @<local_file_path> \
+    --unix-socket /var/snap/lxd/common/lxd/unix.socket \
+    lxd/1.0/instances/<instance_name>/files?path=<path_to_file>
+```
+````
 
 ## Mount a file system from the instance
 
+`````{tabs}
+````{group-tab} CLI
 You can mount an instance file system into a local path on your client.
 
 To do so, make sure that you have `sshfs` installed.
@@ -111,3 +179,8 @@ For example:
     sshfs xFn8ai8c@127.0.0.1:/home my-instance-files -p 35147
 
 You can then access the file system of your instance at the specified location on the local machine.
+````
+````{group-tab} API
+Mounting a file system is not directly supported through the API, but requires additional processing logic on the client side.
+````
+`````

--- a/doc/howto/instances_backup.md
+++ b/doc/howto/instances_backup.md
@@ -41,6 +41,8 @@ Instance snapshots are stored in the same storage pool as the instance volume it
 
 ### Create a snapshot
 
+`````{tabs}
+````{group-tab} CLI
 Use the following command to create a snapshot of an instance:
 
     lxc snapshot <instance_name> [<snapshot name>]
@@ -53,9 +55,33 @@ Use the following command to create a snapshot of an instance:
 
 For virtual machines, you can add the `--stateful` flag to capture not only the data included in the instance volume but also the running state of the instance.
 Note that this feature is not fully supported for containers because of CRIU limitations.
+````
+````{group-tab} API
+To create a snapshot of an instance, send a POST request to the `snapshots` endpoint:
 
+    lxc query --request POST /1.0/instances/<instance_name>/snapshots --data '{"name": "<snapshot_name>"}'
+
+The snapshot name is optional.
+If you set it to an empty string, the name follows the naming pattern defined in {config:option}`instance-snapshots:snapshots.pattern`.
+
+By default, snapshots are kept forever, unless the {config:option}`instance-snapshots:snapshots.expiry` configuration option is set.
+To set an expiration date, add the`expires_at` field to the request data.
+To retain a specific snapshot even if a general expiry time is set, set the `expires_at` field to `"0001-01-01T00:00:00Z"`.
+
+If you want to replace an existing snapshot, {ref}`delete it <instances-snapshots-delete>` first and then create another snapshot with the same name.
+
+For virtual machines, you can add `"stateful": true` to the request data to capture not only the data included in the instance volume but also the running state of the instance.
+Note that this feature is not fully supported for containers because of CRIU limitations.
+
+See [`POST /1.0/instances/{name}/snapshots`](swagger:/instances/instance_snapshots_post) for more information.
+````
+`````
+
+(instances-snapshots-delete)=
 ### View, edit or delete snapshots
 
+`````{tabs}
+````{group-tab} CLI
 Use the following command to display the snapshots for an instance:
 
     lxc info <instance_name>
@@ -79,19 +105,71 @@ Other changes to the configuration are silently ignored.
 To delete a snapshot, use the following command:
 
     lxc delete <instance_name>/<snapshot_name>
+````
+````{group-tab} API
+To retrieve the snapshots for an instance, send a GET request to the `snapshots` endpoint:
+
+    lxc query --request GET /1.0/instances/<instance_name>/snapshots
+
+To show configuration information about a snapshot, send the following request:
+
+    lxc query --request GET /1.0/instances/<instance_name>/snapshots/<snapshot_name>
+
+To change the expiry date of a snapshot, send a PATCH request:
+
+    lxc query --request PATCH /1.0/instances/<instance_name>/snapshots/<snapshot_name> --data '{
+      "expires_at": "2029-03-23T17:38:37.753398689-04:00"
+    }'
+
+```{note}
+In general, snapshots cannot be modified, because they preserve the state of the instance.
+The only exception is the expiry date.
+Other changes to the configuration are silently ignored.
+```
+
+To delete a snapshot, send a DELETE request:
+
+    lxc query --request DELETE /1.0/instances/<instance_name>/snapshots/<snapshot_name>
+
+See [`GET /1.0/instances/{name}/snapshots`](swagger:/instances/instance_snapshots_get), [`GET /1.0/instances/{name}/snapshots/{snapshot}`](swagger:/instances/instance_snapshot_get), [`PATCH /1.0/instances/{name}/snapshots/{snapshot}`](swagger:/instances/instance_snapshot_patch), and [`DELETE /1.0/instances/{name}/snapshots/{snapshot}`](swagger:/instances/instance_snapshot_delete) for more information.
+
+````
+`````
 
 ### Schedule instance snapshots
 
 You can configure an instance to automatically create snapshots at specific times (at most once every minute).
 To do so, set the {config:option}`instance-snapshots:snapshots.schedule` instance option.
 
-For example, to configure daily snapshots, use the following command:
+For example, to configure daily snapshots:
 
+````{tabs}
+```{group-tab} CLI
     lxc config set <instance_name> snapshots.schedule @daily
+```
+```{group-tab} API
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "config": {
+        "snapshots.schedule": "@daily"
+      }
+    }'
+```
+````
 
-To configure taking a snapshot every day at 6 am, use the following command:
+To configure taking a snapshot every day at 6 am:
 
+````{tabs}
+```{group-tab} CLI
     lxc config set <instance_name> snapshots.schedule "0 6 * * *"
+```
+```{group-tab} API
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "config": {
+        "snapshots.schedule": "0 6 * * *"
+      }
+    }'
+```
+````
 
 When scheduling regular snapshots, consider setting an automatic expiry ({config:option}`instance-snapshots:snapshots.expiry`) and a naming pattern for snapshots ({config:option}`instance-snapshots:snapshots.pattern`).
 You should also configure whether you want to take snapshots of instances that are not running ({config:option}`instance-snapshots:snapshots.schedule.stopped`).
@@ -100,11 +178,31 @@ You should also configure whether you want to take snapshots of instances that a
 
 You can restore an instance to any of its snapshots.
 
-To do so, use the following command:
+````{tabs}
+```{group-tab} CLI
+To restore an instance to a snapshot, use the following command:
 
     lxc restore <instance_name> <snapshot_name>
 
 If the snapshot is stateful (which means that it contains information about the running state of the instance), you can add the `--stateful` flag to restore the state.
+```
+```{group-tab} API
+To restore an instance to a snapshot, send a PUT request to the instance:
+
+    lxc query --request PUT /1.0/instances/<instance_name> --data '{
+      "restore": "<instance_name>/<snapshot_name>"
+    }'
+
+If the snapshot is stateful (which means that it contains information about the running state of the instance), you can add `"stateful": true` to the request data:
+
+    lxc query --request PUT /1.0/instances/<instance_name> --data '{
+      "restore": "<instance_name>/<snapshot_name>",
+      "stateful": true
+    }'
+
+See [`PUT /1.0/instances/{name}`](swagger:/instances/instance_put) for more information.
+```
+````
 
 (instances-backup-export)=
 ## Use export files for instance backup
@@ -114,6 +212,8 @@ For highest reliability, store the backup file on a different file system to ens
 
 ### Export an instance
 
+`````{tabs}
+````{group-tab} CLI
 Use the following command to export an instance to a compressed file (for example, `/path/to/my-instance.tgz`):
 
     lxc export <instance_name> [<file_path>]
@@ -134,16 +234,69 @@ If the output file (`<instance_name>.<extension>` or the specified file path) al
 : By default, the export file contains all snapshots of the instance.
   Add this flag to export the instance without its snapshots.
 
+````
+````{group-tab} API
+To create a backup of an instance, send a POST request to the `backups` endpoint:
+
+    lxc query --request POST /1.0/instances/<instance_name>/backups --data '{"name": ""}'
+
+You can specify a name for the backup, or use the default (`backup0`, `backup1` and so on).
+
+You can add any of the following fields to the request data:
+
+`"compression_algorithm": "bzip2"`
+: By default, the output file uses `gzip` compression.
+  You can specify a different compression algorithm (for example, `bzip2`) or turn off compression with `none`.
+
+`"optimized-storage": true`
+: If your storage pool uses the `btrfs` or the `zfs` driver, set the `"optimized-storage"` field to `true` to store the data as a driver-specific binary blob instead of an archive of individual files.
+  In this case, the backup can only be used with pools that use the same storage driver.
+
+  Exporting a volume in optimized mode is usually quicker than exporting the individual files.
+  Snapshots are exported as differences from the main volume, which decreases their size and makes them easily accessible.
+
+`"instance-only": true`
+: By default, the backup contains all snapshots of the instance.
+  Set this field to `true` to back up the instance without its snapshots.
+
+After creating the backup, you can download it with the following request:
+
+    lxc query --request GET /1.0/instances/<instance_name>/backups/<backup_name>/export > <file_name>
+
+Remember to delete the backup when you don't need it anymore:
+
+    lxc query --request DELETE /1.0/instances/<instance_name>/backups/<backup_name>
+
+See [`POST /1.0/instances/{name}/backups`](swagger:/instances/instance_backups_post), [`GET /1.0/instances/{name}/backups/{backup}/export`](swagger:/instances/instance_backup_export), and [`DELETE /1.0/instances/{name}/backups/{backup}`](swagger:/instances/instance_backup_delete) for more information.
+````
+`````
+
 ### Restore an instance from an export file
 
 You can import an export file (for example, `/path/to/my-backup.tgz`) as a new instance.
-To do so, use the following command:
+
+````{tabs}
+```{group-tab} CLI
+To import an export file, use the following command:
 
     lxc import <file_path> [<instance_name>]
 
 If you do not specify an instance name, the original name of the exported instance is used for the new instance.
 If an instance with that name already (or still) exists in the specified storage pool, the command returns an error.
 In that case, either delete the existing instance before importing the backup or specify a different instance name for the import.
+```
+```{group-tab} API
+To import an export file, post it to the `/1.0/instances` endpoint:
+
+    curl -X POST -H "Content-Type: application/octet-stream" -T <file_path> \
+    --unix-socket /var/snap/lxd/common/lxd/unix.socket lxd/1.0/instances
+
+If an instance with that name already (or still) exists in the specified storage pool, the command returns an error.
+In this case, delete the existing instance before importing the backup.
+
+See [`POST /1.0/instances`](swagger:/instances/instances_post) for more information.
+```
+````
 
 (instances-backup-copy)=
 ## Copy an instance to a backup server

--- a/doc/howto/instances_configure.md
+++ b/doc/howto/instances_configure.md
@@ -27,7 +27,12 @@ Specify the instance name and the key and value of the instance option:
 Send a PATCH request to the instance to update instance options.
 Specify the instance name and the key and value of the instance option:
 
-    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"config": {"<option_key>":"<option_value>","<option_key>":"<option_value>"}}'
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "config": {
+        "<option_key>": "<option_value>",
+        "<option_key>": "<option_value>"
+      }
+    }'
 
 See [`PATCH /1.0/instances/{name}`](swagger:/instances/instance_patch) for more information.
 ```
@@ -56,7 +61,11 @@ To set the memory limit to 8 GiB, enter the following command:
 ```{group-tab} API
 To set the memory limit to 8 GiB, send the following request:
 
-    lxc query --request PATCH /1.0/instances/my-container --data '{"config": {"limits.memory":"8GiB"}}'
+    lxc query --request PATCH /1.0/instances/my-container --data '{
+      "config": {
+        "limits.memory": "8GiB"
+      }
+    }'
 ```
 
 ```{group-tab} UI
@@ -101,7 +110,11 @@ The only difference is that properties are on the root level of the configuratio
 
 Therefore, to set an instance property, send a PATCH request to the instance:
 
-    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"<property_key>":"<property_value>","<property_key>":"property_value>"}}'
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "<property_key>": "<property_value>",
+      "<property_key>": "property_value>"
+      }
+    }'
 
 To unset an instance property, send a PUT request that contains the full instance configuration that you want except for the property that you want to unset.
 
@@ -163,11 +176,27 @@ The device configuration is located under the `devices` field of the configurati
 
 Specify the instance name, a device name, the device type and maybe device options (depending on the {ref}`device type <devices>`):
 
-    lxc query --request PATCH /1.0/instances/<instance_name> --data '{"devices": {"<device_name>": {"type":"<device_type>","<device_option_key>":"<device_option_value>","<device_option_key>":"device_option_value>"}}}'
+    lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+      "devices": {
+        "<device_name>": {
+          "type": "<device_type>",
+          "<device_option_key>": "<device_option_value>",
+          "<device_option_key>": "device_option_value>"
+        }
+      }
+    }'
 
 For example, to add the storage at `/share/c1` on the host system to your instance at path `/opt`, enter the following command:
 
-    lxc query --request PATCH /1.0/instances/my-container --data '{"devices": {"disk-storage-device": {"type":"disk","source":"/share/c1","path":"/opt"}}}'
+    lxc query --request PATCH /1.0/instances/my-container --data '{
+      "devices": {
+        "disk-storage-device": {
+          "type": "disk",
+          "source": "/share/c1",
+          "path": "/opt"
+        }
+      }
+    }'
 
 See [`PATCH /1.0/instances/{name}`](swagger:/instances/instance_patch) for more information.
 ````
@@ -200,7 +229,7 @@ To display the current configuration of your instance, including writable instan
 ```{group-tab} API
 To retrieve the current configuration of your instance, including writable instance properties, instance options, devices and device options, send a GET request to the instance:
 
-    lxc query /1.0/instances/<instance_name>
+    lxc query --request GET /1.0/instances/<instance_name>
 
 See [`GET /1.0/instances/{name}`](swagger:/instances/instance_get) for more information.
 ```

--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -5,14 +5,18 @@ discourse: 9223
 (instances-console)=
 # How to access the console
 
-Use the [`lxc console`](lxc_console.md) command to attach to instance consoles.
+You can access the instance console to log in to the instance and see log messages.
 The console is available at boot time already, so you can use it to see boot messages and, if necessary, debug startup issues of a container or VM.
 
+`````{tabs}
+````{group-tab} CLI
+
+Use the [`lxc console`](lxc_console.md) command to attach to instance consoles.
 To get an interactive console, enter the following command:
 
     lxc console <instance_name>
 
-To show log output, pass the `--show-log` flag:
+To show new log messages (only for containers), pass the `--show-log` flag:
 
     lxc console <instance_name> --show-log
 
@@ -20,6 +24,61 @@ You can also immediately attach to the console when you start your instance:
 
     lxc start <instance_name> --console
     lxc start <instance_name> --console=vga
+
+```{tip}
+To exit the console, enter {kbd}`Ctrl`+{kbd}`a` {kbd}`q`.
+```
+````
+````{group-tab} API
+
+To start an interactive console, send a POST request to the `console` endpoint:
+
+    lxc query --request POST /1.0/instances/<instance_name>/console --data '{
+      "height": 24,
+      "type": "console",
+      "width": 80
+    }'
+
+This query sets up two WebSockets that you can use for connection.
+One WebSocket is used for control, and the other transmits the actual console data.
+
+See [`POST /1.0/instances/{name}/console`](swagger:/instances/instance_console_post) for more information.
+
+To access the WebSockets, you need the operation ID and the secrets for each socket.
+This information is available in the operation started by the query, for example:
+
+    {
+      "class": "websocket",
+      "created_at": "2024-01-31T10:11:48.135150288Z",
+      "description": "Showing console",
+      "err": "",
+      "id": "<operation_ID>",
+      "location": "none",
+      "may_cancel": false,
+      "metadata": {
+        "fds": {
+          "0": "<data_socket_secret>",
+          "control": "<control_socket_secret>"
+        }
+      }
+    [...]
+    }
+
+How to connect to the WebSockets depends on the tooling that you use (see [`GET /1.0/operations/{id}/websocket`](swagger:/operations/operation_websocket_get) for general information).
+To quickly check whether the connection is successful and you can read from the socket, you can use a tool like [`websocat`](https://github.com/vi/websocat):
+
+    websocat --text \
+    --ws-c-uri=ws://unix.socket/1.0/operations/<operation_ID>/websocket?secret=<data_socket_secret> \
+    - ws-c:unix:/var/snap/lxd/common/lxd/unix.socket
+
+Alternatively, if you just want to retrieve new log messages from the console instead of connecting through a WebSocket, you can send a GET request to the `console` endpoint:
+
+    lxc query --request GET /1.0/instances/<instance_name>/console
+
+See [`GET /1.0/instances/{name}/console`](swagger:/instances/instance_console_get) for more information.
+Note that this operation is supported only for containers, not for VMs.
+````
+`````
 
 ## Access the graphical console (for virtual machines)
 
@@ -32,7 +91,22 @@ Using the console you can, for example, install an operating system using a grap
 An additional advantage is that the console is available even if the `lxd-agent` process is not running.
 This means that you can access the VM through the console before the `lxd-agent` starts up, and also if the `lxd-agent` is not available at all.
 
+````{tabs}
+```{group-tab} CLI
 To start the VGA console with graphical output for your VM, you must install a SPICE client (for example, `virt-viewer` or `spice-gtk-client`).
 Then enter the following command:
 
     lxc console <vm_name> --type vga
+```
+```{group-tab} API
+To start the VGA console with graphical output for your VM, send a POST request to the `console` endpoint:
+
+    lxc query --request POST /1.0/instances/<instance_name>/console --data '{
+      "height": 0,
+      "type": "vga",
+      "width": 0
+    }'
+
+See [`POST /1.0/instances/{name}/console`](swagger:/instances/instance_console_post) for more information.
+```
+````

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -1,38 +1,37 @@
 (instances-create)=
 # How to create instances
 
+When creating an instance, you must specify the {ref}`image <about-images>` on which the instance should be based.
+
+Images contain a basic operating system (for example, a Linux distribution) and some LXD-related information.
+Images for various operating systems are available on the built-in remote image servers.
+See {ref}`images` for more information.
+
+If you don't specify a name for the instance, LXD will automatically generate one.
+Instance names must be unique within a LXD deployment (also within a cluster).
+See {ref}`instance-name-requirements` for additional requirements.
+
+`````{tabs}
+````{group-tab} CLI
+
 To create an instance, you can use either the [`lxc init`](lxc_init.md) or the [`lxc launch`](lxc_launch.md) command.
 The [`lxc init`](lxc_init.md) command only creates the instance, while the [`lxc launch`](lxc_launch.md) command creates and starts it.
-
-## Usage
 
 Enter the following command to create a container:
 
     lxc launch|init <image_server>:<image_name> <instance_name> [flags]
 
-Image
-: Images contain a basic operating system (for example, a Linux distribution) and some LXD-related information.
-  Images for various operating systems are available on the built-in remote image servers.
-  See {ref}`images` for more information.
+Unless the image is available locally, you must specify the name of the image server and the name of the image (for example, `ubuntu:22.04` for the official 22.04 Ubuntu image).
 
-  Unless the image is available locally, you must specify the name of the image server and the name of the image (for example, `ubuntu:22.04` for the official 22.04 Ubuntu image).
+See [`lxc launch --help`](lxc_launch.md) or [`lxc init --help`](lxc_init.md) for a full list of flags.
+The most common flags are:
 
-Instance name
-: Instance names must be unique within a LXD deployment (also within a cluster).
-  See {ref}`instance-properties` for additional requirements.
-
-Flags
-: See [`lxc launch --help`](lxc_launch.md) or [`lxc init --help`](lxc_init.md) for a full list of flags.
-  The most common flags are:
-
-  - `--config` to specify a configuration option for the new instance
-  - `--device` to override {ref}`device options <devices>` for a device provided through a profile, or to specify an {ref}`initial configuration for the root disk device <devices-disk-initial-config>`
-  - `--profile` to specify a {ref}`profile <profiles>` to use for the new instance
-  - `--network` or `--storage` to make the new instance use a specific network or storage pool
-  - `--target` to create the instance on a specific cluster member
-  - `--vm` to create a virtual machine instead of a container
-
-## Pass a configuration file
+- `--config` to specify a configuration option for the new instance
+- `--device` to override {ref}`device options <devices>` for a device provided through a profile, or to specify an {ref}`initial configuration for the root disk device <devices-disk-initial-config>`
+- `--profile` to specify a {ref}`profile <profiles>` to use for the new instance
+- `--network` or `--storage` to make the new instance use a specific network or storage pool
+- `--target` to create the instance on a specific cluster member
+- `--vm` to create a virtual machine instead of a container
 
 Instead of specifying the instance configuration as flags, you can pass it to the command as a YAML file.
 
@@ -43,40 +42,165 @@ For example, to launch a container with the configuration from `config.yaml`, en
 ```{tip}
 Check the contents of an existing instance configuration ([`lxc config show <instance_name> --expanded`](lxc_config_show.md)) to see the required syntax of the YAML file.
 ```
+````
+
+````{group-tab} API
+To create an instance, send a POST request to the `/1.0/instances` endpoint:
+
+    lxc query --request POST /1.0/instances --data '{
+      "name": "<instance_name>",
+      "source": {
+        "alias": "<image_alias>",
+        "protocol": "simplestreams",
+        "server": "<server_URL>",
+        "type": "image"
+      }
+    }'
+
+The return value of this query contains an operation ID, which you can use to query the status of the operation:
+
+    lxc query --request GET /1.0/operations/<operation_ID>
+
+Use the following query to monitor the state of the instance:
+
+    lxc query --request GET /1.0/instances/<instance_name>/state
+
+See [`POST /1.0/instances`](swagger:/instances/instances_post) and [`GET /1.0/instances/{name}/state`](swagger:/instances/instance_state_get) for more information.
+
+The request creates the instance, but does not start it.
+To start an instance, send a PUT request to change the instance state:
+
+    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action": "start"}'
+
+See {ref}`instances-manage-start` for more information.
+
+````
+`````
 
 ## Examples
 
-The following examples use [`lxc launch`](lxc_launch.md), but you can use [`lxc init`](lxc_init.md) in the same way.
+The following examples create the instances, but don't start them.
+If you are using the CLI client, you can use [`lxc launch`](lxc_launch.md) instead of [`lxc init`](lxc_init.md) to automatically start them after creation.
 
-### Launch a container
+### Create a container
 
-To launch a container with an Ubuntu 22.04 image from the `ubuntu` server using the instance name `ubuntu-container`, enter the following command:
+To create a container with an Ubuntu 22.04 image from the `ubuntu` server using the instance name `ubuntu-container`, enter the following command:
 
-    lxc launch ubuntu:22.04 ubuntu-container
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 ubuntu-container
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "name": "ubuntu-container",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      }
+    }'
+```
+````
 
-### Launch a virtual machine
+### Create a virtual machine
 
-To launch a virtual machine with an Ubuntu 22.04 image from the `ubuntu` server using the instance name `ubuntu-vm`, enter the following command:
+To create a virtual machine with an Ubuntu 22.04 image from the `ubuntu` server using the instance name `ubuntu-vm`, enter the following command:
 
-    lxc launch ubuntu:22.04 ubuntu-vm --vm
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 ubuntu-vm --vm
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "name": "ubuntu-vm",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      },
+      "type": "virtual-machine"
+    }'
+```
+````
 
 Or with a bigger disk:
 
-    lxc launch ubuntu:22.04 ubuntu-vm-big --vm --device root,size=30GiB
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 ubuntu-vm-big --vm --device root,size=30GiB
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "devices": {
+        "root": {
+          "path": "/",
+          "pool": "default",
+          "size": "30GiB",
+          "type": "disk"
+        }
+      },
+      "name": "ubuntu-vm-big",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      },
+      "type": "virtual-machine"
+    }'
+```
+````
 
-### Launch a container with specific configuration options
+### Create a container with specific configuration options
 
-To launch a container and limit its resources to one vCPU and 192 MiB of RAM, enter the following command:
+To create a container and limit its resources to one vCPU and 192 MiB of RAM, enter the following command:
 
-    lxc launch ubuntu:22.04 ubuntu-limited --config limits.cpu=1 --config limits.memory=192MiB
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 ubuntu-limited --config limits.cpu=1 --config limits.memory=192MiB
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "config": {
+        "limits.cpu": "1",
+        "limits.memory": "192MiB"
+      },
+      "name": "ubuntu-limited",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      }
+    }'
+```
+````
 
-### Launch a VM on a specific cluster member
+### Create a VM on a specific cluster member
 
-To launch a virtual machine on the cluster member `server2`, enter the following command:
+To create a virtual machine on the cluster member `server2`, enter the following command:
 
-    lxc launch ubuntu:22.04 ubuntu-container --vm --target server2
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 ubuntu-vm-server2 --vm --target server2
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances?target=server2 --data '{
+      "name": "ubuntu-vm-server2",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      },
+      "type": "virtual-machine"
+    }'
+```
+````
 
-### Launch a container with a specific instance type
+### Create a container with a specific instance type
 
 LXD supports simple instance types for clouds.
 Those are represented as a string that can be passed at instance creation time.
@@ -93,9 +217,25 @@ For example, the following three instance types are equivalent:
 - `aws:t2.micro`
 - `c1-m1`
 
-To launch a container with this instance type, enter the following command:
+To create a container with this instance type, enter the following command:
 
-    lxc launch ubuntu:22.04 my-instance --type t2.micro
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 my-instance --type t2.micro
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "instance_type": "t2.micro",
+      "name": "my-instance",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      }
+    }'
+```
+````
 
 The list of supported clouds and instance types can be found here:
 
@@ -103,33 +243,116 @@ The list of supported clouds and instance types can be found here:
 - [Google Compute Engine](https://raw.githubusercontent.com/canonical/lxd/main/meta/instance-types/gce.yaml)
 - [Microsoft Azure](https://raw.githubusercontent.com/canonical/lxd/main/meta/instance-types/azure.yaml)
 
-### Launch a VM that boots from an ISO
+### Create a VM that boots from an ISO
 
-To launch a VM that boots from an ISO, you must first create a VM.
+To create a VM that boots from an ISO, you must first create a VM.
 Let's assume that we want to create a VM and install it from the ISO image.
 In this scenario, use the following command to create an empty VM:
 
+````{tabs}
+```{group-tab} CLI
     lxc init iso-vm --empty --vm
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "name": "iso-vm",
+      "source": {
+        "type": "none"
+      },
+      "type": "virtual-machine"
+    }'
+```
+````
 
 The second step is to import an ISO image that can later be attached to the VM as a storage volume:
 
+`````{tabs}
+````{group-tab} CLI
     lxc storage volume import <pool> <path-to-image.iso> iso-volume --type=iso
+````
+````{group-tab} API
+    curl -X POST -H "Content-Type: application/octet-stream" -H "X-LXD-name: iso-volume" \
+    -H "X-LXD-type: iso" --data-binary @<path-to-image.iso> --unix-socket /var/snap/lxd/common/lxd/unix.socket \
+    lxd/1.0/storage-pools/<pool>/volumes/custom
 
-Lastly, you need to attach the custom ISO volume to the VM using the following command:
+```{note}
+When importing an ISO image, you must send both binary data from a file and additional headers.
+The [`lxc query`](lxc_query.md) command cannot do this, so you need to use `curl` or another tool instead.
+```
+````
+`````
 
+Lastly, attach the custom ISO volume to the VM using the following command:
+
+````{tabs}
+```{group-tab} CLI
     lxc config device add iso-vm iso-volume disk pool=<pool> source=iso-volume boot.priority=10
+```
+```{group-tab} API
+    lxc query --request PATCH /1.0/instances/iso-vm --data '{
+      "devices": {
+        "iso-volume": {
+          "boot.priority": "10",
+          "pool": "<pool>",
+          "source": "iso-volume",
+          "type": "disk"
+        }
+      }
+    }'
+```
+````
 
 The `boot.priority` configuration key ensures that the VM will boot from the ISO first.
-Start the VM and connect to the console as there might be a menu you need to interact with:
+Start the VM and {ref}`connect to the console <instances-console>` as there might be a menu you need to interact with:
 
+````{tabs}
+```{group-tab} CLI
     lxc start iso-vm --console
+```
+```{group-tab} API
+    lxc query --request PUT /1.0/instances/iso-vm/state --data '{"action": "start"}'
+    lxc query --request POST /1.0/instances/iso-vm/console --data '{
+      "height": 24,
+      "type": "console",
+      "width": 80
+    }'
+```
+````
 
-Once you're done in the serial console, you need to disconnect from the console using `ctrl+a-q`, and connect to the VGA console using the following command:
+Once you're done in the serial console, disconnect from the console using {kbd}`Ctrl`+{kbd}`a` {kbd}`q` and {ref}`connect to the VGA console <instances-console>` using the following command:
 
+````{tabs}
+```{group-tab} CLI
     lxc console iso-vm --type=vga
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances/iso-vm/console --data '{
+      "height": 24,
+      "type": "vga",
+      "width": 80
+    }'
+```
+````
 
-You should now see the installer. After the installation is done, you need to detach the custom ISO volume:
+You should now see the installer. After the installation is done, detach the custom ISO volume:
 
+`````{tabs}
+````{group-tab} CLI
     lxc storage volume detach <pool> iso-volume iso-vm
+````
+````{group-tab} API
+    lxc query --request GET /1.0/instances/iso-vm
+    lxc query --request PUT /1.0/instances/iso-vm --data '{
+      [...]
+      "devices": {}
+      [...]
+    }'
+
+```{note}
+You cannot remove the device through a PATCH request, but you must use a PUT request.
+Therefore, get the current configuration first and then provide the relevant configuration with an empty devices list through the PUT request.
+```
+````
+`````
 
 Now the VM can be rebooted, and it will boot from disk.

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -84,6 +84,7 @@ Click the instance name to go to the instance detail page, which contains detail
 ```
 ````
 
+(instances-manage-start)=
 ## Start an instance
 
 ````{tabs}

--- a/doc/howto/instances_manage.md
+++ b/doc/howto/instances_manage.md
@@ -29,19 +29,19 @@ Enter [`lxc list --help`](lxc_list.md) to see all filter options.
 Query the `/1.0/instances` endpoint to list all instances.
 You can use {ref}`rest-api-recursion` to display more information about the instances:
 
-    lxc query /1.0/instances?recursion=2
+    lxc query --request GET /1.0/instances?recursion=2
 
 You can {ref}`filter <rest-api-filtering>` the instances that are displayed, by name, type, status or the cluster member where the instance is located:
 
-    lxc query /1.0/instances?filter=name+eq+ubuntu
-    lxc query /1.0/instances?filter=type+eq+container
-    lxc query /1.0/instances?filter=status+eq+running
-    lxc query /1.0/instances?filter=location+eq+server1
+    lxc query --request GET /1.0/instances?filter=name+eq+ubuntu
+    lxc query --request GET /1.0/instances?filter=type+eq+container
+    lxc query --request GET /1.0/instances?filter=status+eq+running
+    lxc query --request GET /1.0/instances?filter=location+eq+server1
 
 To list several instances, use a regular expression for the name.
 For example:
 
-    lxc query /1.0/instances?filter=name+eq+ubuntu.*
+    lxc query --request GET /1.0/instances?filter=name+eq+ubuntu.*
 
 See [`GET /1.0/instances`](swagger:/instances/instances_get) for more information.
 ```
@@ -72,7 +72,7 @@ Add `--show-log` to the command to show the latest log lines for the instance:
 ```{group-tab} API
 Query the following endpoint to show detailed information about an instance:
 
-    lxc query /1.0/instances/<instance_name>
+    lxc query --request GET /1.0/instances/<instance_name>
 
 See [`GET /1.0/instances/{name}`](swagger:/instances/instance_get) for more information.
 ```
@@ -106,16 +106,16 @@ See {ref}`instances-console` for more information.
 ```{group-tab} API
 To start an instance, send a PUT request to change the instance state:
 
-    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action":"start"}'
+    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action": "start"}'
 
 <!-- Include start monitor status -->
 The return value of this query contains an operation ID, which you can use to query the status of the operation:
 
-    lxc query /1.0/operations/<operation_ID>
+    lxc query --request GET /1.0/operations/<operation_ID>
 
 Use the following query to monitor the state of the instance:
 
-    lxc query /1.0/instances/<instance_name>/state
+    lxc query --request GET /1.0/instances/<instance_name>/state
 
 See [`GET /1.0/instances/{name}/state`](swagger:/instances/instance_state_get) and [`PUT /1.0/instances/{name}/state`](swagger:/instances/instance_state_put)for more information.
 <!-- Include end monitor status -->
@@ -146,7 +146,7 @@ You will get an error if the instance does not exist or if it is not running.
 ````{group-tab} API
 To stop an instance, send a PUT request to change the instance state:
 
-    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action":"stop"}'
+    lxc query --request PUT /1.0/instances/<instance_name>/state --data '{"action": "stop"}'
 
 % Include content from above
 ```{include} ./instances_manage.md
@@ -246,11 +246,21 @@ For more information about the `rebuild` command, see [`lxc rebuild --help`](lxc
 To rebuild the instance with a different image, send a POST request to the instance's `rebuild` endpoint.
 For example:
 
-    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{"source": {"alias":"<image_alias>","server":"<server_URL>", protocol:"simplestreams"}}'
+    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{
+      "source": {
+        "alias": "<image_alias>",
+        "protocol": "simplestreams",
+        "server": "<server_URL>"
+      }
+    }'
 
 To rebuild the instance with an empty root disk, specify the source type as `none`:
 
-    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{"source": {"type":"none"}}'
+    lxc query --request POST /1.0/instances/<instance_name>/rebuild --data '{
+      "source": {
+        "type": "none"
+      }
+    }'
 
 See [`POST /1.0/instances/{name}/rebuild`](swagger:/instances/instance_rebuild_post) for more information.
 ```

--- a/doc/howto/instances_routed_nic_vm.md
+++ b/doc/howto/instances_routed_nic_vm.md
@@ -7,17 +7,70 @@ For virtual machines, the gateways must be configured manually or via a mechanis
 
 To configure the gateways with `cloud-init`, firstly initialize an instance:
 
-    lxc init ubuntu:22.04 jammy --vm
+````{tabs}
+```{group-tab} CLI
+    lxc init ubuntu:22.04 my-vm --vm
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances --data '{
+      "name": "my-vm",
+      "source": {
+        "alias": "22.04",
+        "protocol": "simplestreams",
+        "server": "https://cloud-images.ubuntu.com/releases",
+        "type": "image"
+      },
+      "type": "virtual-machine"
+    }'
+```
+````
 
 Then add the routed NIC device:
 
-    lxc config device add jammy eth0 nic nictype=routed parent=my-parent-network ipv4.address=192.0.2.2 ipv6.address=2001:db8::2
+````{tabs}
+```{group-tab} CLI
+    lxc config device add my-vm eth0 nic nictype=routed parent=my-parent ipv4.address=192.0.2.2 ipv6.address=2001:db8::2
+```
+```{group-tab} API
+    lxc query --request PATCH /1.0/instances/my-vm --data '{
+      "devices": {
+        "eth0": {
+          "ipv4.address": "192.0.2.2",
+          "ipv6.address": "2001:db8::2",
+          "nictype": "routed",
+          "parent": "my-parent",
+          "type": "nic"
+        }
+      }
+    }'
+```
+````
 
 In this command, `my-parent-network` is your parent network, and the IPv4 and IPv6 addresses are within the subnet of the parent.
 
 Next we will add some `netplan` configuration to the instance using the `cloud-init.network-config` configuration key:
 
-    cat <<EOF | lxc config set jammy cloud-init.network-config -
+````{tabs}
+```{group-tab} CLI
+    cat <<EOF | lxc config set my-vm cloud-init.network-config -
+    network:
+      version: 2
+      ethernets:
+        enp5s0:
+          routes:
+          - to: default
+            via: 169.254.0.1
+            on-link: true
+          - to: default
+            via: fe80::1
+            on-link: true
+          addresses:
+          - 192.0.2.2/32
+          - 2001:db8::2/128
+    EOF
+```
+```{group-tab} API
+    cat > cloud-init.txt <<EOF
     network:
       version: 2
       ethernets:
@@ -34,6 +87,14 @@ Next we will add some `netplan` configuration to the instance using the `cloud-i
           - 2001:db8::2/128
     EOF
 
+    lxc query --request PATCH /1.0/instances/my-vm --data '{
+      "config": {
+        "cloud-init.network-config": "'"$(awk -v ORS='\\n' '1' cloud-init.txt)"'"
+      }
+    }'
+```
+````
+
 This `netplan` configuration adds the {ref}`static link-local next-hop addresses <nic-routed>` (`169.254.0.1` and `fe80::1`) that are required.
 For each of these routes we set `on-link` to `true`, which specifies that the route is directly connected to the interface.
 We also add the addresses that we configured in our routed NIC device.
@@ -45,10 +106,15 @@ To enable DNS within the instance, you must set a valid DNS IP address.
 If there is a `lxdbr0` network on the host, the name server can be set to that IP instead.
 ```
 
-You can then start your instance with:
+Before you start your instance, make sure that you have {ref}`configured the parent network <nic-routed-parent>` to enable proxy ARP/NDP.
 
-    lxc start jammy
+Then start your instance with:
 
-```{note}
-Before you start your instance, make sure that you have {ref}`configured the parent network <nic-routed>` to enable proxy ARP/NDP.
+````{tabs}
+```{group-tab} CLI
+    lxc start my-vm
 ```
+```{group-tab} API
+    lxc query --request PUT /1.0/instances/my-vm/state --data '{"action": "start"}'
+```
+````

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -14,12 +14,26 @@ To troubleshoot the problem, complete the following steps:
    Instance log
    : Enter the following command to display the instance log:
 
+     ````{tabs}
+     ```{group-tab} CLI
          lxc info <instance_name> --show-log
+     ```
+     ```{group-tab} API
+         lxc query --request GET /1.0/instances/<instance_name>/logs/lxc.log
+     ```
+     ````
 
    Console log
    : Enter the following command to display the console log:
 
+     ````{tabs}
+     ```{group-tab} CLI
          lxc console <instance_name> --show-log
+     ```
+     ```{group-tab} API
+         lxc query --request GET /1.0/instances/<instance_name>/console
+     ```
+     ````
 
    Detailed server information
    : The LXD snap includes a tool that collects the relevant server information for debugging.

--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -48,6 +48,9 @@ Use the following command to create a snapshot for a custom storage volume:
     lxc storage volume snapshot <pool_name> <volume_name> [<snapshot_name>]
 
 <!-- Include start create snapshot options -->
+The snapshot name is optional.
+If you don't specify one, the name follows the naming pattern defined in `snapshots.pattern`.
+
 Add the `--reuse` flag in combination with a snapshot name to replace an existing snapshot.
 
 By default, snapshots are kept forever, unless the `snapshots.expiry` configuration option is set.

--- a/doc/instance-exec.md
+++ b/doc/instance-exec.md
@@ -11,18 +11,39 @@ By running a shell command (for example, `/bin/bash`), you can get shell access 
 
 ## Run commands inside your instance
 
+````{tabs}
+```{group-tab} CLI
 To run a single command from the terminal of the host machine, use the [`lxc exec`](lxc_exec.md) command:
 
     lxc exec <instance_name> -- <command>
 
 For example, enter the following command to update the package list on your container:
 
-    lxc exec ubuntu-container -- apt-get update
+    lxc exec my-instance -- apt-get update
+```
+```{group-tab} API
+Send a POST request to the instance's `exec` endpoint to run a single command from the terminal of the host machine:
+
+    lxc query --request POST /1.0/instances/<instance_name>/exec --data '{
+      "command": [ "<command>" ]
+    }'
+
+For example, enter the following command to update the package list on your container:
+
+    lxc query --request POST /1.0/instances/my-instance/exec --data '{
+      "command": [ "apt-get", "update" ]
+    }'
+
+See [`POST /1.0/instances/{name}/exec`](swagger:/instances/instance_exec_post) for more information.
+```
+````
 
 ### Execution mode
 
 LXD can execute commands either interactively or non-interactively.
 
+````{tabs}
+```{group-tab} CLI
 In interactive mode, a pseudo-terminal device (PTS) is used to handle input (stdin) and output (stdout, stderr).
 This mode is automatically selected by the CLI if connected to a terminal emulator (and not run from a script).
 To force interactive mode, add either `--force-interactive` or `--mode interactive` to the command.
@@ -30,6 +51,43 @@ To force interactive mode, add either `--force-interactive` or `--mode interacti
 In non-interactive mode, pipes are allocated instead (one for each of stdin, stdout and stderr).
 This method allows running a command and properly getting separate stdin, stdout and stderr as required by many scripts.
 To force non-interactive mode, add either `--force-noninteractive` or `--mode non-interactive` to the command.
+```
+```{group-tab} API
+In both modes, the operation creates a control socket that can be used for out-of-band communication with LXD.
+You can send signals and window sizing information through this socket.
+
+Interactive mode
+: In interactive mode, the operation creates an additional single bi-directional WebSocket.
+  To force interactive mode, add `"interactive": true` and `"wait-for-websocket": true` to the request data.
+  For example:
+
+      lxc query --request POST /1.0/instances/my-instance/exec --data '{
+        "command": [ "/bin/bash" ],
+        "interactive": true,
+        "wait-for-websocket": true
+      }'
+
+Non-interactive mode
+: In non-interactive mode, the operation creates three additional WebSockets: one each for stdin, stdout, and stderr.
+  To force non-interactive mode, add `"interactive": false` to the request data.
+
+  When running a command in non-interactive mode, you can instruct LXD to record the output of the command.
+  To do so, add `"record-output": true` to the request data.
+  You can then send a request to the `exec-output` endpoint to retrieve the list of files that contain command output:
+
+      lxc query --request GET /1.0/instances/<instance_name>/logs/exec-output
+
+  To display the output of one of the files, send a request to one of the files:
+
+      lxc query --request GET /1.0/instances/<instance_name>/logs/exec-output/<record-output-file>
+
+  When you don't need the command output anymore, you can delete it:
+
+      lxc query --request DELETE /1.0/instances/<instance_name>/logs/exec-output/<record-output-file>
+
+  See [`GET /1.0/instances/{name}/logs/exec-output`](swagger:/instances/instance_exec-outputs_get), [`GET /1.0/instances/{name}/logs/exec-output/{filename}`](swagger:/instances/instance_exec-output_get), and [`DELETE /1.0/instances/{name}/logs/exec-output/{filename}`](swagger:/instances/instance_exec-output_delete) for more information.
+```
+````
 
 ### User, groups and working directory
 
@@ -39,26 +97,75 @@ Therefore, LXD does not parse files like `/etc/passwd`, `/etc/group` or `/etc/ns
 As a result, LXD doesn't know the home directory for the user or the supplementary groups the user is in.
 
 By default, LXD runs commands as `root` (UID 0) with the default group (GID 0) and the working directory set to `/root`.
-You can override the user, group and working directory by specifying absolute values through the following flags:
+You can override the user, group and working directory by specifying absolute values.
+
+````{tabs}
+```{group-tab} CLI
+You can override the default settings by adding the following flags to the [`lxc exec`](lxc_exec.md) command:
 
 - `--user` - the user ID for running the command
 - `--group` - the group ID for running the command
 - `--cwd` - the directory in which the command should run
+
+```
+```{group-tab} API
+You can override the default settings by adding the following fields to the request data:
+
+- `"user": <user_ID>` - the user ID for running the command
+- `"group": <group_ID>` - the group ID for running the command
+- `"cwd": "<directory>"` - the directory in which the command should run
+
+```
+````
 
 ### Environment
 
 You can pass environment variables to an exec session in the following two ways:
 
 Set environment variables as instance options
-: To set the `ENVVAR` environment variable to `VALUE` in the instance, set the `environment.ENVVAR` instance option (see {config:option}`instance-miscellaneous:environment.*`):
+: ````{tabs}
 
-      lxc config set <instance_name> environment.ENVVAR=VALUE
+  ```{group-tab} CLI
+  To set the `<ENVVAR>` environment variable to `<value>` in the instance, set the `environment.<ENVVAR>` instance option (see {config:option}`instance-miscellaneous:environment.*`):
+
+      lxc config set <instance_name> environment.<ENVVAR>=<value>
+  ```
+
+  ```{group-tab} API
+  To set the `<ENVVAR>` environment variable to `<value>` in the instance, set the `environment.<ENVVAR>` instance option (see {config:option}`instance-miscellaneous:environment.*`):
+
+      lxc query --request PATCH /1.0/instances/<instance_name> --data '{
+        "config": {
+          "environment.<ENVVAR>": "<value>"
+        }
+      }'
+  ```
+
+  ````
 
 Pass environment variables to the exec command
-: To pass an environment variable to the exec command, use the `--env` flag.
+: ````{tabs}
+
+  ```{group-tab} CLI
+  To pass an environment variable to the exec command, use the `--env` flag.
   For example:
 
-      lxc exec <instance_name> --env ENVVAR=VALUE -- <command>
+      lxc exec <instance_name> --env <ENVVAR>=<value> -- <command>
+  ```
+
+  ```{group-tab} API
+  To pass an environment variable to the exec command, add an `environment` field to the request data.
+  For example:
+
+      lxc query --request POST /1.0/instances/<instance_name>/exec --data '{
+        "command": [ "<command>" ],
+        "environment": {
+          "<ENVVAR>": "<value>"
+        }
+      }'
+  ```
+
+  ````
 
 In addition, LXD sets the following default values (unless they are passed in one of the ways described above):
 
@@ -95,15 +202,33 @@ In addition, LXD sets the following default values (unless they are passed in on
 If you want to run commands directly in your instance, run a shell command inside it.
 For example, enter the following command (assuming that the `/bin/bash` command exists in your instance):
 
+````{tabs}
+```{group-tab} CLI
     lxc exec <instance_name> -- /bin/bash
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances/<instance_name>/exec --data '{
+      "command": [ "/bin/bash" ]
+    }'
+```
+````
 
 By default, you are logged in as the `root` user.
 If you want to log in as a different user, enter the following command:
 
+````{tabs}
+```{group-tab} CLI
     lxc exec <instance_name> -- su --login <user_name>
+
+To exit the instance shell, enter `exit` or press {kbd}`Ctrl`+{kbd}`d`.
+```
+```{group-tab} API
+    lxc query --request POST /1.0/instances/<instance_name>/exec --data '{
+      "command": [ "su", "--login", "<user_name>" ]
+    }'
+```
+````
 
 ```{note}
 Depending on the operating system that you run in your instance, you might need to create a user first.
 ```
-
-To exit the instance shell, enter `exit` or press `Ctrl`+`d`.

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -481,6 +481,7 @@ Multiple IP addresses
   In this case, set the `ipv4.gateway` and `ipv6.gateway` values to `none` on any subsequent interfaces to avoid default gateway conflicts.
   Also consider specifying a different host-side address for these subsequent interfaces using `ipv4.host_address` and/or `ipv6.host_address`.
 
+(nic-routed-parent)=
 Parent interface
 : This NIC can operate with and without a `parent` network interface set.
 


### PR DESCRIPTION
Add API instructions for the different how-tos and clean up the ones that we already had.