### PR TITLE
Storage: Set `volatile.uuid` for all volumes and snapshots

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2334,3 +2334,9 @@ The value of the claim will be extracted and might be used to make authorization
 Adds a new `loki.instance` server configuration key to customize the `instance` field in Loki events.
 This can be used to expose the name of the cluster rather than the individual system name sending
 the event as that's usually already covered by the `location` field.
+
+## `storage_volatile_uuid`
+
+Adds a new `volatile.uuid` configuration key to all storage volumes, snapshots and buckets.
+This information can be used by storage drivers as a separate identifier besides the name
+when working with volumes.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1890,6 +1890,13 @@ This number is then incremented by one for the new name.
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 ```
 
+```{config:option} volatile.uuid storage-btrfs-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
+```
+
 <!-- config group storage-btrfs-volume-conf end -->
 <!-- config group storage-ceph-pool-conf start -->
 ```{config:option} ceph.cluster_name storage-ceph-pool-conf
@@ -2038,6 +2045,13 @@ This number is then incremented by one for the new name.
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 ```
 
+```{config:option} volatile.uuid storage-ceph-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
+```
+
 <!-- config group storage-ceph-volume-conf end -->
 <!-- config group storage-cephfs-pool-conf start -->
 ```{config:option} cephfs.cluster_name storage-cephfs-pool-conf
@@ -2171,6 +2185,13 @@ This number is then incremented by one for the new name.
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 ```
 
+```{config:option} volatile.uuid storage-cephfs-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
+```
+
 <!-- config group storage-cephfs-volume-conf end -->
 <!-- config group storage-cephobject-bucket-conf start -->
 ```{config:option} size storage-cephobject-bucket-conf
@@ -2301,6 +2322,13 @@ This number is then incremented by one for the new name.
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+```{config:option} volatile.uuid storage-dir-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
 ```
 
 <!-- config group storage-dir-volume-conf end -->
@@ -2482,6 +2510,13 @@ This number is then incremented by one for the new name.
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
 ```
 
+```{config:option} volatile.uuid storage-lvm-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
+```
+
 <!-- config group storage-lvm-volume-conf end -->
 <!-- config group storage-zfs-bucket-conf start -->
 ```{config:option} size storage-zfs-bucket-conf
@@ -2618,6 +2653,13 @@ This number is then incremented by one for the new name.
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
+```
+
+```{config:option} volatile.uuid storage-zfs-volume-conf
+:defaultdesc: "random UUID"
+:shortdesc: "The volume's UUID"
+:type: "string"
+
 ```
 
 ```{config:option} zfs.block_mode storage-zfs-volume-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2054,6 +2054,14 @@
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
+							"type": "string"
+						}
 					}
 				]
 			}
@@ -2214,6 +2222,14 @@
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
+							"type": "string"
+						}
 					}
 				]
 			}
@@ -2352,6 +2368,14 @@
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
 							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
 					}
@@ -2500,6 +2524,14 @@
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
 							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
 					}
@@ -2692,6 +2724,14 @@
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
+							"type": "string"
+						}
 					}
 				]
 			}
@@ -2832,6 +2872,14 @@
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
 							"shortdesc": "Schedule for automatic volume snapshots",
+							"type": "string"
+						}
+					},
+					{
+						"volatile.uuid": {
+							"defaultdesc": "random UUID",
+							"longdesc": "",
+							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
 					},

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -18,6 +18,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/uuid"
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7"
 	"golang.org/x/sync/errgroup"
@@ -729,12 +730,25 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		volumeConfig = srcBackup.Config.Volume.Config
 	}
 
