### PR TITLE
lxd/storage/drivers/generic_vfs: Return if the right file was found

### DIFF
--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -794,10 +794,7 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol Volume, snapshots []str
 				}
 
 				if hdr.Name == srcFile {
-					err := unpack(hdr.Size)
-					if err != nil {
-						return err
-					}
+					return unpack(hdr.Size)
 				}
 			}
 


### PR DESCRIPTION
This fixes a regression caused in https://github.com/canonical/lxd/pull/12852/files#diff-30511c7ce3bcabd6a4ddc8624541cc2f5240a13b5e3b19aac8c787fdbd0e4720.

Due to the refactoring it doesn't anymore exit the loop but instead falls back to printing the `"Could not find %q"` after unpacking.