### PR TITLE
shared/simplestreams/products: Search only for lxd archives (stable-5.0)

### DIFF
--- a/shared/simplestreams/products.go
+++ b/shared/simplestreams/products.go
@@ -10,8 +10,8 @@ import (
 	"github.com/canonical/lxd/shared/osarch"
 )
 
-var lxdCompatCombinedItems = []string{"lxd_combined.tar.gz", "incus_combined.tar.gz"}
-var lxdCompatItems = []string{"lxd.tar.xz", "incus.tar.xz"}
+var lxdCompatCombinedItems = []string{"lxd_combined.tar.gz"}
+var lxdCompatItems = []string{"lxd.tar.xz"}
 
 // Products represents the base of download.json.
 type Products struct {


### PR DESCRIPTION
By merging https://github.com/canonical/lxd/pull/12834 it is now causing problems consuming `images:` remote because the stable-5.0 didn't get the change to stop searching for incus files from the `images:` remote (https://github.com/canonical/lxd/pull/12748/commits/0c9253da9448475e6de60dd345c67c0179884f13).

Confirmed that the images.linuxcontainers.org metadata is still giving out both incus (`"incus.tar.xz"`) and lxd (`"lxd.tar.xz"`) metadata entries, and so the revert from https://github.com/canonical/lxd/pull/12834 is now causing the original problem I was trying to work around.

```
"ubuntu:jammy:amd64:default": {
      "aliases": "ubuntu/jammy/default,ubuntu/22.04/default,ubuntu/jammy,ubuntu/22.04",
      "arch": "amd64",
      "os": "Ubuntu",
      "release": "jammy",
      "release_title": "jammy",
      "requirements": {},
      "variant": "default",
      "versions": {
        "20240206_07:42": {
          "items": {
            "incus.tar.xz": {
              "ftype": "incus.tar.xz",
              "sha256": "8a57f00189bea6998866ef2d0847cd604461a6818ce1c4b95de12eeabab54f47",
              "size": 672,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/incus.tar.xz",
              "combined_sha256": "fe75174163a60fc12617c568860002fac54b2c5de7978a48a265b2fcfb3a140a",
              "combined_rootxz_sha256": "fe75174163a60fc12617c568860002fac54b2c5de7978a48a265b2fcfb3a140a",
              "combined_squashfs_sha256": "0aa7b66e11bbf30c6f58b9fd26f2cb9fbaf9c1f464addf9aba22f120d1fb0af7",
              "combined_disk-kvm-img_sha256": "6e9b0286df1e7881fb89b243b0f07b19c0a1ffc8dec4a036ba96bdb09768809d"
            },
            "lxd.tar.xz": {
              "ftype": "lxd.tar.xz",
              "sha256": "8a57f00189bea6998866ef2d0847cd604461a6818ce1c4b95de12eeabab54f47",
              "size": 672,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/incus.tar.xz",
              "combined_sha256": "fe75174163a60fc12617c568860002fac54b2c5de7978a48a265b2fcfb3a140a",
              "combined_rootxz_sha256": "fe75174163a60fc12617c568860002fac54b2c5de7978a48a265b2fcfb3a140a",
              "combined_squashfs_sha256": "0aa7b66e11bbf30c6f58b9fd26f2cb9fbaf9c1f464addf9aba22f120d1fb0af7",
              "combined_disk-kvm-img_sha256": "6e9b0286df1e7881fb89b243b0f07b19c0a1ffc8dec4a036ba96bdb09768809d"
            },
            "root.tar.xz": {
              "ftype": "root.tar.xz",
              "sha256": "c100f5eecc0bc83521735de0c0f4625b76ec7d46f0e94df4e4d3fe91631d1226",
              "size": 114731588,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/rootfs.tar.xz"
            },
            "root.squashfs": {
              "ftype": "squashfs",
              "sha256": "ac54ab52733dce55394481c77f7a347f504dd2bc52cd95b1257081c4a7ea86ba",
              "size": 124948480,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/rootfs.squashfs"
            },
            "disk.qcow2": {
              "ftype": "disk-kvm.img",
              "sha256": "5f55bb17e7b034839ec70a9a5a906301f074c1a6d028fed5ebd8b3652c0444f3",
              "size": 276430336,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/disk.qcow2"
            },
            "root.20240205_21:44.vcdiff": {
              "ftype": "squashfs.vcdiff",
              "sha256": "e0f0474a80a10156d370035f687e9897f007eeeaf97054709c8e92d6e638be3e",
              "size": 900559,
              "path": "images/ubuntu/jammy/amd64/default/20240206_07:42/delta-20240205_21:44.vcdiff",
              "delta_base": "20240205_21:44"
            }
          }
        },
```

Signed-off-by: Din Music <din.music@canonical.com>
(cherry picked from commit 0c9253da9448475e6de60dd345c67c0179884f13)