+	// At this stage the DB record for the new volume isn't yet created.
+	// We have to set the UUID manually to allow passing it into the storage driver.
+	// It will get used later when creating the DB record.
+	// A new UUID has to be assigned to avoid conflicts when importing the same instance multiple times.
+	volumeConfig["volatile.uuid"] = uuid.New().String()
+
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 
 	sourceSnapshots := make([]drivers.Volume, 0, len(srcBackup.Config.VolumeSnapshots))
 	for _, volSnap := range srcBackup.Config.VolumeSnapshots {
 		snapshotName := drivers.GetSnapshotVolumeName(srcBackup.Name, volSnap.Name)
 		snapshotStorageName := project.Instance(srcBackup.Project, snapshotName)
+
+		// At this stage the DB record for the new volume snapshot isn't yet created.
+		// We have to set the UUID manually to allow passing it into the storage driver.
+		// It will get used later when creating the DB record.
+		// A new UUID has to be assigned to avoid conflicts when importing the same instance multiple times.
+		volSnap.Config["volatile.uuid"] = uuid.New().String()
+
 		sourceSnapshots = append(sourceSnapshots, b.GetVolume(volType, contentType, snapshotStorageName, volSnap.Config))
 	}
 
@@ -1049,6 +1063,10 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		srcVolStorageName := project.Instance(src.Project().Name, src.Name())
 		srcVol := b.GetVolume(volType, contentType, srcVolStorageName, srcConfig.Volume.Config)
 
