### PR TITLE
test/suites: Ensure restricted certs cannot view storage pool config.

### DIFF
--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -33,6 +33,10 @@ test_tls_restrictions() {
   # Confirm we can still view storage pools
   [ "$(lxc_remote storage list localhost: --format csv | wc -l)" = 1 ]
 
+  # Confirm we cannot view storage pool configuration
+  pool_name="$(lxc_remote storage list localhost: --format csv | cut -d, -f1)"
+  ! lxc_remote storage show "localhost:${pool_name}" | grep -F 'source:' || false
+
   # Allow access to project blah
   lxc config trust show "${FINGERPRINT}" | sed -e "s/projects: \[\]/projects: ['blah']/" -e "s/restricted: false/restricted: true/" | lxc config trust edit "${FINGERPRINT}"
 


### PR DESCRIPTION
Follow up to #12848 (see https://github.com/canonical/lxd/pull/12848#discussion_r1484133257)