### PR TITLE
Doc: update versioning scheme and snap channels

### DIFF
--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -32,6 +32,8 @@ For example:
 
     sudo snap install lxd --channel=latest/stable
 
+If you do not specify a channel, snap will choose the default channel (the latest LTS release).
+
 To see all available channels of the LXD snap, run the following command:
 
     snap info lxd

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -53,7 +53,11 @@ Complete the following steps to install the snap:
 1. Install the snap package.
    For the latest feature release, use:
 
-        sudo snap install lxd
+        sudo snap install lxd --channel=latest/stable
+
+   For the LXD 5.21 LTS release, use:
+
+        sudo snap install lxd --channel=5.21/stable
 
    For the LXD 5.0 LTS release, use:
 

--- a/doc/support.md
+++ b/doc/support.md
@@ -5,18 +5,19 @@
 LXD maintains different release branches in parallel.
 
 Long term support (LTS) releases
-: The current LTS releases are LXD 5.0.x (snap channel `5.0/stable`) and LXD 4.0.x (snap channel `4.0/stable`).
+: The current LTS releases are LXD 5.21.x (snap channel `5.21/stable` - this is the default channel), LXD 5.0.x (snap channel `5.0/stable`) and LXD 4.0.x (snap channel `4.0/stable`).
 
   The LTS releases follow the Ubuntu release schedule and are released every two years:
 
-  - LXD 5.0 is supported until June 2027 and gets frequent bugfix and security updates, but does not receive any feature additions.
+  - LXD 5.21 is supported until June 2029.
+    It gets frequent bugfix and security updates, but does not receive any feature additions.
     Updates to this release happen approximately every six months, but this schedule should be seen as a rough estimation that can change based on priorities and discovered bugs.
+  - LXD 5.0 is supported until June 2027.
   - LXD 4.0 is supported until June 2025.
-  - LXD 6.0 is planned for April 2024 and will be supported until June 2029.
 
 Feature releases
-: The current feature release is LXD 5.x.
-  It is available through the snap channels `latest/stable`, `latest/candidate`, and `latest/edge`, in addition to channels for the most recent specific releases (for example, `5.18/stable`).
+: After LXD 5.21 is released, the next feature release will be LXD 6.x (starting with 6.1).
+  It is available through the snap channels `latest/stable`, `latest/candidate`, and `latest/edge`, in addition to channels for the most recent specific releases (for example, `6.1/stable`).
   See `sudo snap info lxd` for a full list of available channels.
 
   Feature releases are pushed out about every month and contain new features as well as bugfixes.


### PR DESCRIPTION
Update the docs to reflect 5.21 as the new LTS and 6.1 as the next feature release.
Also make sure that the installation commands use the correct channels, and mention that the default channel will be the LTS channel in the future.

@tomponline and @mionaalex, please make sure this is actually what we want.
It's a bit awkward since it isn't really true until 5.21 is released, and also then we don't have a 6.1 channel yet.