+		// Delete the source volume's UUID.
+		// A new one gets set when creating the record in the DB.
+		delete(vol.Config(), "volatile.uuid")
+
 		// Validate config and create database entry for new storage volume.
 		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", vol.Type(), false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, false, true)
 		if err != nil {
@@ -1066,6 +1084,10 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
 				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(srcConfig.VolumeSnapshots[i].Config, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume.
 			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, srcConfig.VolumeSnapshots[i].Config, srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
@@ -1211,13 +1233,30 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 
 	// Use the source volume's config if not supplied.
 	if config == nil {
-		config = srcConfig.Volume.Config
+		// Create a deep copy to be able to set different volume attributes for the source and target.
+		for k, v := range srcConfig.Volume.Config {
+			config[k] = v
+		}
 	}
 
 	// Use the source volume's description if not supplied.
 	if desc == "" {
 		desc = srcConfig.Volume.Description
 	}
+
+	// Load the target volume from database.
+	dbVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeType(srcConfig.Volume.Type))
+	if err != nil {
+		return err
+	}
+
+	volUUID := dbVol.Config["volatile.uuid"]
+	if volUUID == "" {
+		return fmt.Errorf(`Volume %q is missing the required "volatile.uuid" setting`, volName)
+	}
+
+	// Replace the target volume's UUID.
+	config["volatile.uuid"] = volUUID
 
 	contentDBType, err := VolumeContentTypeNameToContentType(srcConfig.Volume.ContentType)
 	if err != nil {
@@ -1335,6 +1374,10 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			if srcSnap.ExpiresAt != nil {
 				snapExpiryDate = *srcSnap.ExpiresAt
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(srcSnap.Config, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume from source volume config.
 			err = VolumeDBCreate(b, projectName, newSnapshotName, srcSnap.Description, drivers.VolumeTypeCustom, true, srcSnap.Config, srcSnap.CreatedAt, snapExpiryDate, contentType, false, true)
@@ -1594,6 +1637,10 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
 				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(srcConfig.VolumeSnapshots[i].Config, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume.
 			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, volType, true, srcConfig.VolumeSnapshots[i].Config, srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, contentType, false, true)
@@ -1971,6 +2018,10 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 				return fmt.Errorf("Cannot create volume, already exists on migration target storage")
 			}
 		} else {
+			// Delete the source volume's UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(vol.Config(), "volatile.uuid")
+
 			// Validate config and create database entry for new storage volume if not refreshing.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 			err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), volumeDescription, volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, true)
@@ -2012,6 +2063,10 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 					}
 				}
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(snapConfig, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
@@ -2217,8 +2272,9 @@ func (b *lxdBackend) RenameInstance(inst instance.Instance, newName string, op *
 	}
 
 	revert.Add(func() {
-		// There's no need to pass config as it's not needed when renaming a volume.
-		newVol := b.GetVolume(volType, contentType, newVolStorageName, nil)
+		// Renaming a volume doesn't change its UUID.
+		// Pass the same configuration as for the initial rename operation.
+		newVol := b.GetVolume(volType, contentType, newVolStorageName, volume.Config)
 		_ = b.driver.RenameVolume(newVol, volStorageName, op)
 	})
 
@@ -2289,8 +2345,13 @@ func (b *lxdBackend) DeleteInstance(inst instance.Instance, op *operations.Opera
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	contentType := InstanceContentType(inst)
 
-	// There's no need to pass config as it's not needed when deleting a volume.
-	vol := b.GetVolume(volType, contentType, volStorageName, nil)
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
 	// Delete the volume from the storage device. Must come after snapshots are removed.
 	// Must come before DB VolumeDBDelete so that the volume ID is still available.
@@ -2572,8 +2633,13 @@ func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, op *operations
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	contentType := InstanceContentType(inst)
 
-	// There's no need to pass config as it's not needed when deleting a volume.
-	vol := b.GetVolume(volType, contentType, volStorageName, nil)
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
 	// Remove empty snapshot mount paths.
 	snapshotDir := drivers.GetVolumeSnapshotDir(b.Name(), vol.Type(), vol.Name())
@@ -2713,9 +2779,14 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 	contentType := InstanceContentType(inst)
 	val := VolumeUsage{}
 
-	// There's no need to pass config as it's not needed when retrieving the volume usage.
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return nil, err
+	}
+
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
-	vol := b.GetVolume(volType, contentType, volStorageName, nil)
+	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
 	// Get the usage.
 	size, err := b.driver.GetVolumeUsage(vol)
@@ -2929,10 +3000,14 @@ func (b *lxdBackend) getInstanceDisk(inst instance.Instance) (string, error) {
 	contentType := InstanceContentType(inst)
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return "", err
+	}
+
 	// Get the volume.
-	// There's no need to pass config as it's not needed when getting the
-	// location of the disk block device.
-	vol := b.GetVolume(volType, contentType, volStorageName, nil)
+	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
 	// Get the location of the disk block device.
 	diskPath, err := b.driver.GetVolumeDiskPath(vol)
@@ -2975,6 +3050,14 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 		return err
 	}
 
+	parentUUID := srcDBVol.Config["volatile.uuid"]
+	if parentUUID == "" {
+		return fmt.Errorf(`Instance volume %q is missing the required "volatile.uuid" setting`, src.Name())
+	}
+
+	// Delete the volume's UUID.
+	delete(srcDBVol.Config, "volatile.uuid")
+
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -3003,8 +3086,10 @@ func (b *lxdBackend) CreateInstanceSnapshot(inst instance.Instance, src instance
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
 	// Get the volume.
-	// There's no need to pass config as it's not needed when creating volume snapshots.
-	vol := b.GetVolume(volType, contentType, volStorageName, nil)
+	vol := b.GetVolume(volType, contentType, volStorageName, srcDBVol.Config)
+
+	// Set the parent volume's UUID.
+	vol.SetParentUUID(parentUUID)
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
@@ -3065,8 +3150,14 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	contentType := InstanceContentType(inst)
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
-	// Rename storage volume snapshot. No need to pass config as it's not needed when renaming a volume.
-	snapVol := b.GetVolume(volType, contentType, volStorageName, nil)
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	// Rename storage volume snapshot.
+	snapVol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 	err = b.driver.RenameVolumeSnapshot(snapVol, newName, op)
 	if err != nil {
 		return err
@@ -3075,8 +3166,10 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	newVolName := drivers.GetSnapshotVolumeName(parentName, newName)
 
 	revert.Add(func() {
-		// Revert rename. No need to pass config as it's not needed when renaming a volume.
-		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, newVolName), nil)
+		// Revert rename.
+		// Renaming a volume snapshot doesn't change its UUID.
+		// Pass the same configuration as for the initial rename operation.
+		newSnapVol := b.GetVolume(volType, contentType, project.Instance(inst.Project().Name, newVolName), dbVol.Config)
 		_ = b.driver.RenameVolumeSnapshot(newSnapVol, oldSnapshotName, op)
 	})
 
@@ -3129,8 +3222,13 @@ func (b *lxdBackend) DeleteInstanceSnapshot(inst instance.Instance, op *operatio
 
 	snapVolName := drivers.GetSnapshotVolumeName(parentStorageName, snapName)
 
-	// There's no need to pass config as it's not needed when deleting a volume snapshot.
-	vol := b.GetVolume(volType, contentType, snapVolName, nil)
+	// Load storage volume from database.
+	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
+	if err != nil {
+		return err
+	}
+
+	vol := b.GetVolume(volType, contentType, snapVolName, dbVol.Config)
 
 	volExists, err := b.driver.HasVolume(vol)
 	if err != nil {
@@ -3212,6 +3310,7 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 		return fmt.Errorf("Volume name must be a snapshot")
 	}
 
+	// Load storage volume from database.
 	srcDBVol, err := VolumeDBGet(b, src.Project().Name, src.Name(), volType)
 	if err != nil {
 		return err
@@ -3225,12 +3324,23 @@ func (b *lxdBackend) RestoreInstanceSnapshot(inst instance.Instance, src instanc
 			return err
 		}
 
+		volUUID := dbVol.Config["volatile.uuid"]
+		if volUUID == "" {
+			return fmt.Errorf(`Instance volume %q is missing the required "volatile.uuid" setting`, inst.Name())
+		}
+
+		// Set the actual target volume's UUID.
+		// This is required because we have just copied the source volume's config.
+		srcDBVol.Config["volatile.uuid"] = volUUID
+
 		err = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID(), srcDBVol.Description, srcDBVol.Config)
 		if err != nil {
 			return err
 		}
 
 		revert.Add(func() {
+			// Update the instance snapshot with its old config.
+			// This will also reset its UUID.
 			_ = b.state.DB.Cluster.UpdateStoragePoolVolume(inst.Project().Name, inst.Name(), volDBType, b.ID(), dbVol.Description, dbVol.Config)
 		})
 	}
@@ -4708,6 +4818,10 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		volStorageName := project.StorageVolume(projectName, volName)
 		vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, config)
 
