### PR TITLE
test/lint: Temporarily remove `--whole-files` flag.

### DIFF
--- a/test/lint/golangci.sh
+++ b/test/lint/golangci.sh
@@ -39,4 +39,4 @@ elif ! git log --max-count=1 --format=%H "${target_revision}" >/dev/null 2>&1; t
 fi
 
 echo "Checking for golangci-lint errors between HEAD and ${target_branch} (${target_revision})..."
-golangci-lint run --timeout 5m --new --new-from-rev "${target_revision}" --whole-files
+golangci-lint run --timeout 5m --new --new-from-rev "${target_revision}"


### PR DESCRIPTION
This flag was added with the intention that we will slowly improve the quality of the code-base. Some current features are under significant time pressure and affect a large portion of the code base, and this flag is quite prohibitive.

It will still not be possible to add new code that causes lint errors.