### PR TITLE
github: ask bug reporters to provide the list of relevant snaps

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,6 +9,7 @@ Feel free to remove anything which doesn't apply to you and add more information
 
  * Distribution:
  * Distribution version:
+ * The output of "snap list --all lxd core20 core22 core24 snapd":
  * The output of "lxc info" or if that fails:
    * Kernel version:
    * LXC version:


### PR DESCRIPTION
@tomponline You'll probably pick up that `core24` is normally not yet on many systems but `snap list` just doesn't care as we can see:

```
$ snap list --all lxd core20 core22 core24 snapd
Name    Version      Rev    Tracking       Publisher   Notes
core20  20231123     2105   latest/stable  canonical✓  base
core22  20231123     1033   latest/stable  canonical✓  base
lxd     git-59a5a74  26985  latest/edge    canonical✓  disabled
lxd     git-def587b  27004  latest/edge    canonical✓  -
snapd   2.61.1       20671  latest/stable  canonical✓  snapd
```