+		// Delete the source volume's UUID.
+		// A new one gets set when creating the record in the DB.
+		delete(vol.Config(), "volatile.uuid")
+
 		// Validate config and create database entry for new storage volume.
 		err = VolumeDBCreate(b, projectName, volName, desc, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), false, true)
 		if err != nil {
@@ -4725,6 +4839,10 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
 				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(srcConfig.VolumeSnapshots[i].Config, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume.
 			err = VolumeDBCreate(b, projectName, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, srcConfig.VolumeSnapshots[i].Config, srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
@@ -5108,6 +5226,10 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	defer revert.Fail()
 
 	if !args.Refresh {
+		// Delete the source volume's UUID.
+		// A new one gets set when creating the record in the DB.
+		delete(vol.Config(), "volatile.uuid")
+
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 		err = VolumeDBCreate(b, projectName, args.Name, args.Description, vol.Type(), false, vol.Config(), time.Now().UTC(), time.Time{}, vol.ContentType(), true, true)
@@ -5147,6 +5269,10 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 					break
 				}
 			}
+
+			// Delete the source volume's snapshot UUID.
+			// A new one gets set when creating the record in the DB.
+			delete(snapConfig, "volatile.uuid")
 
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
@@ -5509,8 +5635,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 		return err
 	}
 
-	// There's no need to pass config as it's not needed when deleting a volume.
-	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, nil)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, curVol.Config)
 
 	// Delete the volume from the storage device. Must come after snapshots are removed.
 	volExists, err := b.driver.HasVolume(vol)
