### PR TITLE
VM instance's UEFI variables manipulation support

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -175,6 +175,8 @@ type InstanceServer interface {
 	UpdateInstances(state api.InstancesPut, ETag string) (op Operation, err error)
 	RebuildInstance(instanceName string, req api.InstanceRebuildPost) (op Operation, err error)
 	RebuildInstanceFromImage(source ImageServer, image api.Image, instanceName string, req api.InstanceRebuildPost) (op RemoteOperation, err error)
+	GetInstanceUEFIVars(name string) (instanceUEFI *api.InstanceUEFIVars, ETag string, err error)
+	UpdateInstanceUEFIVars(name string, instanceUEFI api.InstanceUEFIVars, ETag string) (err error)
 
 	ExecInstance(instanceName string, exec api.InstanceExecPost, args *InstanceExecArgs) (op Operation, err error)
 	ConsoleInstance(instanceName string, console api.InstanceConsolePost, args *InstanceConsoleArgs) (op Operation, err error)

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -484,6 +484,50 @@ func (r *ProtocolLXD) GetInstance(name string) (*api.Instance, string, error) {
 	return &instance, etag, nil
 }
 
+// GetInstanceUEFIVars returns the instance UEFI variables list for the provided name.
+func (r *ProtocolLXD) GetInstanceUEFIVars(name string) (*api.InstanceUEFIVars, string, error) {
+	instanceUEFI := api.InstanceUEFIVars{}
+
+	path, _, err := r.instanceTypeToPath(api.InstanceTypeAny)
+	if err != nil {
+		return nil, "", err
+	}
+
+	err = r.CheckExtension("instances_uefi_vars")
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Fetch the raw value
+	etag, err := r.queryStruct("GET", fmt.Sprintf("%s/%s/uefi-vars", path, url.PathEscape(name)), nil, "", &instanceUEFI)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &instanceUEFI, etag, nil
+}
+
+// UpdateInstanceUEFIVars updates the instance's UEFI variables.
+func (r *ProtocolLXD) UpdateInstanceUEFIVars(name string, instanceUEFI api.InstanceUEFIVars, ETag string) error {
+	path, _, err := r.instanceTypeToPath(api.InstanceTypeAny)
+	if err != nil {
+		return err
+	}
+
+	err = r.CheckExtension("instances_uefi_vars")
+	if err != nil {
+		return err
+	}
+
+	// Send the request
+	_, _, err = r.query("PUT", fmt.Sprintf("%s/%s/uefi-vars", path, url.PathEscape(name)), instanceUEFI, ETag)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetInstanceFull returns the instance entry for the provided name along with snapshot information.
 func (r *ProtocolLXD) GetInstanceFull(name string) (*api.InstanceFull, string, error) {
 	instance := api.InstanceFull{}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2344,3 +2344,7 @@ when working with volumes.
 ## `import_instance_devices`
 
 This API extension provides the ability to use flags `--device` when importing an instance to override instance's devices.
+
+## `instances_uefi_vars`
+
+This API extension indicates that the `/1.0/instances/{name}/uefi-vars` endpoint is supported on the server. This endpoint allows to get the full list of UEFI variables (HTTP method GET) or replace the entire set of UEFI variables (HTTP method PUT).

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -6,6 +6,7 @@
 :diataxis:/daemon-behavior
 :diataxis:/environment
 :diataxis:/syscall-interception
+:diataxis:/reference/uefi_variables
 :diataxis:User namespace setup </userns-idmap>
 ```
 
@@ -26,5 +27,6 @@ How-to guides:
 :topical:/environment
 :topical:/syscall-interception
 :topical:User namespace setup </userns-idmap>
+:topical:/reference/uefi_variables
 :topical:Configuration option index </config-options>
 ```

--- a/doc/reference/uefi_variables.md
+++ b/doc/reference/uefi_variables.md
@@ -1,0 +1,64 @@
+---
+discourse: ubuntu:42313
+---
+
+# UEFI variables for VMs
+
+{abbr}`UEFI (Unified Extensible Firmware Interface)` variables store and represent configuration settings of the UEFI firmware.
+See [UEFI](https://en.wikipedia.org/wiki/UEFI) for more information.
+
+You can see a list of UEFI variables on your system by running `ls -l /sys/firmware/efi/efivars/`.
+Usually, you don't need to touch these variables, but in specific cases they can be useful to debug UEFI, SHIM, or boot loader issues in virtual machines.
+
+To configure UEFI variables for a VM, use the [`lxc config uefi`](lxc_config_uefi.md) command or the `/1.0/instances/<instance_name>/uefi-vars` endpoint.
+
+For example, to set a variable to a value (hexadecimal):
+
+````{tabs}
+```{group-tab} CLI
+    lxc config uefi set <instance_name> <variable_name>-<GUID>=<value>
+```
+```{group-tab} API
+    lxc query --request PUT /1.0/instances/<instance_name>/uefi-vars --data '{
+      "variables": {
+        "<variable_name>-<GUID>": {
+          "attr": 3,
+          "data": "<value>"
+        },
+      }
+    }'
+
+See [`PUT /1.0/instances/{name}/uefi-vars`](swagger:/instances/instance_uefi_vars_put) for more information.
+```
+````
+
+To display the variables that are set for a specific VM:
+
+````{tabs}
+```{group-tab} CLI
+    lxc config uefi show <instance_name>
+```
+```{group-tab} API
+    lxc query --request GET /1.0/instances/<instance_name>/uefi-vars
+
+See [`GET /1.0/instances/{name}/uefi-vars`](swagger:/instances/instance_uefi_vars_get) for more information.
+```
+````
+
+## Example
+
+You can use UEFI variables to disable secure boot, for example.
+
+```{important}
+Use this method only for debugging purposes.
+LXD provides the {config:option}`instance-security:security.secureboot` option to control the secure boot behavior.
+```
+
+The following command checks the secure boot state:
+
+    lxc config uefi get v1 SecureBootEnable-f0a30bc7-af08-4556-99c4-001009c93a44
+
+A value of `01` indicates that secure boot is active.
+You can then turn it off with the following command:
+
+    lxc config uefi set v1 SecureBootEnable-f0a30bc7-af08-4556-99c4-001009c93a44=00

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2395,6 +2395,47 @@ definitions:
         title: InstanceType represents the type if instance being returned or requested via the API.
         type: string
         x-go-package: github.com/canonical/lxd/shared/api
+    InstanceUEFIVariable:
+        description: InstanceUEFIVariable represents an EFI variable entry
+        properties:
+            attr:
+                description: UEFI variable attributes
+                example: 7
+                format: uint32
+                type: integer
+                x-go-name: Attr
+            data:
+                description: UEFI variable data (HEX-encoded)
+                example: "01"
+                type: string
+                x-go-name: Data
+            digest:
+                description: UEFI variable digest (HEX-encoded)
+                type: string
+                x-go-name: Digest
+            timestamp:
+                description: UEFI variable timestamp (HEX-encoded)
+                type: string
+                x-go-name: Timestamp
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    InstanceUEFIVars:
+        properties:
+            variables:
+                additionalProperties:
+                    $ref: '#/definitions/InstanceUEFIVariable'
+                description: |-
+                    UEFI variables map
+                    Hashmap key format is <uefi-variable-name>-<UUID>
+                example:
+                    SecureBootEnable-f0a30bc7-af08-4556-99c4-001009c93a44:
+                        attr: 3
+                        data: "01"
+                type: object
+                x-go-name: Variables
+        title: InstanceUEFIVars represents the UEFI variables of a LXD virtual machine.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     InstancesPost:
         properties:
             architecture:
@@ -9946,6 +9987,78 @@ paths:
                 "500":
                     $ref: '#/responses/InternalServerError'
             summary: Change the state
+            tags:
+                - instances
+    /1.0/instances/{name}/uefi-vars:
+        get:
+            description: Gets the UEFI variables for a specific VM.
+            operationId: instance_uefi_vars_get
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Instance UEFI variables
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/InstanceUEFIVars'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the instance's UEFI variables
+            tags:
+                - instances
+        put:
+            consumes:
+                - application/json
+            description: Sets the UEFI variables for a specific VM.
+            operationId: instance_uefi_vars_put
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+                - description: UEFI variables update request
+                  in: body
+                  name: instanceEFI
+                  schema:
+                    $ref: '#/definitions/InstanceUEFIVars'
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/EmptySyncResponse'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Set the instance's UEFI variables
             tags:
                 - instances
     /1.0/instances/{name}?recursion=1:

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -68,6 +68,7 @@ var api10 = []APIEndpoint{
 	instanceSnapshotCmd,
 	instanceSnapshotsCmd,
 	instanceStateCmd,
+	instanceUEFIVarsCmd,
 	eventsCmd,
 	imageAliasCmd,
 	imageAliasesCmd,

--- a/lxd/apparmor/pyuefivars.go
+++ b/lxd/apparmor/pyuefivars.go
@@ -1,0 +1,164 @@
+package apparmor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/canonical/lxd/lxd/subprocess"
+	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/shared"
+)
+
+var pythonUEFIVarsProfileTpl = template.Must(template.New("pythonUEFIVarsProfile").Parse(`#include <tunables/global>
+profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  # Python locations
+  /usr/bin/python* mixr,
+  /bin**/*.py r,
+  /usr/lib/python** r,
+  /lib/python** r,
+  /**/pyvenv.cfg r,
+
+{{- if .snap }}
+  # Snap-specific libraries
+  /snap/lxd/*/lib/**.so* mr,
+
+  # Snap-specific Python locations
+  /snap/lxd/*/bin**/*.py r,
+  /snap/lxd/*/usr/lib/python** r,
+  /snap/lxd/*/lib/python** r,
+{{- end }}
+
+{{if .libraryPath -}}
+  # Entries from LD_LIBRARY_PATH
+{{range $index, $element := .libraryPath}}
+  {{$element}}/** mr,
+{{- end }}
+{{- end }}
+}
+`))
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+// Close provides a nop implementation for io.WriteCloser.
+func (*nopWriteCloser) Close() error {
+	return nil
+}
+
+// PythonUEFIVars runs pyuefivars with an AppArmor profile based on the efiVarsPath supplied.
+func PythonUEFIVars(sysOS *sys.OS, stdin io.Reader, stdout io.Writer, efiVarsPath string) error {
+	var input io.ReadCloser
+	var output io.WriteCloser
+
+	cmd := []string{"uefivars.py"}
+	if stdin == nil {
+		f, err := os.OpenFile(efiVarsPath, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = f.Close() }()
+
+		// read from file
+		input = f
+		output = &nopWriteCloser{stdout}
+		cmd = append(cmd, "-o", "json", "-i", "edk2")
+	} else {
+		f, err := os.OpenFile(efiVarsPath, os.O_WRONLY, 0)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = f.Close() }()
+
+		input = io.NopCloser(stdin)
+		// write to file
+		output = f
+		cmd = append(cmd, "-i", "json", "-o", "edk2")
+	}
+
+	profileName, err := pythonUEFIVarsProfileLoad(sysOS, efiVarsPath)
+	if err != nil {
+		return fmt.Errorf("Failed to load pyuefivars profile: %w", err)
+	}
+
+	defer func() {
+		_ = deleteProfile(sysOS, profileName, profileName)
+	}()
+
+	var buffer bytes.Buffer
+	p := subprocess.NewProcessWithFds(cmd[0], cmd[1:], input, output, &nullWriteCloser{&buffer})
+
+	// Drop privileges
+	p.SetCreds(sysOS.UnprivUID, sysOS.UnprivGID)
+
+	// Set AppArmor profile to run with
+	p.SetApparmor(profileName)
+
+	err = p.Start(context.TODO())
+	if err != nil {
+		return fmt.Errorf("Failed running pyuefivars: %w", err)
+	}
+
+	_, err = p.Wait(context.TODO())
+	if err != nil {
+		return shared.NewRunError(cmd[0], cmd[1:], err, nil, &buffer)
+	}
+
+	return nil
+}
+
+// pythonUEFIVarsProfileLoad ensures that the pyuefivars's policy is loaded into the kernel.
+func pythonUEFIVarsProfileLoad(sysOS *sys.OS, efiVarsPath string) (string, error) {
+	name := fmt.Sprintf("<%s>", strings.ReplaceAll(strings.Trim(efiVarsPath, "/"), "/", "-"))
+	profileName := profileName("pyuefivars", name)
+	profilePath := filepath.Join(aaPath, "profiles", profileName)
+	content, err := os.ReadFile(profilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+
+	updated, err := pythonUEFIVarsProfile(profileName)
+	if err != nil {
+		return "", err
+	}
+
+	if string(content) != string(updated) {
+		err = os.WriteFile(profilePath, []byte(updated), 0600)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	err = loadProfile(sysOS, profileName)
+	if err != nil {
+		return "", err
+	}
+
+	return profileName, nil
+}
+
+// pythonUEFIVarsProfile generates the AppArmor profile.
+func pythonUEFIVarsProfile(profileName string) (string, error) {
+	// Render the profile.
+	sb := &strings.Builder{}
+	err := pythonUEFIVarsProfileTpl.Execute(sb, map[string]any{
+		"name":        profileName,
+		"snap":        shared.InSnap(),
+		"libraryPath": strings.Split(os.Getenv("LD_LIBRARY_PATH"), ":"),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return sb.String(), nil
+}

--- a/lxd/instance/drivers/uefi/uefi.go
+++ b/lxd/instance/drivers/uefi/uefi.go
@@ -1,0 +1,160 @@
+package uefi
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/canonical/lxd/lxd/apparmor"
+	"github.com/canonical/lxd/lxd/sys"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// PyUEFIVars represents the JSON output format of the python-uefivars utility
+// URL: https://github.com/awslabs/python-uefivars
+type PyUEFIVars struct {
+	Version   uint32      `json:"version"`
+	Variables []PyUEFIVar `json:"variables"`
+}
+
+// PyUEFIVar represents a UEFI variable entry.
+type PyUEFIVar struct {
+	// UEFI variable name
+	GUID string `json:"guid"`
+
+	// UEFI variable name
+	Name string `json:"name"`
+
+	// UEFI variable data (HEX-encoded)
+	Data string `json:"data"`
+
+	// UEFI variable attributes
+	Attr uint32 `json:"attr"`
+
+	// UEFI variable timestamp (HEX-encoded)
+	Timestamp string `json:"timestamp"`
+
+	// UEFI variable digest (HEX-encoded)
+	Digest string `json:"digest"`
+}
+
+// Validate checks whether the InstanceUEFIVars structure is valid.
+func Validate(e api.InstanceUEFIVars) error {
+	for k, v := range e.Variables {
+		// Hashmap key format is <Var name>-<UUID>
+		// UUID length is 36
+		// Var name length is at least 1
+		// and we have "-" as a separator between name and UUID
+		if len(k) < 36+1+1 {
+			return fmt.Errorf("Bad UEFI variable key: %q", k)
+		}
+
+		guid := k[len(k)-36:]
+		_, err := uuid.Parse(guid)
+		if err != nil {
+			return fmt.Errorf("Bad UEFI variable key: %q. Bad UUID: %w", k, err)
+		}
+
+		name := k[:len(k)-37]
+
+		_, err = hex.DecodeString(v.Timestamp)
+		if err != nil {
+			return fmt.Errorf("Bad UEFI variable (key: %q) timestamp (HEX-encoding expected): %w", k, err)
+		}
+
+		_, err = hex.DecodeString(v.Digest)
+		if err != nil {
+			return fmt.Errorf("Bad UEFI variable (key: %q) digest (HEX-encoding expected): %w", k, err)
+		}
+
+		// Linux kernel efivarfs limits [1] maximum capacity for
+		// the variable data and name to 1024 bytes, while edk2
+		// allows up to 33KiB. [2]
+		// [1] https://github.com/torvalds/linux/blob/1f719a2f3fa67665578c759ac34fd3d3690c1a20/fs/efivarfs/vars.c#L393
+		// [2] https://github.com/tianocore/edk2/blob/e32b58ab5a12d37c82327f28376e7d12cccc8b3a/OvmfPkg/OvmfPkgX64.dsc#L526
+		decodedData, err := hex.DecodeString(v.Data)
+		if err != nil {
+			return fmt.Errorf("Bad UEFI variable (key: %q) data (HEX-encoding expected): %w", k, err)
+		}
+
+		if len(name)+len(decodedData) > 0x8400 {
+			return fmt.Errorf("Bad UEFI variable key: %q", k)
+		}
+	}
+
+	return nil
+}
+
+// UEFIVars reads UEFI Variables for instance.
+func UEFIVars(sysOS *sys.OS, uefiVarsPath string) (*api.InstanceUEFIVars, error) {
+	var stdout bytes.Buffer
+	err := apparmor.PythonUEFIVars(sysOS, nil, &stdout, uefiVarsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	pyUEFIVars := PyUEFIVars{}
+	err = json.Unmarshal(stdout.Bytes(), &pyUEFIVars)
+	if err != nil {
+		return nil, err
+	}
+
+	if pyUEFIVars.Version != 2 {
+		return nil, fmt.Errorf("python-uefivars utility version is not compatible with LXD server")
+	}
+
+	instanceUEFI := api.InstanceUEFIVars{}
+	instanceUEFI.Variables = make(map[string]api.InstanceUEFIVariable)
+
+	for _, v := range pyUEFIVars.Variables {
+		key := v.Name + "-" + v.GUID
+		instanceUEFI.Variables[key] = api.InstanceUEFIVariable{
+			Data:      v.Data,
+			Attr:      v.Attr,
+			Timestamp: v.Timestamp,
+			Digest:    v.Digest,
+		}
+	}
+
+	return &instanceUEFI, nil
+}
+
+// UEFIVarsUpdate updates UEFI Variables for instance.
+func UEFIVarsUpdate(sysOS *sys.OS, newUEFIVarsSet api.InstanceUEFIVars, uefiVarsPath string) error {
+	err := Validate(newUEFIVarsSet)
+	if err != nil {
+		return err
+	}
+
+	pyUEFIVars := PyUEFIVars{
+		Version:   2,
+		Variables: make([]PyUEFIVar, 0),
+	}
+
+	for k, v := range newUEFIVarsSet.Variables {
+		pyUEFIVars.Variables = append(pyUEFIVars.Variables, PyUEFIVar{
+			GUID:      k[len(k)-36:],
+			Name:      k[:len(k)-37],
+			Data:      v.Data,
+			Attr:      v.Attr,
+			Timestamp: v.Timestamp,
+			Digest:    v.Digest,
+		})
+	}
+
+	pyUEFIVarsJSON, err := json.Marshal(pyUEFIVars)
+	if err != nil {
+		return err
+	}
+
+	err = apparmor.PythonUEFIVars(sysOS, strings.NewReader(string(pyUEFIVarsJSON)), nil, uefiVarsPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -187,6 +187,10 @@ type VM interface {
 	Instance
 
 	AgentCertificate() *x509.Certificate
+
+	// UEFI vars handling.
+	UEFIVars() (*api.InstanceUEFIVars, error)
+	UEFIVarsUpdate(newUEFIVarsSet api.InstanceUEFIVars) error
 }
 
 // CriuMigrationArgs arguments for CRIU migration.

--- a/lxd/instance_uefi_vars.go
+++ b/lxd/instance_uefi_vars.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
+	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// swagger:operation GET /1.0/instances/{name}/uefi-vars instances instance_uefi_vars_get
+//
+//	Get the instance's UEFI variables
+//
+//	Gets the UEFI variables for a specific VM.
+//
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Instance UEFI variables
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/InstanceUEFIVars"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func instanceUEFIVarsGet(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	instanceType, err := urlInstanceTypeDetect(r)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	projectName := request.ProjectParam(r)
+	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if shared.IsSnapshot(name) {
+		return response.BadRequest(fmt.Errorf("Invalid instance name"))
+	}
+
+	// Handle requests targeted to a container on a different node
+	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if resp != nil {
+		return resp
+	}
+
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if inst.Type() != instancetype.VM {
+		return response.BadRequest(fmt.Errorf("UEFI variables manipulation supported for VM type instances only"))
+	}
+
+	instanceUEFI, err := inst.(instance.VM).UEFIVars()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	etag := []any{instanceUEFI}
+
+	return response.SyncResponseETag(true, instanceUEFI, etag)
+}
+
+// swagger:operation PUT /1.0/instances/{name}/uefi-vars instances instance_uefi_vars_put
+//
+//	Set the instance's UEFI variables
+//
+//	Sets the UEFI variables for a specific VM.
+//
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: instanceEFI
+//	    description: UEFI variables update request
+//	    schema:
+//	      $ref: "#/definitions/InstanceUEFIVars"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func instanceUEFIVarsPut(d *Daemon, r *http.Request) response.Response {
+	// Don't mess with instance while in setup mode.
+	<-d.waitReady.Done()
+
+	s := d.State()
+
+	instanceType, err := urlInstanceTypeDetect(r)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	projectName := request.ProjectParam(r)
+
+	// Get the container
+	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if shared.IsSnapshot(name) {
+		return response.BadRequest(fmt.Errorf("Invalid instance name"))
+	}
+
+	// Handle requests targeted to a container on a different node
+	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if resp != nil {
+		return resp
+	}
+
+	unlock, err := instanceOperationLock(s.ShutdownCtx, projectName, name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	defer unlock()
+
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if inst.Type() != instancetype.VM {
+		return response.BadRequest(fmt.Errorf("UEFI variables manipulation supported for VM type instances only"))
+	}
+
+	instanceUEFI, err := inst.(instance.VM).UEFIVars()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Validate the ETag
+	etag := []any{instanceUEFI}
+	err = util.EtagCheck(r, etag)
+	if err != nil {
+		return response.PreconditionFailed(err)
+	}
+
+	configRaw := api.InstanceUEFIVars{}
+	err = json.NewDecoder(r.Body).Decode(&configRaw)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	err = inst.(instance.VM).UEFIVarsUpdate(configRaw)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -53,6 +53,17 @@ var instanceCmd = APIEndpoint{
 	Patch:  APIEndpointAction{Handler: instancePatch, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanEdit, "name")},
 }
 
+var instanceUEFIVarsCmd = APIEndpoint{
+	Name: "instanceUEFIVars",
+	Path: "instances/{name}/uefi-vars",
+	Aliases: []APIEndpointAlias{
+		{Name: "vmUEFIVars", Path: "virtual-machines/{name}/uefi-vars"},
+	},
+
+	Get: APIEndpointAction{Handler: instanceUEFIVarsGet, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanView, "name")},
+	Put: APIEndpointAction{Handler: instanceUEFIVarsPut, AccessHandler: allowPermission(entity.TypeInstance, auth.EntitlementCanEdit, "name")},
+}
+
 var instanceRebuildCmd = APIEndpoint{
 	Name: "instanceRebuild",
 	Path: "instances/{name}/rebuild",

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,6 +60,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -74,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -378,7 +413,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -398,7 +433,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -415,15 +450,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,11 +491,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -473,7 +508,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -522,11 +557,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -589,7 +624,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -626,7 +661,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -697,7 +732,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -716,7 +751,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -871,7 +906,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -895,7 +930,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -943,13 +978,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -963,7 +998,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1017,8 +1052,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1096,14 +1131,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1214,12 +1250,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1248,7 +1284,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1510,12 +1546,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1573,9 +1610,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1772,6 +1809,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1780,7 +1821,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1892,7 +1933,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1902,7 +1943,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2102,11 +2143,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2116,7 +2157,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2126,12 +2167,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2156,7 +2197,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2238,7 +2279,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2276,7 +2317,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2292,8 +2333,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2360,7 +2405,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2372,7 +2417,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2523,7 +2568,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2654,6 +2699,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2672,7 +2721,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2744,7 +2793,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2753,7 +2802,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3102,7 +3151,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3281,6 +3330,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3377,7 +3430,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3700,7 +3753,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3728,7 +3781,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3755,7 +3808,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3957,7 +4010,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4024,11 +4077,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4044,7 +4097,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4057,7 +4110,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4069,7 +4122,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4086,10 +4139,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4199,7 +4252,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4297,7 +4350,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4388,37 +4441,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4488,7 +4541,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4537,7 +4590,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4561,6 +4614,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4678,7 +4735,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4715,25 +4772,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4770,11 +4831,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4930,7 +4991,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4998,7 +5059,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5042,11 +5103,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5126,11 +5191,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5338,7 +5403,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5419,7 +5484,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5447,12 +5512,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5588,13 +5653,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5686,7 +5751,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5714,7 +5779,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5754,6 +5819,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5770,7 +5839,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5886,7 +5955,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6021,7 +6090,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6191,7 +6260,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6210,6 +6280,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6609,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6617,15 +6695,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6633,7 +6711,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6706,13 +6784,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6722,6 +6800,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6945,7 +7038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6957,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6994,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,6 +100,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -124,7 +159,7 @@ msgstr ""
 "### Dies ist eine yaml-Repräsentation des Cluster-Mitglieds.\n"
 "### Jede mit '# beginnende Zeile wird ignoriert."
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -626,7 +661,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -650,7 +685,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -670,15 +705,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -716,11 +751,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -733,7 +768,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
@@ -789,11 +824,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -859,7 +894,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -898,7 +933,7 @@ msgstr "Aliasse:\n"
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -976,7 +1011,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -995,7 +1030,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1163,7 +1198,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1187,7 +1222,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1239,13 +1274,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1259,7 +1294,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1314,8 +1349,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1396,14 +1431,15 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1519,12 +1555,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1553,7 +1589,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1844,12 +1880,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1907,9 +1944,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2123,6 +2160,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
@@ -2133,7 +2175,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2255,7 +2297,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2265,7 +2307,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2478,11 +2520,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2492,7 +2534,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2502,12 +2544,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2532,7 +2574,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2618,7 +2660,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2656,7 +2698,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2672,10 +2714,15 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2749,7 +2796,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2763,7 +2810,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2926,7 +2973,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3062,6 +3109,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -3080,7 +3131,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3154,7 +3205,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -3164,7 +3215,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3546,7 +3597,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3741,6 +3792,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/config.go:31 lxc/config.go:32
 #, fuzzy
 msgid "Manage instance and server configuration options"
@@ -3858,7 +3914,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4206,7 +4262,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4234,7 +4290,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4261,7 +4317,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4469,7 +4525,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4536,11 +4592,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4556,7 +4612,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -4570,7 +4626,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -4584,7 +4640,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4601,10 +4657,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4719,7 +4775,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4818,7 +4874,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4915,37 +4971,37 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5025,7 +5081,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -5079,7 +5135,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -5105,6 +5161,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5230,7 +5290,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -5267,21 +5327,21 @@ msgstr "Erstellt: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5289,6 +5349,11 @@ msgstr ""
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5326,12 +5391,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5497,7 +5562,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5573,7 +5638,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5620,12 +5685,17 @@ msgstr "Geräte zu Containern oder Profilen hinzufügen"
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "Anhalten des Containers fehlgeschlagen!"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -5719,11 +5789,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5943,7 +6013,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6029,7 +6099,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6058,12 +6128,12 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6203,13 +6273,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6302,7 +6372,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -6330,7 +6400,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6371,6 +6441,11 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6390,7 +6465,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6528,7 +6603,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6674,7 +6749,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6998,7 +7073,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7035,6 +7111,22 @@ msgstr ""
 #: lxc/config_device.go:354
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -7831,7 +7923,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7849,7 +7941,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -7857,7 +7949,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -7865,7 +7957,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7882,7 +7974,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -7955,13 +8047,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7971,6 +8063,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -8198,7 +8305,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -8210,7 +8317,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8247,7 +8354,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -527,11 +562,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -595,7 +630,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -632,7 +667,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -703,7 +738,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -722,7 +757,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -878,7 +913,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -902,7 +937,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -950,13 +985,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -970,7 +1005,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1024,8 +1059,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1103,14 +1138,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1221,12 +1257,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1255,7 +1291,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1524,12 +1560,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1587,9 +1624,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1790,6 +1827,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1798,7 +1839,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1915,7 +1956,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1925,7 +1966,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2125,11 +2166,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2139,7 +2180,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2149,12 +2190,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2179,7 +2220,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2261,7 +2302,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2299,7 +2340,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2315,8 +2356,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2389,7 +2434,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2402,7 +2447,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2559,7 +2604,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2690,6 +2735,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2708,7 +2757,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2780,7 +2829,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2789,7 +2838,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3140,7 +3189,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3320,6 +3369,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "  Χρήση δικτύου:"
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3425,7 +3479,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3755,7 +3809,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3783,7 +3837,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3810,7 +3864,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4014,7 +4068,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4081,11 +4135,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4101,7 +4155,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4114,7 +4168,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4127,7 +4181,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4144,10 +4198,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4257,7 +4311,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4355,7 +4409,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4446,37 +4500,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4550,7 +4604,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4600,7 +4654,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4624,6 +4678,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4742,7 +4800,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4779,25 +4837,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4835,11 +4897,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5001,7 +5063,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5075,7 +5137,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5120,11 +5182,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5212,11 +5278,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5425,7 +5491,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5506,7 +5572,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5534,12 +5600,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
@@ -5675,13 +5741,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5773,7 +5839,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5801,7 +5867,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5841,6 +5907,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -5858,7 +5928,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5990,7 +6060,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6125,7 +6195,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6295,7 +6365,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6314,6 +6385,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6713,7 +6792,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6721,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6737,7 +6816,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6810,13 +6889,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6826,6 +6905,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7049,7 +7143,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7061,7 +7155,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7098,7 +7192,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,6 +108,41 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -128,7 +163,7 @@ msgstr ""
 "### Esta es una representación YAML del grupo de clústeres.\n"
 "### Cualquier línea que empiece con un '#' será ignorada."
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -615,7 +650,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -637,7 +672,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -655,15 +690,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -697,11 +732,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -714,7 +749,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -766,11 +801,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -834,7 +869,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -871,7 +906,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -944,7 +979,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -963,7 +998,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -1122,7 +1157,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1147,7 +1182,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1195,13 +1230,13 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1215,7 +1250,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1270,8 +1305,8 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1351,14 +1386,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1471,12 +1507,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1505,7 +1541,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1779,12 +1815,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1842,9 +1879,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2045,6 +2082,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -2053,7 +2094,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2170,7 +2211,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2180,7 +2221,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2384,11 +2425,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2398,7 +2439,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2408,12 +2449,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2438,7 +2479,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2521,7 +2562,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2559,7 +2600,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2575,9 +2616,14 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "Aliases:"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2649,7 +2695,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2662,7 +2708,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2822,7 +2868,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2956,6 +3002,11 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#, fuzzy
+msgid "Instance name must be specified"
+msgstr "Nombre del contenedor es: %s"
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2974,7 +3025,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3047,7 +3098,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3056,7 +3107,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3416,7 +3467,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3598,6 +3649,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "Nombre del Miembro del Cluster"
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3703,7 +3759,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4043,7 +4099,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4071,7 +4127,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4098,7 +4154,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4300,7 +4356,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4367,11 +4423,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4443,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4400,7 +4456,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4413,7 +4469,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4430,10 +4486,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4547,7 +4603,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4645,7 +4701,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4738,37 +4794,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4843,7 +4899,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4894,7 +4950,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4918,6 +4974,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5041,7 +5101,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -5078,19 +5138,19 @@ msgstr "Creado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5098,6 +5158,11 @@ msgstr ""
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "Aliases:"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5134,11 +5199,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5300,7 +5365,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5374,7 +5439,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5419,11 +5484,16 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "Dispositivo %s añadido a %s"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5511,11 +5581,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5725,7 +5795,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5808,7 +5878,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5836,12 +5906,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -5978,13 +6048,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6078,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -6106,7 +6176,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6146,6 +6216,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "Aliases:"
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6163,7 +6238,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6295,7 +6370,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6431,7 +6506,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6636,7 +6711,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -6660,6 +6736,16 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: lxc/config_device.go:354
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/config_device.go:443
@@ -7150,7 +7236,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7160,17 +7246,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7180,7 +7266,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -7253,13 +7339,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7269,6 +7355,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7492,7 +7593,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7504,7 +7605,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7541,7 +7642,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,6 +100,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -126,7 +161,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -622,7 +657,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -642,7 +677,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -661,17 +696,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -714,12 +749,12 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -732,7 +767,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
@@ -786,11 +821,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Ajouter de nouveaux serveurs distants"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -865,7 +900,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -903,7 +938,7 @@ msgstr "Alias :"
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -980,7 +1015,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -999,7 +1034,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Rendre l'image publique"
@@ -1159,7 +1194,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1185,7 +1220,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1234,13 +1269,13 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1254,7 +1289,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1309,8 +1344,8 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1399,14 +1434,15 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1523,12 +1559,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1557,7 +1593,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1869,12 +1905,13 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1932,9 +1969,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2143,6 +2180,11 @@ msgstr "Création du conteneur"
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
@@ -2153,7 +2195,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2276,7 +2318,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2286,7 +2328,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2510,12 +2552,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2525,7 +2567,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2535,12 +2577,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2565,7 +2607,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2652,7 +2694,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2690,7 +2732,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2706,9 +2748,14 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "Création du conteneur"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2782,7 +2829,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2796,7 +2843,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2963,7 +3010,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3107,6 +3154,11 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#, fuzzy
+msgid "Instance name must be specified"
+msgstr "Le nom du conteneur est : %s"
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -3125,7 +3177,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3198,7 +3250,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -3208,7 +3260,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3633,7 +3685,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3822,6 +3874,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/config.go:31 lxc/config.go:32
 #, fuzzy
 msgid "Manage instance and server configuration options"
@@ -3939,7 +3996,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4293,7 +4350,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4321,7 +4378,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr "NON"
 
@@ -4349,7 +4406,7 @@ msgstr ""
 msgid "Name"
 msgstr "Nom : %s"
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4563,7 +4620,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4635,11 +4692,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4656,7 +4713,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -4670,7 +4727,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -4684,7 +4741,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4701,10 +4758,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4820,7 +4877,7 @@ msgstr "Profil %s supprimé"
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4918,7 +4975,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -5018,37 +5075,37 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5128,7 +5185,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -5182,7 +5239,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -5208,6 +5265,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5350,7 +5411,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5390,21 +5451,21 @@ msgstr "Créé : %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -5412,6 +5473,11 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "Création du conteneur"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5449,12 +5515,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5622,7 +5688,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5698,7 +5764,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5745,12 +5811,17 @@ msgstr "Afficher la configuration étendue"
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "L'arrêt du conteneur a échoué !"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -5849,12 +5920,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6076,7 +6147,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6167,7 +6238,7 @@ msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6196,12 +6267,12 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6340,7 +6411,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
@@ -6348,7 +6419,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6442,7 +6513,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr "URL"
 
@@ -6470,7 +6541,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -6511,6 +6582,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "tous les profils de la source n'existent pas sur la cible"
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6530,7 +6606,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6671,7 +6747,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6814,7 +6890,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr "OUI"
 
@@ -7162,7 +7238,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7202,6 +7279,22 @@ msgstr ""
 #: lxc/config_device.go:354
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -8073,7 +8166,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8097,7 +8190,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8105,7 +8198,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8113,7 +8206,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -8133,7 +8226,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8207,13 +8300,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8223,6 +8316,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -8468,7 +8576,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -8481,7 +8589,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8518,7 +8626,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,6 +64,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -78,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -382,7 +417,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -402,7 +437,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -419,15 +454,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,11 +495,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -477,7 +512,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -526,11 +561,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -593,7 +628,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -630,7 +665,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -701,7 +736,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -720,7 +755,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -875,7 +910,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -899,7 +934,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -947,13 +982,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +1002,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1021,8 +1056,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1100,14 +1135,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1218,12 +1254,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1288,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1514,12 +1550,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1577,9 +1614,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1776,6 +1813,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1784,7 +1825,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1896,7 +1937,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1906,7 +1947,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2106,11 +2147,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2120,7 +2161,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2130,12 +2171,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2160,7 +2201,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2242,7 +2283,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2280,7 +2321,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2296,8 +2337,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2364,7 +2409,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2376,7 +2421,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2527,7 +2572,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2658,6 +2703,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2676,7 +2725,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2748,7 +2797,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2757,7 +2806,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3106,7 +3155,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3285,6 +3334,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3381,7 +3434,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3704,7 +3757,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3732,7 +3785,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3759,7 +3812,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3961,7 +4014,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4028,11 +4081,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4048,7 +4101,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4061,7 +4114,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4073,7 +4126,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4090,10 +4143,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4203,7 +4256,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4301,7 +4354,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4392,37 +4445,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4492,7 +4545,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4541,7 +4594,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4565,6 +4618,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4682,7 +4739,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4719,25 +4776,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4774,11 +4835,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4934,7 +4995,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5002,7 +5063,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5046,11 +5107,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5130,11 +5195,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5342,7 +5407,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5423,7 +5488,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5451,12 +5516,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5592,13 +5657,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5690,7 +5755,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5718,7 +5783,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5758,6 +5823,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5774,7 +5843,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5890,7 +5959,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6025,7 +6094,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6195,7 +6264,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6214,6 +6284,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6613,7 +6691,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6621,15 +6699,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6637,7 +6715,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6710,13 +6788,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6726,6 +6804,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6949,7 +7042,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6961,7 +7054,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6998,7 +7091,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,6 +108,41 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -138,7 +173,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -616,7 +651,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -636,7 +671,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -654,15 +689,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -696,11 +731,11 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -713,7 +748,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -765,11 +800,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -833,7 +868,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -870,7 +905,7 @@ msgstr "Alias:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -943,7 +978,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -962,7 +997,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -1118,7 +1153,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1142,7 +1177,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1190,13 +1225,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1210,7 +1245,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1265,8 +1300,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1344,14 +1379,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1462,12 +1498,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1496,7 +1532,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1773,12 +1809,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1836,9 +1873,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2042,6 +2079,11 @@ msgstr "Creazione del container in corso"
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "Creazione del container in corso"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -2050,7 +2092,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2166,7 +2208,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2176,7 +2218,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2379,11 +2421,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2393,7 +2435,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2403,12 +2445,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2433,7 +2475,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2517,7 +2559,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2555,7 +2597,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2571,9 +2613,14 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "Creazione del container in corso"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2643,7 +2690,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2656,7 +2703,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2813,7 +2860,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2947,6 +2994,11 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#, fuzzy
+msgid "Instance name must be specified"
+msgstr "Il nome del container è: %s"
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2965,7 +3017,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3038,7 +3090,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -3048,7 +3100,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3409,7 +3461,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3594,6 +3646,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "Creazione del container in corso"
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3701,7 +3758,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4039,7 +4096,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4067,7 +4124,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4094,7 +4151,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4297,7 +4354,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4364,11 +4421,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4441,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4398,7 +4455,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4411,7 +4468,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4428,10 +4485,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4543,7 +4600,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4641,7 +4698,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4735,37 +4792,37 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4841,7 +4898,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4892,7 +4949,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4916,6 +4973,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5039,7 +5100,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -5076,19 +5137,19 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5096,6 +5157,11 @@ msgstr ""
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "Creazione del container in corso"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5132,11 +5198,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5296,7 +5362,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5368,7 +5434,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5413,11 +5479,16 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "errore di processamento degli alias %s\n"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5505,11 +5576,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5721,7 +5792,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5803,7 +5874,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5832,12 +5903,12 @@ msgstr "il remote %s non esiste"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
@@ -5974,13 +6045,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6073,7 +6144,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -6101,7 +6172,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -6142,6 +6213,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "non tutti i profili dell'origine esistono nella destinazione"
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6160,7 +6236,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6286,7 +6362,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6423,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6631,7 +6707,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -6655,6 +6732,16 @@ msgstr "Creazione del container in corso"
 #: lxc/config_device.go:354
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr "Creazione del container in corso"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr "Creazione del container in corso"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
 #: lxc/config_device.go:443
@@ -7145,7 +7232,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7155,17 +7242,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
@@ -7175,7 +7262,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -7248,13 +7335,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7264,6 +7351,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7487,7 +7589,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -7500,7 +7602,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7537,7 +7639,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,6 +95,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -115,7 +150,7 @@ msgstr ""
 "### This is a YAML representation of the cluster group.\n"
 "### Any line starting with a '# will be ignored."
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -610,7 +645,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -630,7 +665,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -647,15 +682,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -690,11 +725,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -707,7 +742,7 @@ msgstr "アクセスキー（空白の場合自動生成）"
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -758,11 +793,11 @@ msgstr "グループからメンバーを削除します"
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -843,7 +878,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -880,7 +915,7 @@ msgstr "エイリアス:"
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -956,7 +991,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -975,7 +1010,7 @@ msgstr "自動更新は pull モードのときのみ有効です"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr "利用可能なプロジェクト:"
 
@@ -1133,7 +1168,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1157,7 +1192,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1210,14 +1245,14 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1231,7 +1266,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1285,8 +1320,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1368,14 +1403,15 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1501,12 +1537,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1535,7 +1571,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1801,12 +1837,13 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1864,9 +1901,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2071,6 +2108,11 @@ msgstr "インスタンス内のファイルを編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "インスタンスのメタデータファイルを編集します"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr "インスタンスのファイルテンプレートを編集します"
@@ -2079,7 +2121,7 @@ msgstr "インスタンスのファイルテンプレートを編集します"
 msgid "Edit instance metadata files"
 msgstr "インスタンスのメタデータファイルを編集します"
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr "インスタンスもしくはサーバの設定をYAMLファイルで編集します"
 
@@ -2202,7 +2244,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2212,7 +2254,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
@@ -2427,11 +2469,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2441,7 +2483,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2451,12 +2493,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2481,7 +2523,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -2579,7 +2621,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2617,7 +2659,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2633,9 +2675,14 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "インスタンスからファイルをマウントします"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2710,7 +2757,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2722,7 +2769,7 @@ msgstr "クラスターメンバーの設定値を取得します"
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定値を取得します"
 
@@ -2879,7 +2926,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3017,6 +3064,11 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#, fuzzy
+msgid "Instance name must be specified"
+msgstr "インスタンス名: %s"
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
@@ -3035,7 +3087,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3115,7 +3167,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -3124,7 +3176,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3596,7 +3648,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -3806,6 +3858,11 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "インスタンスのメタデータファイルを管理します"
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr "インスタンスやサーバの設定を管理します"
@@ -3906,7 +3963,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -4247,7 +4304,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4275,7 +4332,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr "NO"
 
@@ -4302,7 +4359,7 @@ msgstr "NVRM バージョン: %v"
 msgid "Name"
 msgstr "名前"
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
@@ -4507,7 +4564,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4574,11 +4631,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4594,7 +4651,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -4607,7 +4664,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -4619,7 +4676,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4636,10 +4693,10 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4751,7 +4808,7 @@ msgstr "プロジェクト %s を削除しました"
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
@@ -4852,7 +4909,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -4945,37 +5002,37 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -5045,7 +5102,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5094,7 +5151,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5120,6 +5177,10 @@ msgstr "レンダー: %s (%s)"
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
+msgstr ""
 
 #: lxc/delete.go:36
 msgid "Require user confirmation"
@@ -5243,7 +5304,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5280,20 +5341,20 @@ msgstr "秘密鍵: %s"
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 #, fuzzy
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -5301,6 +5362,11 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 #, c-format
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "インスタンスからファイルをマウントします"
 
 #: lxc/cluster.go:366
 msgid "Set a cluster member's configuration keys"
@@ -5344,11 +5410,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5553,7 +5619,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5630,7 +5696,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5675,11 +5741,16 @@ msgstr "デバイスの設定をすべて表示します"
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "インスタンスのメタデータファイルを表示します"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -5759,11 +5830,11 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -5971,7 +6042,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6055,7 +6126,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6086,12 +6157,12 @@ msgstr "プロファイルのデバイスが存在しません"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6241,7 +6312,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
@@ -6250,7 +6321,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6346,7 +6417,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr "URL"
 
@@ -6374,7 +6445,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -6414,6 +6485,11 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
@@ -6430,7 +6506,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -6555,7 +6631,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6698,7 +6774,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr "YES"
 
@@ -6872,7 +6948,8 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
@@ -6892,6 +6969,16 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr "[<remote>:][<instance>] <key>"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
+msgstr "[<remote>:][<instance>] <key>=<value>..."
 
 #: lxc/config_device.go:443
 msgid "[<remote>:]<instance> <name>..."
@@ -7309,7 +7396,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -7317,15 +7404,15 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
@@ -7334,7 +7421,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr "現在値"
 
@@ -7428,7 +7515,7 @@ msgstr ""
 "    some-pool 上の some-volume ボリュームをインスタンス内の /opt にマウントし"
 "ます。"
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
@@ -7436,7 +7523,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7455,6 +7542,24 @@ msgstr ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
+
+#: lxc/config.go:1166
+#, fuzzy
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+"lxc config edit <instance> < instance.yaml\n"
+"    インスタンスの設定を config.yaml を使って更新します。"
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
+msgstr ""
 
 #: lxc/export.go:34
 msgid ""
@@ -7786,7 +7891,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr "n"
 
@@ -7798,7 +7903,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7837,7 +7942,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr "y"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,6 +60,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -74,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -378,7 +413,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -398,7 +433,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -415,15 +450,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,11 +491,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -473,7 +508,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -522,11 +557,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -589,7 +624,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -626,7 +661,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -697,7 +732,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -716,7 +751,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -871,7 +906,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -895,7 +930,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -943,13 +978,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -963,7 +998,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1017,8 +1052,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1096,14 +1131,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1214,12 +1250,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1248,7 +1284,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1510,12 +1546,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1573,9 +1610,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1772,6 +1809,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1780,7 +1821,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1892,7 +1933,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1902,7 +1943,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2102,11 +2143,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2116,7 +2157,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2126,12 +2167,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2156,7 +2197,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2238,7 +2279,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2276,7 +2317,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2292,8 +2333,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2360,7 +2405,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2372,7 +2417,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2523,7 +2568,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2654,6 +2699,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2672,7 +2721,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2744,7 +2793,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2753,7 +2802,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3102,7 +3151,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3281,6 +3330,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3377,7 +3430,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3700,7 +3753,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3728,7 +3781,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3755,7 +3808,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3957,7 +4010,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4024,11 +4077,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4044,7 +4097,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4057,7 +4110,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4069,7 +4122,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4086,10 +4139,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4199,7 +4252,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4297,7 +4350,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4388,37 +4441,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4488,7 +4541,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4537,7 +4590,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4561,6 +4614,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4678,7 +4735,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4715,25 +4772,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4770,11 +4831,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4930,7 +4991,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4998,7 +5059,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5042,11 +5103,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5126,11 +5191,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5338,7 +5403,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5419,7 +5484,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5447,12 +5512,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5588,13 +5653,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5686,7 +5751,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5714,7 +5779,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5754,6 +5819,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5770,7 +5839,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5886,7 +5955,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6021,7 +6090,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6191,7 +6260,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6210,6 +6280,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6609,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6617,15 +6695,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6633,7 +6711,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6706,13 +6784,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6722,6 +6800,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6945,7 +7038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6957,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6994,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-02-07 09:44+0000\n"
+        "POT-Creation-Date: 2024-02-20 10:14+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,6 +57,39 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
+#: lxc/config.go:1177
+msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
+        "### Any line starting with a '# will be ignored.\n"
+        "###\n"
+        "### A sample UEFI variables configuration looks like:\n"
+        "### variables:\n"
+        "###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+        "###     data: 3a5001001000afaf040000000100000000000000\n"
+        "###     attr: 3\n"
+        "###     timestamp: \"\"\n"
+        "###     digest: \"\"\n"
+        "###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+        "###     data: df7f3f\n"
+        "###     attr: 3\n"
+        "###     timestamp: \"\"\n"
+        "###     digest: \"\"\n"
+        "###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+        "###     data: \"07000100020003000400050000000600\"\n"
+        "###     attr: 7\n"
+        "###     timestamp: \"\"\n"
+        "###     digest: \"\"\n"
+        "###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+        "###     data: 0e00000100012cb0289c00163e0bd47a\n"
+        "###     attr: 3\n"
+        "###     timestamp: \"\"\n"
+        "###     digest: \"\"\n"
+        "###\n"
+        "### Note that the format of the key in the variables map is \"<EFI variable name>-<UUID>\".\n"
+        "### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+        "### Field \"attr\" is an unsigned 32-bit integer.\n"
+        "###"
+msgstr  ""
+
 #: lxc/config_trust.go:245
 msgid   "### This is a YAML representation of the certificate.\n"
         "### Any line starting with a '# will be ignored.\n"
@@ -69,7 +102,7 @@ msgid   "### This is a YAML representation of the cluster group.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid   "### This is a YAML representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -356,7 +389,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -376,7 +409,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793 lxc/info.go:453
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797 lxc/info.go:453
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -392,15 +425,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -432,11 +465,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -449,7 +482,7 @@ msgstr  ""
 msgid   "Access key: %s"
 msgstr  ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid   "Access the expanded configuration"
 msgstr  ""
 
@@ -498,11 +531,11 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -558,7 +591,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -595,7 +628,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -665,7 +698,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -684,7 +717,7 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid   "Available projects:"
 msgstr  ""
 
@@ -837,7 +870,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -861,7 +894,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -907,12 +940,12 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -926,7 +959,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -980,7 +1013,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734 lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1697 lxc/storage_volume.go:1824 lxc/storage_volume.go:1970 lxc/storage_volume.go:2074 lxc/storage_volume.go:2114 lxc/storage_volume.go:2207 lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738 lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56 lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792 lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283 lxc/network_forward.go:170 lxc/network_forward.go:234 lxc/network_forward.go:406 lxc/network_forward.go:529 lxc/network_forward.go:671 lxc/network_forward.go:748 lxc/network_forward.go:814 lxc/network_load_balancer.go:172 lxc/network_load_balancer.go:236 lxc/network_load_balancer.go:407 lxc/network_load_balancer.go:530 lxc/network_load_balancer.go:673 lxc/network_load_balancer.go:749 lxc/network_load_balancer.go:813 lxc/network_load_balancer.go:914 lxc/network_load_balancer.go:976 lxc/storage.go:99 lxc/storage.go:347 lxc/storage.go:418 lxc/storage.go:671 lxc/storage.go:765 lxc/storage.go:850 lxc/storage_bucket.go:85 lxc/storage_bucket.go:185 lxc/storage_bucket.go:248 lxc/storage_bucket.go:379 lxc/storage_bucket.go:536 lxc/storage_bucket.go:629 lxc/storage_bucket.go:695 lxc/storage_bucket.go:770 lxc/storage_bucket.go:850 lxc/storage_bucket.go:928 lxc/storage_bucket.go:993 lxc/storage_bucket.go:1129 lxc/storage_volume.go:335 lxc/storage_volume.go:537 lxc/storage_volume.go:616 lxc/storage_volume.go:860 lxc/storage_volume.go:1074 lxc/storage_volume.go:1187 lxc/storage_volume.go:1617 lxc/storage_volume.go:1697 lxc/storage_volume.go:1824 lxc/storage_volume.go:1970 lxc/storage_volume.go:2074 lxc/storage_volume.go:2114 lxc/storage_volume.go:2207 lxc/storage_volume.go:2279 lxc/storage_volume.go:2431
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1031,7 +1064,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268 lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:635 lxc/network_load_balancer.go:637 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:635 lxc/network_load_balancer.go:637 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:993 lxc/storage_volume.go:1025
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1135,12 +1168,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1169,7 +1202,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1412,7 +1445,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87 lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811 lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1580,6 +1613,10 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid   "Edit instance UEFI variables"
+msgstr  ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid   "Edit instance file templates"
 msgstr  ""
@@ -1588,7 +1625,7 @@ msgstr  ""
 msgid   "Edit instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid   "Edit instance or server configurations as YAML"
 msgstr  ""
 
@@ -1695,12 +1732,12 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:469 lxc/network_load_balancer.go:470 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194 lxc/network_acl.go:467 lxc/network_forward.go:469 lxc/network_load_balancer.go:470 lxc/network_peer.go:463 lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856 lxc/project.go:634 lxc/storage.go:727 lxc/storage_bucket.go:597 lxc/storage_volume.go:1886 lxc/storage_volume.go:1924
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
@@ -1890,11 +1927,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -1904,7 +1941,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -1914,12 +1951,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -1944,7 +1981,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2013,7 +2050,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2049,7 +2086,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2065,8 +2102,12 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid   "Generating a client certificate. This may take a minute..."
+msgstr  ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid   "Get UEFI variables for instance"
 msgstr  ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2133,7 +2174,7 @@ msgstr  ""
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid   "Get the key as an instance property"
 msgstr  ""
 
@@ -2145,7 +2186,7 @@ msgstr  ""
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid   "Get values for instance or server configuration keys"
 msgstr  ""
 
@@ -2296,7 +2337,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2424,6 +2465,10 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid   "Instance name must be specified"
+msgstr  ""
+
 #: lxc/file.go:1025
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
@@ -2442,7 +2487,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2513,7 +2558,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -2522,7 +2567,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2855,7 +2900,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3032,6 +3077,10 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid   "Manage instance UEFI variables"
+msgstr  ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid   "Manage instance and server configuration options"
 msgstr  ""
@@ -3126,7 +3175,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -3375,7 +3424,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
+#: lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
 msgid   "NAME"
 msgstr  ""
 
@@ -3399,7 +3448,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456 lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476 lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid   "NO"
 msgstr  ""
 
@@ -3425,7 +3474,7 @@ msgstr  ""
 msgid   "Name"
 msgstr  ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
@@ -3626,7 +3675,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3693,11 +3742,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3713,7 +3762,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -3726,7 +3775,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -3738,7 +3787,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -3755,7 +3804,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269 lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3860,7 +3909,7 @@ msgstr  ""
 msgid   "Project %s renamed to %s"
 msgstr  ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid   "Project to use for the remote"
 msgstr  ""
 
@@ -3942,7 +3991,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid   "Public image server"
 msgstr  ""
 
@@ -4033,36 +4082,36 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886 lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898 lxc/remote.go:938
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -4132,7 +4181,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4180,7 +4229,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4204,6 +4253,10 @@ msgstr  ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid   "Request a join token for adding a cluster member"
+msgstr  ""
+
+#: lxc/config.go:969
+msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
 #: lxc/delete.go:36
@@ -4318,7 +4371,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid   "STATIC"
 msgstr  ""
 
@@ -4355,25 +4408,29 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
 #: lxc/version.go:66
 #, c-format
 msgid   "Server version: %s\n"
+msgstr  ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid   "Set UEFI variables for instance"
 msgstr  ""
 
 #: lxc/cluster.go:366
@@ -4406,11 +4463,11 @@ msgstr  ""
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4542,7 +4599,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4610,7 +4667,7 @@ msgstr  ""
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid   "Set the key as an instance property"
 msgstr  ""
 
@@ -4654,11 +4711,15 @@ msgstr  ""
 msgid   "Show image properties"
 msgstr  ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid   "Show instance UEFI variables"
+msgstr  ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -4738,11 +4799,11 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -4950,7 +5011,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5026,7 +5087,7 @@ msgstr  ""
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid   "The is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5054,12 +5115,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid   "The property %q does not exist on the instance %q: %v"
 msgstr  ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
@@ -5189,12 +5250,12 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid   "To start your first container, try: lxc launch ubuntu:22.04\n"
         "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773 lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777 lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5282,7 +5343,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid   "URL"
 msgstr  ""
 
@@ -5308,7 +5369,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5347,6 +5408,10 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid   "Unset UEFI variables for instance"
+msgstr  ""
+
 #: lxc/cluster.go:438
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
@@ -5363,7 +5428,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5479,7 +5544,7 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -5604,7 +5669,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458 lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478 lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid   "YES"
 msgstr  ""
 
@@ -5768,7 +5833,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53 lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -5786,6 +5851,14 @@ msgstr  ""
 
 #: lxc/config_device.go:354
 msgid   "[<remote>:]<instance> <device> [key=value...]"
+msgstr  ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid   "[<remote>:]<instance> <key>"
+msgstr  ""
+
+#: lxc/config.go:986
+msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
 #: lxc/config_device.go:443
@@ -6160,7 +6233,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6168,15 +6241,15 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
@@ -6184,7 +6257,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid   "current"
 msgstr  ""
 
@@ -6249,12 +6322,12 @@ msgid   "lxc config device add [<remote>:]instance1 <device-name> disk source=/s
         "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr  ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -6263,6 +6336,16 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "\n"
         "lxc config set core.trust_password=blah\n"
         "    Will set the server's trust password to blah."
+msgstr  ""
+
+#: lxc/config.go:1166
+msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+        "    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr  ""
+
+#: lxc/config.go:990
+msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+        "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
 
 #: lxc/export.go:34
@@ -6448,7 +6531,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid   "n"
 msgstr  ""
 
@@ -6460,7 +6543,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6497,7 +6580,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,6 +99,41 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -127,7 +162,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -598,7 +633,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -618,7 +653,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -635,15 +670,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -676,11 +711,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -693,7 +728,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -742,11 +777,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -809,7 +844,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -846,7 +881,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -917,7 +952,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -936,7 +971,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -1091,7 +1126,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1115,7 +1150,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1163,13 +1198,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1183,7 +1218,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1237,8 +1272,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1316,14 +1351,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1434,12 +1470,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1468,7 +1504,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1730,12 +1766,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1793,9 +1830,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1992,6 +2029,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -2000,7 +2041,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2112,7 +2153,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2122,7 +2163,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2322,11 +2363,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2336,7 +2377,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2346,12 +2387,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2376,7 +2417,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2458,7 +2499,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2496,7 +2537,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2512,8 +2553,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2580,7 +2625,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2592,7 +2637,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2743,7 +2788,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2874,6 +2919,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2892,7 +2941,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2964,7 +3013,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2973,7 +3022,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3322,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3501,6 +3550,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3597,7 +3650,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3920,7 +3973,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3948,7 +4001,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3975,7 +4028,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4177,7 +4230,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4244,11 +4297,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4264,7 +4317,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4277,7 +4330,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4289,7 +4342,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4306,10 +4359,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4419,7 +4472,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4517,7 +4570,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4608,37 +4661,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4708,7 +4761,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4757,7 +4810,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4781,6 +4834,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4898,7 +4955,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4935,25 +4992,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4990,11 +5051,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5150,7 +5211,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5218,7 +5279,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5262,11 +5323,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5346,11 +5411,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5558,7 +5623,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5639,7 +5704,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5667,12 +5732,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5808,13 +5873,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5906,7 +5971,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5934,7 +5999,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5974,6 +6039,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5990,7 +6059,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6106,7 +6175,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6241,7 +6310,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6411,7 +6480,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6430,6 +6500,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6829,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6837,15 +6915,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6853,7 +6931,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6926,13 +7004,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6942,6 +7020,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7165,7 +7258,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7177,7 +7270,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7214,7 +7307,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,6 +97,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -133,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -632,7 +667,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -652,7 +687,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -669,15 +704,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -710,11 +745,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -727,7 +762,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -776,11 +811,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -843,7 +878,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -880,7 +915,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -951,7 +986,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -970,7 +1005,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -1125,7 +1160,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1149,7 +1184,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1197,13 +1232,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1217,7 +1252,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1271,8 +1306,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1350,14 +1385,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1468,12 +1504,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1502,7 +1538,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1764,12 +1800,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1827,9 +1864,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2026,6 +2063,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -2034,7 +2075,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2146,7 +2187,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2156,7 +2197,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2356,11 +2397,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2370,7 +2411,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2380,12 +2421,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2410,7 +2451,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2492,7 +2533,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2530,7 +2571,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2546,8 +2587,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2614,7 +2659,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2626,7 +2671,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2777,7 +2822,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2908,6 +2953,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2926,7 +2975,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2998,7 +3047,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3007,7 +3056,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3356,7 +3405,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3535,6 +3584,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3631,7 +3684,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3954,7 +4007,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3982,7 +4035,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4009,7 +4062,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4211,7 +4264,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4278,11 +4331,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4298,7 +4351,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4311,7 +4364,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4323,7 +4376,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4340,10 +4393,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4453,7 +4506,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4551,7 +4604,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4642,37 +4695,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4742,7 +4795,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4791,7 +4844,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4815,6 +4868,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4932,7 +4989,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4969,25 +5026,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -5024,11 +5085,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5184,7 +5245,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5252,7 +5313,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5296,11 +5357,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5380,11 +5445,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5592,7 +5657,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5673,7 +5738,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5701,12 +5766,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5842,13 +5907,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5940,7 +6005,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5968,7 +6033,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6008,6 +6073,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -6024,7 +6093,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6140,7 +6209,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6275,7 +6344,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6445,7 +6514,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6464,6 +6534,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6863,7 +6941,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6871,15 +6949,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6887,7 +6965,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6960,13 +7038,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6976,6 +7054,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7199,7 +7292,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7211,7 +7304,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7248,7 +7341,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,6 +60,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -74,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -378,7 +413,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -398,7 +433,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -415,15 +450,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,11 +491,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -473,7 +508,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -522,11 +557,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -589,7 +624,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -626,7 +661,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -697,7 +732,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -716,7 +751,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -871,7 +906,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -895,7 +930,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -943,13 +978,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -963,7 +998,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1017,8 +1052,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1096,14 +1131,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1214,12 +1250,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1248,7 +1284,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1510,12 +1546,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1573,9 +1610,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1772,6 +1809,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1780,7 +1821,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1892,7 +1933,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1902,7 +1943,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2102,11 +2143,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2116,7 +2157,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2126,12 +2167,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2156,7 +2197,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2238,7 +2279,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2276,7 +2317,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2292,8 +2333,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2360,7 +2405,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2372,7 +2417,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2523,7 +2568,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2654,6 +2699,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2672,7 +2721,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2744,7 +2793,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2753,7 +2802,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3102,7 +3151,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3281,6 +3330,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3377,7 +3430,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3700,7 +3753,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3728,7 +3781,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3755,7 +3808,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3957,7 +4010,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4024,11 +4077,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4044,7 +4097,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4057,7 +4110,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4069,7 +4122,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4086,10 +4139,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4199,7 +4252,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4297,7 +4350,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4388,37 +4441,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4488,7 +4541,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4537,7 +4590,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4561,6 +4614,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4678,7 +4735,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4715,25 +4772,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4770,11 +4831,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4930,7 +4991,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4998,7 +5059,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5042,11 +5103,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5126,11 +5191,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5338,7 +5403,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5419,7 +5484,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5447,12 +5512,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5588,13 +5653,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5686,7 +5751,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5714,7 +5779,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5754,6 +5819,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5770,7 +5839,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5886,7 +5955,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6021,7 +6090,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6191,7 +6260,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6210,6 +6280,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6609,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6617,15 +6695,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6633,7 +6711,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6706,13 +6784,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6722,6 +6800,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6945,7 +7038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6957,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6994,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,6 +102,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -130,7 +165,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -626,7 +661,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -651,7 +686,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -669,15 +704,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -711,11 +746,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
@@ -728,7 +763,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 #, fuzzy
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
@@ -781,11 +816,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -852,7 +887,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -890,7 +925,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -968,7 +1003,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -987,7 +1022,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Criar projetos"
@@ -1144,7 +1179,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1169,7 +1204,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1217,13 +1252,13 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1237,7 +1272,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1292,8 +1327,8 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1380,14 +1415,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1500,12 +1536,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1534,7 +1570,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1823,12 +1859,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1886,9 +1923,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2094,6 +2131,11 @@ msgstr "Editar arquivos no container"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "Editar arquivos de metadados do container"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
@@ -2104,7 +2146,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Edit instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 #, fuzzy
 msgid "Edit instance or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2226,7 +2268,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2236,7 +2278,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2437,11 +2479,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2451,7 +2493,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2461,12 +2503,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2491,7 +2533,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2574,7 +2616,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2612,7 +2654,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2628,9 +2670,14 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "Adicionar perfis aos containers"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2704,7 +2751,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2718,7 +2765,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 #, fuzzy
 msgid "Get values for instance or server configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2878,7 +2925,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3011,6 +3058,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -3029,7 +3080,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3102,7 +3153,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3111,7 +3162,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3469,7 +3520,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3653,6 +3704,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "Editar arquivos de metadados do container"
+
 #: lxc/config.go:31 lxc/config.go:32
 #, fuzzy
 msgid "Manage instance and server configuration options"
@@ -3765,7 +3821,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4103,7 +4159,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4131,7 +4187,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4158,7 +4214,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4360,7 +4416,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4427,11 +4483,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4447,7 +4503,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4460,7 +4516,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4473,7 +4529,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4490,10 +4546,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4608,7 +4664,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4706,7 +4762,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4800,37 +4856,37 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4908,7 +4964,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4961,7 +5017,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4985,6 +5041,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5112,7 +5172,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -5149,19 +5209,19 @@ msgstr "Criado: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5169,6 +5229,11 @@ msgstr ""
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "Adicionar perfis aos containers"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5207,12 +5272,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5376,7 +5441,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5451,7 +5516,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5498,12 +5563,17 @@ msgstr "Adicionar dispositivos aos containers ou perfis"
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "Editar arquivos de metadados do container"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5596,11 +5666,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5811,7 +5881,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5896,7 +5966,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5924,12 +5994,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
@@ -6066,13 +6136,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6165,7 +6235,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -6193,7 +6263,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6234,6 +6304,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "Não pode fornecer um nome para a imagem de destino"
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6254,7 +6329,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6389,7 +6464,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6526,7 +6601,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6716,7 +6791,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6736,6 +6812,16 @@ msgstr ""
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr "Editar templates de arquivo do container"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
+msgstr "Editar templates de arquivo do container"
 
 #: lxc/config_device.go:443
 msgid "[<remote>:]<instance> <name>..."
@@ -7178,7 +7264,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7186,15 +7272,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
@@ -7204,7 +7290,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -7277,13 +7363,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7293,6 +7379,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7516,7 +7617,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7528,7 +7629,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7565,7 +7666,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,6 +106,41 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -134,7 +169,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -631,7 +666,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -651,7 +686,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -669,15 +704,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -715,11 +750,11 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -732,7 +767,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -785,11 +820,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -853,7 +888,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -891,7 +926,7 @@ msgstr "Псевдонимы:"
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -965,7 +1000,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -984,7 +1019,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 #, fuzzy
 msgid "Available projects:"
 msgstr "Доступные команды:"
@@ -1142,7 +1177,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1166,7 +1201,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1214,13 +1249,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1234,7 +1269,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1289,8 +1324,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1368,14 +1403,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1488,12 +1524,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1522,7 +1558,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1809,12 +1845,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1872,9 +1909,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -2077,6 +2114,11 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+#, fuzzy
+msgid "Edit instance UEFI variables"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 #, fuzzy
 msgid "Edit instance file templates"
@@ -2087,7 +2129,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2204,7 +2246,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2214,7 +2256,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2423,11 +2465,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2437,7 +2479,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2447,12 +2489,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2477,7 +2519,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2560,7 +2602,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2598,7 +2640,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2614,9 +2656,14 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+#, fuzzy
+msgid "Get UEFI variables for instance"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/project.go:801 lxc/project.go:802
 msgid "Get a summary of resource allocations"
@@ -2690,7 +2737,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2703,7 +2750,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2861,7 +2908,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2998,6 +3045,11 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+#, fuzzy
+msgid "Instance name must be specified"
+msgstr "Имя контейнера: %s"
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -3016,7 +3068,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3089,7 +3141,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3098,7 +3150,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3462,7 +3514,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3647,6 +3699,11 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+#, fuzzy
+msgid "Manage instance UEFI variables"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3761,7 +3818,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -4103,7 +4160,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -4131,7 +4188,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -4158,7 +4215,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4364,7 +4421,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4431,11 +4488,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4451,7 +4508,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4464,7 +4521,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4477,7 +4534,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4494,10 +4551,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4607,7 +4664,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4705,7 +4762,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4800,37 +4857,37 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4906,7 +4963,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4957,7 +5014,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4983,6 +5040,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -5107,7 +5168,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -5144,19 +5205,19 @@ msgstr "Авто-обновление: %s"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -5164,6 +5225,11 @@ msgstr ""
 #, c-format
 msgid "Server version: %s\n"
 msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+#, fuzzy
+msgid "Set UEFI variables for instance"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/cluster.go:366
 #, fuzzy
@@ -5200,11 +5266,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5366,7 +5432,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5442,7 +5508,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5488,12 +5554,17 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+#, fuzzy
+msgid "Show instance UEFI variables"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 #, fuzzy
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5583,11 +5654,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5802,7 +5873,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5883,7 +5954,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5911,12 +5982,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
@@ -6052,13 +6123,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6151,7 +6222,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -6179,7 +6250,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6219,6 +6290,11 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+#, fuzzy
+msgid "Unset UEFI variables for instance"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/cluster.go:438
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
@@ -6236,7 +6312,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6370,7 +6446,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6507,7 +6583,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6817,7 +6893,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -6853,6 +6930,22 @@ msgstr ""
 #: lxc/config_device.go:354
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config.go:931 lxc/config.go:1077
+#, fuzzy
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/config.go:986
+#, fuzzy
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -7623,7 +7716,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -7639,7 +7732,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -7647,7 +7740,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -7655,7 +7748,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 #, fuzzy
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
@@ -7671,7 +7764,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -7744,13 +7837,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7760,6 +7853,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7983,7 +8091,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7995,7 +8103,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8032,7 +8140,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,6 +64,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -78,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -382,7 +417,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -402,7 +437,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -419,15 +454,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,11 +495,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -477,7 +512,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -526,11 +561,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -593,7 +628,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -630,7 +665,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -701,7 +736,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -720,7 +755,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -875,7 +910,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -899,7 +934,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -947,13 +982,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +1002,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1021,8 +1056,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1100,14 +1135,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1218,12 +1254,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1288,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1514,12 +1550,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1577,9 +1614,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1776,6 +1813,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1784,7 +1825,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1896,7 +1937,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1906,7 +1947,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2106,11 +2147,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2120,7 +2161,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2130,12 +2171,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2160,7 +2201,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2242,7 +2283,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2280,7 +2321,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2296,8 +2337,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2364,7 +2409,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2376,7 +2421,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2527,7 +2572,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2658,6 +2703,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2676,7 +2725,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2748,7 +2797,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2757,7 +2806,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3106,7 +3155,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3285,6 +3334,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3381,7 +3434,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3704,7 +3757,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3732,7 +3785,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3759,7 +3812,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3961,7 +4014,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4028,11 +4081,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4048,7 +4101,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4061,7 +4114,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4073,7 +4126,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4090,10 +4143,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4203,7 +4256,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4301,7 +4354,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4392,37 +4445,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4492,7 +4545,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4541,7 +4594,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4565,6 +4618,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4682,7 +4739,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4719,25 +4776,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4774,11 +4835,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4934,7 +4995,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5002,7 +5063,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5046,11 +5107,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5130,11 +5195,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5342,7 +5407,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5423,7 +5488,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5451,12 +5516,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5592,13 +5657,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5690,7 +5755,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5718,7 +5783,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5758,6 +5823,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5774,7 +5843,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5890,7 +5959,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6025,7 +6094,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6195,7 +6264,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6214,6 +6284,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6613,7 +6691,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6621,15 +6699,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6637,7 +6715,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6710,13 +6788,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6726,6 +6804,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6949,7 +7042,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6961,7 +7054,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6998,7 +7091,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,6 +64,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -78,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -382,7 +417,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -402,7 +437,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -419,15 +454,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,11 +495,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -477,7 +512,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -526,11 +561,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -593,7 +628,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -630,7 +665,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -701,7 +736,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -720,7 +755,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -875,7 +910,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -899,7 +934,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -947,13 +982,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +1002,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1021,8 +1056,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1100,14 +1135,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1218,12 +1254,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1288,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1514,12 +1550,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1577,9 +1614,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1776,6 +1813,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1784,7 +1825,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1896,7 +1937,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1906,7 +1947,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2106,11 +2147,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2120,7 +2161,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2130,12 +2171,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2160,7 +2201,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2242,7 +2283,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2280,7 +2321,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2296,8 +2337,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2364,7 +2409,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2376,7 +2421,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2527,7 +2572,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2658,6 +2703,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2676,7 +2725,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2748,7 +2797,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2757,7 +2806,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3106,7 +3155,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3285,6 +3334,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3381,7 +3434,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3704,7 +3757,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3732,7 +3785,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3759,7 +3812,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3961,7 +4014,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4028,11 +4081,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4048,7 +4101,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4061,7 +4114,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4073,7 +4126,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4090,10 +4143,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4203,7 +4256,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4301,7 +4354,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4392,37 +4445,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4492,7 +4545,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4541,7 +4594,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4565,6 +4618,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4682,7 +4739,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4719,25 +4776,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4774,11 +4835,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4934,7 +4995,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5002,7 +5063,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5046,11 +5107,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5130,11 +5195,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5342,7 +5407,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5423,7 +5488,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5451,12 +5516,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5592,13 +5657,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5690,7 +5755,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5718,7 +5783,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5758,6 +5823,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5774,7 +5843,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5890,7 +5959,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6025,7 +6094,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6195,7 +6264,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6214,6 +6284,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6613,7 +6691,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6621,15 +6699,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6637,7 +6715,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6710,13 +6788,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6726,6 +6804,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6949,7 +7042,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6961,7 +7054,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6998,7 +7091,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,6 +60,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -74,7 +109,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -378,7 +413,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -398,7 +433,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -415,15 +450,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -456,11 +491,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -473,7 +508,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -522,11 +557,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -589,7 +624,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -626,7 +661,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -697,7 +732,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -716,7 +751,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -871,7 +906,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -895,7 +930,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -943,13 +978,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -963,7 +998,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1017,8 +1052,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1096,14 +1131,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1214,12 +1250,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1248,7 +1284,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1510,12 +1546,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1573,9 +1610,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1772,6 +1809,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1780,7 +1821,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1892,7 +1933,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1902,7 +1943,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2102,11 +2143,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2116,7 +2157,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2126,12 +2167,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2156,7 +2197,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2238,7 +2279,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2276,7 +2317,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2292,8 +2333,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2360,7 +2405,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2372,7 +2417,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2523,7 +2568,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2654,6 +2699,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2672,7 +2721,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2744,7 +2793,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2753,7 +2802,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3102,7 +3151,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3281,6 +3330,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3377,7 +3430,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3700,7 +3753,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3728,7 +3781,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3755,7 +3808,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3957,7 +4010,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4024,11 +4077,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4044,7 +4097,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4057,7 +4110,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4069,7 +4122,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4086,10 +4139,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4199,7 +4252,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4297,7 +4350,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4388,37 +4441,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4488,7 +4541,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4537,7 +4590,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4561,6 +4614,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4678,7 +4735,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4715,25 +4772,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4770,11 +4831,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4930,7 +4991,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4998,7 +5059,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5042,11 +5103,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5126,11 +5191,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5338,7 +5403,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5419,7 +5484,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5447,12 +5512,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5588,13 +5653,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5686,7 +5751,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5714,7 +5779,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5754,6 +5819,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5770,7 +5839,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5886,7 +5955,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6021,7 +6090,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6191,7 +6260,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6210,6 +6280,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6609,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6617,15 +6695,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6633,7 +6711,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6706,13 +6784,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6722,6 +6800,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6945,7 +7038,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6957,7 +7050,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6994,7 +7087,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,6 +64,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -78,7 +113,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -382,7 +417,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -402,7 +437,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -419,15 +454,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -460,11 +495,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -477,7 +512,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -526,11 +561,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -593,7 +628,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -630,7 +665,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -701,7 +736,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -720,7 +755,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -875,7 +910,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -899,7 +934,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -947,13 +982,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -967,7 +1002,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1021,8 +1056,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1100,14 +1135,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1218,12 +1254,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1252,7 +1288,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1514,12 +1550,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1577,9 +1614,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1776,6 +1813,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1784,7 +1825,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1896,7 +1937,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1906,7 +1947,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2106,11 +2147,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2120,7 +2161,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2130,12 +2171,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2160,7 +2201,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2242,7 +2283,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2280,7 +2321,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2296,8 +2337,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2364,7 +2409,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2376,7 +2421,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2527,7 +2572,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2658,6 +2703,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2676,7 +2725,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2748,7 +2797,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2757,7 +2806,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3106,7 +3155,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3285,6 +3334,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3381,7 +3434,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3704,7 +3757,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3732,7 +3785,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3759,7 +3812,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3961,7 +4014,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4028,11 +4081,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4048,7 +4101,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4061,7 +4114,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4073,7 +4126,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4090,10 +4143,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4203,7 +4256,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4301,7 +4354,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4392,37 +4445,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4492,7 +4545,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4541,7 +4594,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4565,6 +4618,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4682,7 +4739,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4719,25 +4776,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4774,11 +4835,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4934,7 +4995,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5002,7 +5063,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5046,11 +5107,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5130,11 +5195,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5342,7 +5407,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5423,7 +5488,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5451,12 +5516,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5592,13 +5657,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5690,7 +5755,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5718,7 +5783,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5758,6 +5823,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5774,7 +5843,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5890,7 +5959,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6025,7 +6094,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6195,7 +6264,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6214,6 +6284,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6613,7 +6691,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6621,15 +6699,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6637,7 +6715,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6710,13 +6788,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6726,6 +6804,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6949,7 +7042,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6961,7 +7054,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6998,7 +7091,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,6 +97,41 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 #, fuzzy
 msgid ""
@@ -133,7 +168,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the configuration.\n"
@@ -531,7 +566,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -551,7 +586,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -568,15 +603,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -609,11 +644,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -626,7 +661,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -675,11 +710,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -742,7 +777,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -779,7 +814,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -850,7 +885,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -869,7 +904,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -1024,7 +1059,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1048,7 +1083,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1096,13 +1131,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1116,7 +1151,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1170,8 +1205,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1249,14 +1284,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1367,12 +1403,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1401,7 +1437,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1663,12 +1699,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1726,9 +1763,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1925,6 +1962,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1933,7 +1974,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -2045,7 +2086,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -2055,7 +2096,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2255,11 +2296,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2269,7 +2310,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2279,12 +2320,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2309,7 +2350,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2391,7 +2432,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2429,7 +2470,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2445,8 +2486,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2513,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2525,7 +2570,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2676,7 +2721,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2807,6 +2852,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2825,7 +2874,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2897,7 +2946,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2906,7 +2955,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3255,7 +3304,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3434,6 +3483,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3530,7 +3583,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3853,7 +3906,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3881,7 +3934,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3908,7 +3961,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -4110,7 +4163,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4177,11 +4230,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4197,7 +4250,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4210,7 +4263,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4222,7 +4275,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4239,10 +4292,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4352,7 +4405,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4450,7 +4503,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4541,37 +4594,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4641,7 +4694,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4690,7 +4743,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4714,6 +4767,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4831,7 +4888,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4868,25 +4925,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4923,11 +4984,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5083,7 +5144,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5151,7 +5212,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5195,11 +5256,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5279,11 +5344,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5491,7 +5556,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5572,7 +5637,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5600,12 +5665,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5741,13 +5806,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5839,7 +5904,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5867,7 +5932,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5907,6 +5972,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5923,7 +5992,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6039,7 +6108,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6174,7 +6243,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6344,7 +6413,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6363,6 +6433,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6762,7 +6840,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6770,15 +6848,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6786,7 +6864,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6859,13 +6937,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6875,6 +6953,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -7098,7 +7191,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -7110,7 +7203,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7147,7 +7240,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-07 09:37+0000\n"
+"POT-Creation-Date: 2024-02-20 10:11+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,6 +63,41 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
+#: lxc/config.go:1177
+msgid ""
+"### This is a YAML representation of the UEFI variables configuration.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### A sample UEFI variables configuration looks like:\n"
+"### variables:\n"
+"###   00163E0BD47A-5b446ed1-e30b-4faa-871a-3654eca36080:\n"
+"###     data: 3a5001001000afaf040000000100000000000000\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   00163E0BD47A-937fe521-95ae-4d1a-8929-48bcd90ad31a:\n"
+"###     data: df7f3f\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   BootOrder-8be4df61-93ca-11d2-aa0d-00e098032b8c:\n"
+"###     data: \"07000100020003000400050000000600\"\n"
+"###     attr: 7\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###   ClientId-9fb9a8a1-2f4a-43a6-889c-d0f7b6c47ad5:\n"
+"###     data: 0e00000100012cb0289c00163e0bd47a\n"
+"###     attr: 3\n"
+"###     timestamp: \"\"\n"
+"###     digest: \"\"\n"
+"###\n"
+"### Note that the format of the key in the variables map is \"<EFI variable "
+"name>-<UUID>\".\n"
+"### Fields \"data\", \"timestamp\", \"digest\" are HEX-encoded.\n"
+"### Field \"attr\" is an unsigned 32-bit integer.\n"
+"###"
+msgstr ""
+
 #: lxc/config_trust.go:245
 msgid ""
 "### This is a YAML representation of the certificate.\n"
@@ -77,7 +112,7 @@ msgid ""
 "### Any line starting with a '# will be ignored."
 msgstr ""
 
-#: lxc/config.go:109
+#: lxc/config.go:113
 msgid ""
 "### This is a YAML representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -381,7 +416,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:468 lxc/config.go:767
+#: lxc/config.go:472 lxc/config.go:771
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -401,7 +436,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:157 lxc/config.go:418 lxc/config.go:594 lxc/config.go:793
+#: lxc/config.go:161 lxc/config.go:422 lxc/config.go:598 lxc/config.go:797
 #: lxc/info.go:453
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -418,15 +453,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:808 lxc/remote.go:864
+#: lxc/remote.go:818 lxc/remote.go:875
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:902
+#: lxc/remote.go:915
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:737
+#: lxc/remote.go:745
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -459,11 +494,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:720
+#: lxc/remote.go:727
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:99
 msgid "Accept certificate"
 msgstr ""
 
@@ -476,7 +511,7 @@ msgstr ""
 msgid "Access key: %s"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:387
 msgid "Access the expanded configuration"
 msgstr ""
 
@@ -525,11 +560,11 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:86
+#: lxc/remote.go:88
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:87
+#: lxc/remote.go:89
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -592,7 +627,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:553
+#: lxc/remote.go:556
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -629,7 +664,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:177
+#: lxc/remote.go:179
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -700,7 +735,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:539
+#: lxc/remote.go:542
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -719,7 +754,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/remote.go:132
+#: lxc/remote.go:134
 msgid "Available projects:"
 msgstr ""
 
@@ -874,7 +909,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:843
+#: lxc/remote.go:854
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -898,7 +933,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:660
+#: lxc/config.go:664 lxc/config.go:1034
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -946,13 +981,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:216
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:442
+#: lxc/remote.go:445
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -966,7 +1001,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:596
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1020,8 +1055,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:101 lxc/config.go:385 lxc/config.go:528 lxc/config.go:734
-#: lxc/config.go:857 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
+#: lxc/config.go:105 lxc/config.go:389 lxc/config.go:532 lxc/config.go:738
+#: lxc/config.go:861 lxc/copy.go:61 lxc/info.go:45 lxc/init.go:56
 #: lxc/move.go:66 lxc/network.go:300 lxc/network.go:723 lxc/network.go:792
 #: lxc/network.go:1134 lxc/network.go:1219 lxc/network.go:1283
 #: lxc/network_forward.go:170 lxc/network_forward.go:234
@@ -1099,14 +1134,15 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:268
-#: lxc/config.go:343 lxc/config_metadata.go:147 lxc/config_trust.go:314
-#: lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620
-#: lxc/network_forward.go:635 lxc/network_load_balancer.go:637
-#: lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143
-#: lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310
-#: lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092
-#: lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
+#: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
+#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/network_acl.go:620 lxc/network_forward.go:635
+#: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
+#: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
+#: lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343
+#: lxc/storage_bucket.go:1092 lxc/storage_volume.go:993
+#: lxc/storage_volume.go:1025
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1217,12 +1253,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:477
+#: lxc/remote.go:480
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:220 lxc/remote.go:461
+#: lxc/remote.go:222 lxc/remote.go:464
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1251,7 +1287,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:472
+#: lxc/remote.go:475
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1513,12 +1549,13 @@ msgstr ""
 #: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
 #: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
 #: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
-#: lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513
-#: lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24
-#: lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285
-#: lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548
-#: lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741
-#: lxc/config_metadata.go:27 lxc/config_metadata.go:55
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
+#: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
+#: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
+#: lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55
 #: lxc/config_metadata.go:180 lxc/config_template.go:27
 #: lxc/config_template.go:67 lxc/config_template.go:110
 #: lxc/config_template.go:152 lxc/config_template.go:240
@@ -1576,9 +1613,9 @@ msgstr ""
 #: lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349
 #: lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659
 #: lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:33 lxc/remote.go:87
-#: lxc/remote.go:620 lxc/remote.go:656 lxc/remote.go:740 lxc/remote.go:811
-#: lxc/remote.go:866 lxc/remote.go:904 lxc/rename.go:21 lxc/restore.go:24
+#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89
+#: lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821
+#: lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24
 #: lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170
 #: lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586
 #: lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847
@@ -1775,6 +1812,10 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
+#: lxc/config.go:1163 lxc/config.go:1164
+msgid "Edit instance UEFI variables"
+msgstr ""
+
 #: lxc/config_template.go:151 lxc/config_template.go:152
 msgid "Edit instance file templates"
 msgstr ""
@@ -1783,7 +1824,7 @@ msgstr ""
 msgid "Edit instance metadata files"
 msgstr ""
 
-#: lxc/config.go:94 lxc/config.go:95
+#: lxc/config.go:98 lxc/config.go:99
 msgid "Edit instance or server configurations as YAML"
 msgstr ""
 
@@ -1895,7 +1936,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:414 lxc/config.go:620 lxc/config.go:652 lxc/network.go:1194
+#: lxc/cluster.go:414 lxc/config.go:624 lxc/config.go:656 lxc/network.go:1194
 #: lxc/network_acl.go:467 lxc/network_forward.go:469
 #: lxc/network_load_balancer.go:470 lxc/network_peer.go:463
 #: lxc/network_zone.go:409 lxc/network_zone.go:1003 lxc/profile.go:856
@@ -1905,7 +1946,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:614 lxc/config.go:646
+#: lxc/config.go:618 lxc/config.go:650
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2105,11 +2146,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:186
+#: lxc/remote.go:188
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:239
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2119,7 +2160,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:229
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2129,12 +2170,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:261
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2159,7 +2200,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:234
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2241,7 +2282,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_load_balancer.go:93 lxc/network_peer.go:84
 #: lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108
-#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:660
+#: lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666
 #: lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769
 #: lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2279,7 +2320,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:723
+#: lxc/remote.go:730
 msgid "GLOBAL"
 msgstr ""
 
@@ -2295,8 +2336,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:155 lxc/remote.go:388
+#: lxc/remote.go:157 lxc/remote.go:391
 msgid "Generating a client certificate. This may take a minute..."
+msgstr ""
+
+#: lxc/config.go:932 lxc/config.go:933
+msgid "Get UEFI variables for instance"
 msgstr ""
 
 #: lxc/project.go:801 lxc/project.go:802
@@ -2363,7 +2408,7 @@ msgstr ""
 msgid "Get the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:384
+#: lxc/config.go:388
 msgid "Get the key as an instance property"
 msgstr ""
 
@@ -2375,7 +2420,7 @@ msgstr ""
 msgid "Get values for device configuration keys"
 msgstr ""
 
-#: lxc/config.go:379 lxc/config.go:380
+#: lxc/config.go:383 lxc/config.go:384
 msgid "Get values for instance or server configuration keys"
 msgstr ""
 
@@ -2526,7 +2571,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:393
+#: lxc/main.go:395
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2657,6 +2702,10 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
+#: lxc/config.go:958 lxc/config.go:1016 lxc/config.go:1135 lxc/config.go:1227
+msgid "Instance name must be specified"
+msgstr ""
+
 #: lxc/file.go:1025
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
@@ -2675,7 +2724,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:343
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2747,7 +2796,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:490
+#: lxc/main.go:495
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -2756,7 +2805,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:332
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3105,7 +3154,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:655 lxc/remote.go:656
+#: lxc/remote.go:661 lxc/remote.go:662
 msgid "List the available remotes"
 msgstr ""
 
@@ -3284,6 +3333,10 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
+#: lxc/config.go:892 lxc/config.go:893
+msgid "Manage instance UEFI variables"
+msgstr ""
+
 #: lxc/config.go:31 lxc/config.go:32
 msgid "Manage instance and server configuration options"
 msgstr ""
@@ -3380,7 +3433,7 @@ msgid ""
 "\"custom\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -3703,7 +3756,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565
 #: lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:498 lxc/remote.go:717 lxc/storage.go:638
+#: lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638
 #: lxc/storage_bucket.go:506 lxc/storage_bucket.go:826
 #: lxc/storage_volume.go:1510
 msgid "NAME"
@@ -3731,7 +3784,7 @@ msgstr ""
 
 #: lxc/network.go:957 lxc/operation.go:154 lxc/project.go:456
 #: lxc/project.go:461 lxc/project.go:466 lxc/project.go:471 lxc/project.go:476
-#: lxc/project.go:481 lxc/remote.go:677 lxc/remote.go:682 lxc/remote.go:687
+#: lxc/project.go:481 lxc/remote.go:684 lxc/remote.go:689 lxc/remote.go:694
 msgid "NO"
 msgstr ""
 
@@ -3758,7 +3811,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:139
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
@@ -3960,7 +4013,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:323
+#: lxc/remote.go:326
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4027,11 +4080,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:719
+#: lxc/remote.go:726
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:721
+#: lxc/image.go:1057 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4047,7 +4100,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:356
+#: lxc/main.go:358
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4060,7 +4113,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:178
+#: lxc/remote.go:180
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4072,7 +4125,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:456
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4089,10 +4142,10 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:269
-#: lxc/config.go:344 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
-#: lxc/network_acl.go:621 lxc/network_forward.go:636
+#: lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273
+#: lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148
+#: lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457
+#: lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
 #: lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344
@@ -4202,7 +4255,7 @@ msgstr ""
 msgid "Project %s renamed to %s"
 msgstr ""
 
-#: lxc/remote.go:102
+#: lxc/remote.go:104
 msgid "Project to use for the remote"
 msgstr ""
 
@@ -4300,7 +4353,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/remote.go:101
+#: lxc/remote.go:103
 msgid "Public image server"
 msgstr ""
 
@@ -4391,37 +4444,37 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:778
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:769 lxc/remote.go:760 lxc/remote.go:831 lxc/remote.go:886
-#: lxc/remote.go:924
+#: lxc/project.go:769 lxc/remote.go:769 lxc/remote.go:842 lxc/remote.go:898
+#: lxc/remote.go:938
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:295
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:839
+#: lxc/remote.go:850
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:764 lxc/remote.go:835 lxc/remote.go:928
+#: lxc/remote.go:773 lxc/remote.go:846 lxc/remote.go:942
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:100
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:286
+#: lxc/remote.go:289
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4491,7 +4544,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:810 lxc/remote.go:811
+#: lxc/remote.go:820 lxc/remote.go:821
 msgid "Remove remotes"
 msgstr ""
 
@@ -4540,7 +4593,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:739 lxc/remote.go:740
+#: lxc/remote.go:747 lxc/remote.go:748
 msgid "Rename remotes"
 msgstr ""
 
@@ -4564,6 +4617,10 @@ msgstr ""
 
 #: lxc/cluster.go:803 lxc/cluster.go:804
 msgid "Request a join token for adding a cluster member"
+msgstr ""
+
+#: lxc/config.go:969
+msgid "Requested UEFI variable does not exist"
 msgstr ""
 
 #: lxc/delete.go:36
@@ -4681,7 +4738,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:722
+#: lxc/remote.go:729
 msgid "STATIC"
 msgstr ""
 
@@ -4718,25 +4775,29 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:100
+#: lxc/remote.go:102
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:454
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:589
+#: lxc/remote.go:592
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:101
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
 #: lxc/version.go:66
 #, c-format
 msgid "Server version: %s\n"
+msgstr ""
+
+#: lxc/config.go:987 lxc/config.go:988
+msgid "Set UEFI variables for instance"
 msgstr ""
 
 #: lxc/cluster.go:366
@@ -4773,11 +4834,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:512
+#: lxc/config.go:516
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:513
+#: lxc/config.go:517
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -4933,7 +4994,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:903 lxc/remote.go:904
+#: lxc/remote.go:916 lxc/remote.go:917
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5001,7 +5062,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:529
+#: lxc/config.go:533
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5045,11 +5106,15 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
+#: lxc/config.go:1109 lxc/config.go:1110
+msgid "Show instance UEFI variables"
+msgstr ""
+
 #: lxc/config_metadata.go:179 lxc/config_metadata.go:180
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:729 lxc/config.go:730
+#: lxc/config.go:733 lxc/config.go:734
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5129,11 +5194,11 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:619 lxc/remote.go:620
+#: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:733
+#: lxc/config.go:737
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5341,7 +5406,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:865 lxc/remote.go:866
+#: lxc/remote.go:876 lxc/remote.go:877
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5422,7 +5487,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:631
+#: lxc/config.go:635
 msgid "The is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5450,12 +5515,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:454
+#: lxc/config.go:458
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:430
+#: lxc/config.go:434
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5591,13 +5656,13 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:398
+#: lxc/main.go:400
 msgid ""
 "To start your first container, try: lxc launch ubuntu:22.04\n"
 "Or for a virtual machine: lxc launch ubuntu:22.04 --vm"
 msgstr ""
 
-#: lxc/config.go:293 lxc/config.go:474 lxc/config.go:681 lxc/config.go:773
+#: lxc/config.go:297 lxc/config.go:478 lxc/config.go:685 lxc/config.go:777
 #: lxc/copy.go:131 lxc/info.go:338 lxc/network.go:821 lxc/storage.go:446
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -5689,7 +5754,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:184 lxc/remote.go:718
+#: lxc/cluster.go:184 lxc/remote.go:725
 msgid "URL"
 msgstr ""
 
@@ -5717,7 +5782,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:209 lxc/remote.go:243
+#: lxc/remote.go:211 lxc/remote.go:245
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5757,6 +5822,10 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
+#: lxc/config.go:1078 lxc/config.go:1079
+msgid "Unset UEFI variables for instance"
+msgstr ""
+
 #: lxc/cluster.go:438
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
@@ -5773,7 +5842,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:853 lxc/config.go:854
+#: lxc/config.go:857 lxc/config.go:858
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -5889,7 +5958,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:858
+#: lxc/config.go:862
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6024,7 +6093,7 @@ msgstr ""
 
 #: lxc/network.go:959 lxc/operation.go:156 lxc/project.go:458
 #: lxc/project.go:463 lxc/project.go:468 lxc/project.go:473 lxc/project.go:478
-#: lxc/project.go:483 lxc/remote.go:679 lxc/remote.go:684 lxc/remote.go:689
+#: lxc/project.go:483 lxc/remote.go:686 lxc/remote.go:691 lxc/remote.go:696
 msgid "YES"
 msgstr ""
 
@@ -6194,7 +6263,8 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:662 lxc/config_metadata.go:53
+#: lxc/config.go:1108 lxc/config.go:1162 lxc/config_device.go:288
+#: lxc/config_device.go:662 lxc/config_metadata.go:53
 #: lxc/config_metadata.go:178 lxc/config_template.go:238 lxc/console.go:34
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -6213,6 +6283,14 @@ msgstr ""
 
 #: lxc/config_device.go:354
 msgid "[<remote>:]<instance> <device> [key=value...]"
+msgstr ""
+
+#: lxc/config.go:931 lxc/config.go:1077
+msgid "[<remote>:]<instance> <key>"
+msgstr ""
+
+#: lxc/config.go:986
+msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
 #: lxc/config_device.go:443
@@ -6612,7 +6690,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:93 lxc/config.go:728
+#: lxc/config.go:97 lxc/config.go:732
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -6620,15 +6698,15 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:378 lxc/config.go:852
+#: lxc/config.go:382 lxc/config.go:856
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:511
+#: lxc/config.go:515
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:85
+#: lxc/remote.go:87
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
@@ -6636,7 +6714,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:488 lxc/remote.go:708
+#: lxc/project.go:488 lxc/remote.go:715
 msgid "current"
 msgstr ""
 
@@ -6709,13 +6787,13 @@ msgid ""
 "    Will mount the some-volume volume on some-pool onto /opt in the instance."
 msgstr ""
 
-#: lxc/config.go:97
+#: lxc/config.go:101
 msgid ""
 "lxc config edit <instance> < instance.yaml\n"
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:522
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -6725,6 +6803,21 @@ msgid ""
 "\n"
 "lxc config set core.trust_password=blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/config.go:1166
+msgid ""
+"lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
+"    Set the instance UEFI variables from instance_uefi_vars.yaml."
+msgstr ""
+
+#: lxc/config.go:990
+msgid ""
+"lxc config uefi set [<remote>:]<instance> "
+"testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
+"    Set a UEFI variable with name \"testvar\", GUID "
+"9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for "
+"the instance."
 msgstr ""
 
 #: lxc/export.go:34
@@ -6948,7 +7041,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:450
+#: lxc/remote.go:453
 msgid "n"
 msgstr ""
 
@@ -6960,7 +7053,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:443
+#: lxc/remote.go:446
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6997,7 +7090,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:455
 msgid "y"
 msgstr ""
 

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -374,3 +374,36 @@ type InstanceSource struct {
 	// API extension: instance_allow_inconsistent_copy
 	AllowInconsistent bool `json:"allow_inconsistent" yaml:"allow_inconsistent"`
 }
+
+// InstanceUEFIVars represents the UEFI variables of a LXD virtual machine.
+//
+// swagger:model
+//
+// API extension: instances_uefi_vars.
+type InstanceUEFIVars struct {
+	// UEFI variables map
+	// Hashmap key format is <uefi-variable-name>-<UUID>
+	// Example: { "SecureBootEnable-f0a30bc7-af08-4556-99c4-001009c93a44": { "data": "01", "attr": 3 } }
+	Variables map[string]InstanceUEFIVariable `json:"variables" yaml:"variables"`
+}
+
+// InstanceUEFIVariable represents an EFI variable entry
+//
+// swagger:model
+//
+// API extension: instances_uefi_vars.
+type InstanceUEFIVariable struct {
+	// UEFI variable data (HEX-encoded)
+	// example: 01
+	Data string `json:"data" yaml:"data"`
+
+	// UEFI variable attributes
+	// example: 7
+	Attr uint32 `json:"attr" yaml:"attr"`
+
+	// UEFI variable timestamp (HEX-encoded)
+	Timestamp string `json:"timestamp" yaml:"timestamp"`
+
+	// UEFI variable digest (HEX-encoded)
+	Digest string `json:"digest" yaml:"digest"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -396,6 +396,7 @@ var APIExtensions = []string{
 	"loki_config_instance",
 	"storage_volatile_uuid",
 	"import_instance_devices",
+	"instances_uefi_vars",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Introduces the `lxc config uefi set/unset/get/show/edit <...>` CLI interface for manipulating UEFI variables of the VM instance.

This feature was requested by our friends from Foundations team. It can be useful for debugging UEFI firmware/boot loader/shim in some cases.

Specification https://discourse.ubuntu.com/t/lxd-vm-instance-efi-variables-edit-cli

Depends on:
https://github.com/canonical/lxd-pkg-snap/pull/324

Test:
https://github.com/canonical/lxd-ci/pull/68