### PR TITLE
Auth: TLS driver should return a false permission checker when client is restricted.

### DIFF
--- a/lxd/auth/driver_tls.go
+++ b/lxd/auth/driver_tls.go
@@ -129,13 +129,13 @@ func (t *tls) GetPermissionChecker(ctx context.Context, r *http.Request, entitle
 			return allowFunc(true), nil
 		}
 
-		return nil, api.StatusErrorf(http.StatusForbidden, "Certificate is restricted")
+		return allowFunc(false), nil
 	case ObjectTypeStoragePool, ObjectTypeCertificate:
 		if entitlement == EntitlementCanView {
 			return allowFunc(true), nil
 		}
 
-		return nil, api.StatusErrorf(http.StatusForbidden, "Certificate is restricted")
+		return allowFunc(false), nil
 	}
 
 	// Error if user does not have access to the project (unless we're getting projects, where we want to filter the results).

--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -30,6 +30,9 @@ test_tls_restrictions() {
   # Confirm no project visible when none listed
   [ "$(lxc_remote project list localhost: --format csv | wc -l)" = 0 ]
 
+  # Confirm we can still view storage pools
+  [ "$(lxc_remote storage list localhost: --format csv | wc -l)" = 1 ]
+
   # Allow access to project blah
   lxc config trust show "${FINGERPRINT}" | sed -e "s/projects: \[\]/projects: ['blah']/" -e "s/restricted: false/restricted: true/" | lxc config trust edit "${FINGERPRINT}"
 


### PR DESCRIPTION
The TLS authorization driver was returning an error on calls to `GetPermissionChecker` when it should have been returning `allowFunc(false)` to indicate the user does not have the given entitlement on any resources of the given type. 

Closes #12846 