@@ -5560,8 +5685,7 @@ func (b *lxdBackend) GetCustomVolumeDisk(projectName, volName string) (string, e
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
 
-	// There's no need to pass config as it's not needed when getting the volume usage.
-	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, nil)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	return b.driver.GetVolumeDiskPath(vol)
 }
@@ -5583,8 +5707,7 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
 
-	// There's no need to pass config as it's not needed when getting the volume usage.
-	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, nil)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Get the usage.
 	size, err := b.driver.GetVolumeUsage(vol)
@@ -5799,6 +5922,14 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return fmt.Errorf("Volume of content type %q does not support snapshots", contentType)
 	}
 
+	parentUUID := parentVol.Config["volatile.uuid"]
+	if parentUUID == "" {
+		return fmt.Errorf(`Volume %q is missing the required "volatile.uuid" setting`, parentVol.Name)
+	}
+
+	// Delete the volume's UUID.
+	delete(parentVol.Config, "volatile.uuid")
+
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -5814,6 +5945,9 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, fullSnapshotName)
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, parentVol.Config)
+
+	// Set the parent volume's UUID.
+	vol.SetParentUUID(parentUUID)
 
 	// Lock this operation to ensure that the only one snapshot is made at the time.
 	// Other operations will wait for this one to finish.
@@ -5859,8 +5993,7 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
 
-	// There's no need to pass config as it's not needed when renaming a volume.
-	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, nil)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	err = b.driver.RenameVolumeSnapshot(vol, newSnapshotName, op)
 	if err != nil {
@@ -5874,7 +6007,9 @@ func (b *lxdBackend) RenameCustomVolumeSnapshot(projectName, volName string, new
 		newVolStorageName := project.StorageVolume(projectName, newVolName)
 
 		// Revert rename.
-		newVol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, nil)
+		// Renaming a volume snapshot doesn't change its UUID.
+		// Pass the same configuration as for the initial rename operation.
+		newVol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), newVolStorageName, volume.Config)
 		_ = b.driver.RenameVolumeSnapshot(newVol, oldSnapshotName, op)
 		return err
 	}
@@ -5916,8 +6051,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
 
-	// There's no need to pass config as it's not needed when deleting a volume snapshot.
-	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, nil)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, volume.Config)
 
 	// Delete the snapshot from the storage device.
 	// Must come before DB VolumeDBDelete so that the volume ID is still available.
@@ -6603,6 +6737,10 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 		return fmt.Errorf("Unknown custom volume content type %q", contentType)
 	}
 
+	// When detecting unknown custom storage volumes we have to set a new UUID.
+	// Otherwise the volume's validation will fail since it isn't set.
+	vol.Config()["volatile.uuid"] = uuid.New().String()
+
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
 	err = b.driver.FillVolumeConfig(*vol)
@@ -6629,9 +6767,22 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 
 	// Populate snaphot volumes.
 	for _, snapOnlyName := range snapshots {
+		// Have to assume the snapshot volume config is same as parent.
+		// Deep copy it to allow setting a different UUID.
+		snapConfig := make(map[string]string, len(vol.Config()))
+		for k, v := range vol.Config() {
+			// We don't copy the parent volume's UUID.
+			// Instead the the snapshot will get its own ID when inserted into the DB.
+			if k == "volatile.uuid" {
+				continue
+			}
+
+			snapConfig[k] = v
+		}
+
 		backupConf.VolumeSnapshots = append(backupConf.VolumeSnapshots, &api.StorageVolumeSnapshot{
 			Name:        snapOnlyName, // Snapshot only name, not full name.
-			Config:      vol.Config(), // Have to assume the snapshot volume config is same as parent.
+			Config:      snapConfig,
 			ContentType: apiContentType,
 		})
 	}
