### PR TITLE
doc: fix extraction of version number

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -28,7 +28,7 @@ author = 'LXD contributors'
 # release = '1.0'
 
 with open("../shared/version/flex.go") as fd:
-    version = fd.read().split("\n")[-2].split()[-1].strip("\"")
+    version = fd.readlines()[3].split()[-1].strip("\"")
 
 # The default value uses the current year as the copyright year.
 #


### PR DESCRIPTION
Make sure the version number is found again, to fix the spelling check in MicroCloud. ;)

See https://github.com/canonical/microcloud/pull/261