@@ -6659,6 +6810,10 @@ func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[s
 	} else if bucket != nil {
 		return nil // Storage record already exists in DB, no recovery needed.
 	}
+
+	// When detecting unknown buckets we have to set a new UUID.
+	// Otherwise the bucket's validation will fail since it isn't set.
+	vol.Config()["volatile.uuid"] = uuid.New().String()
 
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
@@ -7040,6 +7195,10 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(srcBackup.Config.Volume.ContentType), volStorageName, srcBackup.Config.Volume.Config)
 
+	// Delete the source volume's UUID.
+	// A new one gets set when creating the record in the DB.
+	delete(vol.Config(), "volatile.uuid")
+
 	// Validate config and create database entry for new storage volume.
 	// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 	err = VolumeDBCreate(b, srcBackup.Project, srcBackup.Name, srcBackup.Config.Volume.Description, vol.Type(), false, vol.Config(), srcBackup.Config.Volume.CreatedAt, time.Time{}, vol.ContentType(), true, true)
@@ -7065,6 +7224,10 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 		fullSnapName := drivers.GetSnapshotVolumeName(srcBackup.Name, snapName)
 		snapVolStorageName := project.StorageVolume(srcBackup.Project, fullSnapName)
 		snapVol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(srcBackup.Config.Volume.ContentType), snapVolStorageName, snapshot.Config)
+
+		// Delete the source volume's snapshot UUID.
+		// A new one gets set when creating the record in the DB.
+		delete(snapVol.Config(), "volatile.uuid")
 
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2383,6 +2383,11 @@ func (b *lxdBackend) UpdateInstance(inst instance.Instance, newDesc string, newC
 			return fmt.Errorf(`Instance volume "block.filesystem" property cannot be changed`)
 		}
 
+		// Check that the volume's volatile.uuid property isn't being changed.
+		if changedConfig["volatile.uuid"] != "" {
+			return fmt.Errorf(`Instance volume "volatile.uuid" property cannot be changed`)
+		}
+
 		// Load storage volume from database.
 		dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
 		if err != nil {
@@ -5361,6 +5366,11 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 		// Check that the volume's block.filesystem property isn't being changed.
 		if changedConfig["block.filesystem"] != "" {
 			return fmt.Errorf("Custom volume 'block.filesystem' property cannot be changed")
+		}
+
+		// Check that the volume's volatile.uuid property isn't being changed.
+		if changedConfig["volatile.uuid"] != "" {
+			return fmt.Errorf(`Custom volume "volatile.uuid" property cannot be changed`)
 		}
 
 		// Check for config changing that is not allowed when running instances are using it.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5365,7 +5365,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		// Check that the volume's block.filesystem property isn't being changed.
 		if changedConfig["block.filesystem"] != "" {
-			return fmt.Errorf("Custom volume 'block.filesystem' property cannot be changed")
+			return fmt.Errorf(`Custom volume "block.filesystem" property cannot be changed`)
 		}
 
 		// Check that the volume's volatile.uuid property isn't being changed.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -97,6 +97,7 @@ type Volume struct {
 	mountCustomPath      string // Mount the filesystem volume at a custom location.
 	mountFilesystemProbe bool   // Probe filesystem type when mounting volume (when needed).
 	hasSource            bool   // Whether the volume is created from a source volume.
+	parentUUID           string // Set to the parent volume's volatile.uuid (if snapshot).
 }
 
 // VolumeCopy represents a volume and its snapshots for copy and refresh operations.
@@ -566,6 +567,11 @@ func (v *Volume) SetMountFilesystemProbe(probe bool) {
 // SetHasSource indicates whether the Volume is created from a source.
 func (v *Volume) SetHasSource(hasSource bool) {
 	v.hasSource = hasSource
+}
+
+// SetParentUUID sets the parent volume's UUID for snapshots.
+func (v *Volume) SetParentUUID(parentUUID string) {
+	v.parentUUID = parentUUID
 }
 
 // Clone returns a copy of the volume.

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -593,8 +593,17 @@ func (v Volume) Clone() Volume {
 
 // NewVolumeCopy returns a container for copying a volume and its snapshots.
 func NewVolumeCopy(vol Volume, snapshots ...Volume) VolumeCopy {
+	modifiedSnapshots := make([]Volume, 0, len(snapshots))
+
+	// Set the parent volume's UUID for each snapshot.
+	// If the parent volume doesn't have an UUID it's a noop.
+	for _, snapshot := range snapshots {
+		snapshot.SetParentUUID(vol.config["volatile.uuid"])
+		modifiedSnapshots = append(modifiedSnapshots, snapshot)
+	}
+
 	return VolumeCopy{
 		Volume:    vol,
-		Snapshots: snapshots,
+		Snapshots: modifiedSnapshots,
 	}
 }

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/lxd/apparmor"
@@ -258,6 +259,11 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 		volumeConfig = map[string]string{}
 	}
 
+	// Ensure volume has an UUID.
+	if volumeConfig["volatile.uuid"] == "" {
+		volumeConfig["volatile.uuid"] = uuid.New().String()
+	}
+
 	volType, err := VolumeDBTypeToType(volDBType)
 	if err != nil {
 		return err
@@ -377,6 +383,11 @@ func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSp
 	// Make sure that we don't pass a nil to the next function.
 	if bucket.Config == nil {
 		bucket.Config = map[string]string{}
+	}
+
+	// Ensure bucket has an UUID.
+	if bucket.Config["volatile.uuid"] == "" {
+		bucket.Config["volatile.uuid"] = uuid.New().String()
 	}
 
 	bucketVolName := project.StorageVolume(projectName, bucket.Name)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -517,6 +517,17 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		rules["security.unmapped"] = validate.Optional(validate.IsBool)
 	}
 
+	// Those keys are only valid for volumes.
+	if vol != nil {
+		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs; group=volume-conf; key=volatile.uuid)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: random UUID
+		//  shortdesc: The volume's UUID
+		rules["volatile.uuid"] = validate.Optional(validate.IsUUID)
+	}
+
 	return rules
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -394,6 +394,7 @@ var APIExtensions = []string{
 	"server_version_lts",
 	"oidc_groups_claim",
 	"loki_config_instance",
+	"storage_volatile_uuid",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -1,16 +1,18 @@
 test_snapshots() {
-  snapshots
+  snapshots "lxdtest-$(basename "${LXD_DIR}")"
 
   if [ "$(storage_backend "$LXD_DIR")" = "lvm" ]; then
-    # Test that non-thinpool lvm backends work fine with snaphots.
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots" lvm lvm.use_thinpool=false volume.size=25MiB
-    lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots"
+    pool="lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots"
 
-    snapshots
+    # Test that non-thinpool lvm backends work fine with snaphots.
+    lxc storage create "${pool}" lvm lvm.use_thinpool=false volume.size=25MiB
+    lxc profile device set default root pool "${pool}"
+
+    snapshots "${pool}"
 
     lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")"
 
-    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots"
+    lxc storage delete "${pool}"
   fi
 }
 
@@ -18,6 +20,7 @@ snapshots() {
   # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
+  pool="$1"
 
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
@@ -96,18 +99,20 @@ snapshots() {
 }
 
 test_snap_restore() {
-  snap_restore
+  snap_restore "lxdtest-$(basename "${LXD_DIR}")"
 
   if [ "$(storage_backend "$LXD_DIR")" = "lvm" ]; then
-    # Test that non-thinpool lvm backends work fine with snaphots.
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore" lvm lvm.use_thinpool=false volume.size=25MiB
-    lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore"
+    pool="lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore"
 
-    snap_restore
+    # Test that non-thinpool lvm backends work fine with snaphots.
+    lxc storage create "${pool}" lvm lvm.use_thinpool=false volume.size=25MiB
+    lxc profile device set default root pool "${pool}"
+
+    snap_restore "${pool}"
 
     lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")"
 
-    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore"
+    lxc storage delete "${pool}"
   fi
 }
 
@@ -115,6 +120,7 @@ snap_restore() {
   # shellcheck disable=2039,3043
   local lxd_backend
   lxd_backend=$(storage_backend "$LXD_DIR")
+  pool="$1"
 
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -31,6 +31,12 @@ test_storage() {
   lxc storage volume set "$storage_pool" "$storage_volume" user.abc def
   [ "$(lxc storage volume get "$storage_pool" "$storage_volume" user.abc)" = "def" ]
 
+  # Check if storage volume has an UUID.
+  [ -n "$(lxc storage volume get "$storage_pool" "$storage_volume" volatile.uuid)" ]
+
+  # Check if the volume's UUID can be modified
+  ! lxc storage volume set "$storage_pool" "$storage_volume" volatile.uuid "2d94c537-5eff-4751-95b1-6a1b7d11f849" || false
+
   lxc storage volume delete "$storage_pool" "$storage_volume"
 
   # Test copying pool volume.* key to the volume with prefix stripped at volume creation time

--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -85,6 +85,9 @@ test_storage_buckets() {
   initSecretKey=$(echo "${initCreds}" | awk '{ if ($2 == "secret" && $3 == "key:") {print $4}}')
   s3cmdrun "${lxd_backend}" "${initAccessKey}" "${initSecretKey}" ls | grep -F "${bucketPrefix}.foo"
 
+  # Check if the storage bucket has an UUID.
+  [ -n "$(lxc storage bucket get "${poolName}" "${bucketPrefix}.foo" volatile.uuid)" ]
+
   lxc storage bucket list "${poolName}" | grep -F "${bucketPrefix}.foo"
   lxc storage bucket show "${poolName}" "${bucketPrefix}.foo"
 

--- a/test/suites/storage_volume_import.sh
+++ b/test/suites/storage_volume_import.sh
@@ -14,6 +14,10 @@ test_storage_volume_import() {
   lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")" foo | grep -q 'content_type: iso'
   lxc storage volume show "lxdtest-$(basename "${LXD_DIR}")" foobar | grep -q 'content_type: iso'
 
+  # check if storage volumes have an UUID.
+  [ -n "$(lxc storage volume get "lxdtest-$(basename "${LXD_DIR}")" foo volatile.uuid)" ]
+  [ -n "$(lxc storage volume get "lxdtest-$(basename "${LXD_DIR}")" foobar volatile.uuid)" ]
+
   # delete an ISO storage volume and re-import it
   lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")" foo
   lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")" foobar

--- a/test/suites/storage_volume_initial_config.sh
+++ b/test/suites/storage_volume_initial_config.sh
@@ -67,7 +67,6 @@ test_storage_volume_initial_config() {
     lxc storage unset "${pool}" volume.zfs.block_mode
     lxc profile device unset "${profile}" root initial.block.filesystem
 
-
     # > Verify zfs.block_mode without initial configuration.
 
     # Verify "zfs.block_mode=true" is applied from pool configuration.


### PR DESCRIPTION
This PR adds add a `volatile.uuid` config field for each volume, snapshot and bucket. This is a requirement for the Dell PowerFlex storage driver (https://github.com/canonical/lxd/pull/12304) in order to be able to create an equally sized volume name that fits under the size constraints.

A new field gets added to the `drivers.Volume` struct to pass down relevant information from the DB:
* `parentUUID` which contains the parent volumes `volatile.uuid` in case `drivers.Volume` is used to identify a snapshot. This is used when creating snapshots from volumes to be able to reference the parent volume from within the storage driver.

This is a follow up on https://github.com/canonical/lxd/pull/12871 and now applies the `volatile.uuid` also on top of the `drivers.VolumeCopy` struct to allow accessing each volume's UUID including all of its snapshots. 