### PR TITLE
Support passing down extra information to storage drivers

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4548,13 +4548,7 @@ func (b *lxdBackend) CreateCustomVolume(projectName string, volName string, desc
 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
-
-	// Validate config.
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, config)
-	err = b.driver.ValidateVolume(vol, false)
-	if err != nil {
-		return err
-	}
 
 	storagePoolSupported := false
 	for _, supportedType := range b.Driver().Info().VolumeTypes {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -314,12 +314,12 @@ func (d *ceph) getVolumeSize(volumeName string) (int64, error) {
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *ceph) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *ceph) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	var err error
 	revert := revert.New()
 	defer revert.Fail()
@@ -354,7 +354,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 
 		// Resize volume to the size specified. Only uses volume "size" property and does not use
 		// pool/defaults to give the caller more control over the size being used.
-		err = d.SetVolumeQuota(vol, vol.config["size"], false, op)
+		err = d.SetVolumeQuota(vol.Volume, vol.config["size"], false, op)
 		if err != nil {
 			return err
 		}
@@ -364,28 +364,28 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 
 	// For VMs, also copy the filesystem volume.
 	if vol.IsVMBlock() {
-		srcFSVol := srcVol.NewVMBlockFilesystemVolume()
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, copySnapshots, false, op)
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
 		if err != nil {
 			return err
 		}
 
 		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, op) })
 	}
 
 	// Retrieve snapshots on the source.
 	snapshots := []string{}
-	if !srcVol.IsSnapshot() && copySnapshots {
-		snapshots, err = d.VolumeSnapshots(srcVol, op)
+	if !srcVol.IsSnapshot() && len(vol.Snapshots) > 0 {
+		snapshots, err = d.VolumeSnapshots(srcVol.Volume, op)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Copy without snapshots.
-	if !copySnapshots || len(snapshots) == 0 {
+	if len(vol.Snapshots) == 0 || len(snapshots) == 0 {
 		// If lightweight clone mode isn't enabled, perform a full copy of the volume.
 		if shared.IsFalse(d.config["ceph.rbd.clone_copy"]) {
 			_, err = shared.RunCommand(
@@ -393,21 +393,21 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 				"--id", d.config["ceph.user.name"],
 				"--cluster", d.config["ceph.cluster_name"],
 				"cp",
-				d.getRBDVolumeName(srcVol, "", false, true),
-				d.getRBDVolumeName(vol, "", false, true),
+				d.getRBDVolumeName(srcVol.Volume, "", false, true),
+				d.getRBDVolumeName(vol.Volume, "", false, true),
 			)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
 
-			_, err = d.rbdMapVolume(vol)
+			_, err = d.rbdMapVolume(vol.Volume)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = d.rbdUnmapVolume(vol, true) })
+			revert.Add(func() { _ = d.rbdUnmapVolume(vol.Volume, true) })
 		} else {
 			parentVol := srcVol
 			snapshotName := "readonly"
@@ -418,33 +418,33 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 				if srcVol.IsSnapshot() {
 					srcParentName, srcSnapOnlyName, _ := api.GetParentAndSnapshotName(srcVol.name)
 					snapshotName = fmt.Sprintf("snapshot_%s", srcSnapOnlyName)
-					parentVol = NewVolume(d, d.name, srcVol.volType, srcVol.contentType, srcParentName, nil, nil)
+					parentVol = NewVolumeCopy(NewVolume(d, d.name, srcVol.volType, srcVol.contentType, srcParentName, nil, nil))
 				} else {
 					// Create snapshot.
-					err := d.rbdCreateVolumeSnapshot(srcVol, snapshotName)
+					err := d.rbdCreateVolumeSnapshot(srcVol.Volume, snapshotName)
 					if err != nil {
 						return err
 					}
 				}
 
 				// Protect volume so we can create clones of it.
-				err = d.rbdProtectVolumeSnapshot(parentVol, snapshotName)
+				err = d.rbdProtectVolumeSnapshot(parentVol.Volume, snapshotName)
 				if err != nil {
 					return err
 				}
 
-				revert.Add(func() { _ = d.rbdUnprotectVolumeSnapshot(parentVol, snapshotName) })
+				revert.Add(func() { _ = d.rbdUnprotectVolumeSnapshot(parentVol.Volume, snapshotName) })
 			}
 
-			err = d.rbdCreateClone(parentVol, snapshotName, vol)
+			err = d.rbdCreateClone(parentVol.Volume, snapshotName, vol.Volume)
 			if err != nil {
 				return err
 			}
 
-			revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+			revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
 		}
 
-		err = postCreateTasks(vol)
+		err = postCreateTasks(vol.Volume)
 		if err != nil {
 			return err
 		}
@@ -456,15 +456,15 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 	// Copy with snapshots.
 
 	// Create empty placeholder volume
-	err = d.rbdCreateVolume(vol, "0")
+	err = d.rbdCreateVolume(vol.Volume, "0")
 	if err != nil {
 		return err
 	}
 
-	revert.Add(func() { _ = d.rbdDeleteVolume(vol) })
+	revert.Add(func() { _ = d.rbdDeleteVolume(vol.Volume) })
 
 	// Receive over the placeholder volume we created above.
-	targetVolumeName := d.getRBDVolumeName(vol, "", false, true)
+	targetVolumeName := d.getRBDVolumeName(vol.Volume, "", false, true)
 
 	lastSnap := ""
 
@@ -482,13 +482,13 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 		}
 
 		lastSnap = fmt.Sprintf("snapshot_%s", snap)
-		sourceVolumeName := d.getRBDVolumeName(srcVol, lastSnap, false, true)
+		sourceVolumeName := d.getRBDVolumeName(srcVol.Volume, lastSnap, false, true)
 		err = d.copyWithSnapshots(sourceVolumeName, targetVolumeName, prev)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = d.rbdDeleteVolumeSnapshot(vol, snap) })
+		revert.Add(func() { _ = d.rbdDeleteVolumeSnapshot(vol.Volume, snap) })
 
 		snapVol, err := vol.NewSnapshot(snap)
 		if err != nil {
@@ -502,14 +502,14 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 	}
 
 	// Copy snapshot.
-	sourceVolumeName := d.getRBDVolumeName(srcVol, "", false, true)
+	sourceVolumeName := d.getRBDVolumeName(srcVol.Volume, "", false, true)
 
 	err = d.copyWithSnapshots(sourceVolumeName, targetVolumeName, lastSnap)
 	if err != nil {
 		return err
 	}
 
-	err = postCreateTasks(vol)
+	err = postCreateTasks(vol.Volume)
 	if err != nil {
 		return err
 	}
@@ -519,7 +519,7 @@ func (d *ceph) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots boo
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	if volTargetArgs.ClusterMoveSourceName != "" {
 		err := vol.EnsureMountPath()
 		if err != nil {
@@ -527,7 +527,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 		}
 
 		if vol.IsVMBlock() {
-			fsVol := vol.NewVMBlockFilesystemVolume()
+			fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
 			err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
 			if err != nil {
 				return err
@@ -545,22 +545,22 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 	}
 
 	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
 		err := d.CreateVolumeFromMigration(fsVol, conn, volTargetArgs, preFiller, op)
 		if err != nil {
 			return err
 		}
 	}
 
-	recvName := d.getRBDVolumeName(vol, "", false, true)
+	recvName := d.getRBDVolumeName(vol.Volume, "", false, true)
 
-	volExists, err := d.HasVolume(vol)
+	volExists, err := d.HasVolume(vol.Volume)
 	if err != nil {
 		return err
 	}
 
 	if !volExists {
-		err := d.rbdCreateVolume(vol, "0")
+		err := d.rbdCreateVolume(vol.Volume, "0")
 		if err != nil {
 			return err
 		}
@@ -581,7 +581,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 
 		// Transfer the snapshots.
 		for _, snapName := range volTargetArgs.Snapshots {
-			fullSnapshotName := d.getRBDVolumeName(vol, snapName, false, true)
+			fullSnapshotName := d.getRBDVolumeName(vol.Volume, snapName, false, true)
 			wrapper := migration.ProgressWriter(op, "fs_progress", fullSnapshotName)
 
 			err = d.receiveVolume(recvName, conn, wrapper)
@@ -603,7 +603,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 
 	defer func() {
 		// Delete all migration-send-* snapshots.
-		snaps, err := d.rbdListVolumeSnapshots(vol)
+		snaps, err := d.rbdListVolumeSnapshots(vol.Volume)
 		if err != nil {
 			return
 		}
@@ -613,7 +613,7 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 				continue
 			}
 
-			_ = d.rbdDeleteVolumeSnapshot(vol, snap)
+			_ = d.rbdDeleteVolumeSnapshot(vol.Volume, snap)
 		}
 	}()
 
@@ -625,12 +625,12 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 	}
 
 	// Map the RBD volume.
-	devPath, err := d.rbdMapVolume(vol)
+	devPath, err := d.rbdMapVolume(vol.Volume)
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = d.rbdUnmapVolume(vol, true) }()
+	defer func() { _ = d.rbdUnmapVolume(vol.Volume, true) }()
 
 	// Re-generate the UUID.
 	err = d.generateUUID(vol.ConfigBlockFilesystem(), devPath)
@@ -642,8 +642,8 @@ func (d *ceph) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vo
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *ceph) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error {
-	return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+	return genericVFSCopyVolume(d, nil, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
@@ -1363,7 +1363,7 @@ func (d *ceph) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	if volSrcArgs.ClusterMove {
 		return nil // When performing a cluster member move don't do anything on the source member.
 	}
@@ -1382,7 +1382,7 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 
 		defer func() { _, _ = d.UnmountVolume(parentVol, false, op) }()
 
-		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+		return genericVFSMigrateVolume(d, d.state, vol.Volume, conn, volSrcArgs, op)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_RBD {
 		return ErrNotSupported
 	}
@@ -1394,8 +1394,8 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 	}
 
 	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.MigrateVolume(fsVol, conn, volSrcArgs, op)
+		fsVolCopy := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+		err := d.MigrateVolume(fsVolCopy, conn, volSrcArgs, op)
 		if err != nil {
 			return err
 		}
@@ -1441,7 +1441,7 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 		}
 
 		lastSnap = fmt.Sprintf("snapshot_%s", snapName)
-		sendSnapName := d.getRBDVolumeName(vol, lastSnap, false, true)
+		sendSnapName := d.getRBDVolumeName(vol.Volume, lastSnap, false, true)
 
 		// Setup progress tracking.
 		var wrapper *ioprogress.ProgressTracker
@@ -1464,14 +1464,14 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 
 	runningSnapName := fmt.Sprintf("migration-send-%s", uuid.New().String())
 
-	err := d.rbdCreateVolumeSnapshot(vol, runningSnapName)
+	err := d.rbdCreateVolumeSnapshot(vol.Volume, runningSnapName)
 	if err != nil {
 		return err
 	}
 
-	defer func() { _ = d.rbdDeleteVolumeSnapshot(vol, runningSnapName) }()
+	defer func() { _ = d.rbdDeleteVolumeSnapshot(vol.Volume, runningSnapName) }()
 
-	cur := d.getRBDVolumeName(vol, runningSnapName, false, true)
+	cur := d.getRBDVolumeName(vol.Volume, runningSnapName, false, true)
 
 	err = d.sendVolume(conn, cur, lastSnap, wrapper)
 	if err != nil {
@@ -1482,7 +1482,7 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *ceph) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *ceph) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
@@ -1801,7 +1801,7 @@ func (d *ceph) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *ceph) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
 	ourUnmount, err := d.UnmountVolume(vol, false, op)
 	if err != nil {
 		return err
@@ -1810,6 +1810,8 @@ func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 	if ourUnmount {
 		defer func() { _ = d.MountVolume(vol, op) }()
 	}
+
+	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	_, err = shared.RunCommand(
 		"rbd",
@@ -1843,7 +1845,8 @@ func (d *ceph) RestoreVolume(vol Volume, snapshotName string, op *operations.Ope
 	// For VM images, restore the filesystem volume too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.RestoreVolume(fsVol, snapshotName, op)
+		fsSnapVol := snapVol.NewVMBlockFilesystemVolume()
+		err := d.RestoreVolume(fsVol, fsSnapVol, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -62,12 +62,12 @@ func (d *cephfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *cephfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *cephfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
-func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (d *cephfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	bwlimit := d.config["rsync.bwlimit"]
 
 	// Create the main volume path.
@@ -98,9 +98,9 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 	// Ensure the volume is mounted.
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 		// If copying snapshots is indicated, check the source isn't itself a snapshot.
-		if copySnapshots && !srcVol.IsSnapshot() {
+		if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 			// Get the list of snapshots from the source.
-			srcSnapshots, err := srcVol.Snapshots(op)
+			srcSnapshots, err := srcVol.Volume.Snapshots(op)
 			if err != nil {
 				return err
 			}
@@ -127,7 +127,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 		}
 
 		// Apply the volume quota if specified.
-		err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+		err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 }
 
 // CreateVolumeFromMigration creates a new volume (with or without snapshots) from a migration data stream.
-func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *cephfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	if volTargetArgs.MigrationType.FSType != migration.MigrationFSType_RSYNC {
 		return ErrNotSupported
 	}
@@ -216,7 +216,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, 
 
 		if vol.contentType == ContentTypeFS {
 			// Apply the size limit.
-			err = d.SetVolumeQuota(vol, vol.ConfigSize(), false, op)
+			err = d.SetVolumeQuota(vol.Volume, vol.ConfigSize(), false, op)
 			if err != nil {
 				return err
 			}
@@ -472,12 +472,12 @@ func (d *cephfs) RenameVolume(vol Volume, newVolName string, op *operations.Oper
 }
 
 // MigrateVolume streams the volume (with or without snapshots).
-func (d *cephfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *cephfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+	return genericVFSMigrateVolume(d, d.state, vol.Volume, conn, volSrcArgs, op)
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *cephfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *cephfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
@@ -570,8 +570,9 @@ func (d *cephfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string
 }
 
 // RestoreVolume resets a volume to its snapshotted state.
-func (d *cephfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *cephfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
 	sourcePath := GetVolumeMountPath(d.name, vol.volType, vol.name)
+	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 	cephSnapPath := filepath.Join(sourcePath, ".snap", snapshotName)
 
 	// Restore using rsync.

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -318,22 +318,22 @@ func (d *common) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.O
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *common) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *common) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, ErrNotSupported
 }
 
 // CreateVolumeFromCopy copies an existing storage volume (with or without snapshots) into a new volume.
-func (d *common) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (d *common) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	return ErrNotSupported
 }
 
 // CreateVolumeFromMigration creates a new volume (with or without snapshots) from a migration data stream.
-func (d *common) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *common) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	return ErrNotSupported
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *common) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error {
+func (d *common) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	return ErrNotSupported
 }
 
@@ -404,12 +404,12 @@ func (d *common) RenameVolume(vol Volume, newVolName string, op *operations.Oper
 }
 
 // MigrateVolume streams the volume (with or without snapshots).
-func (d *common) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *common) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return ErrNotSupported
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *common) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *common) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return ErrNotSupported
 }
 
@@ -439,7 +439,7 @@ func (d *common) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string
 }
 
 // RestoreVolume resets a volume to its snapshotted state.
-func (d *common) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *common) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
 	return ErrNotSupported
 }
 

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -98,7 +98,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *dir) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Run the generic backup unpacker
 	postHook, revertHook, err := genericVFSBackupUnpack(d.withoutGetVolID(), d.state.OS, vol, srcBackup.Snapshots, srcData, op)
 	if err != nil {
@@ -137,30 +137,34 @@ func (d *dir) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *dir) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
-	var err error
-	var srcSnapshots []Volume
+func (d *dir) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
+	var srcSnapshots []string
 
-	if copySnapshots && !srcVol.IsSnapshot() {
+	if len(vol.Snapshots) > 0 && !srcVol.IsSnapshot() {
 		// Get the list of snapshots from the source.
-		srcSnapshots, err = srcVol.Snapshots(op)
+		allSrcSnapshots, err := srcVol.Volume.Snapshots(op)
 		if err != nil {
 			return err
+		}
+
+		for _, srcSnapshot := range allSrcSnapshots {
+			_, snapshotName, _ := api.GetParentAndSnapshotName(srcSnapshot.name)
+			srcSnapshots = append(srcSnapshots, snapshotName)
 		}
 	}
 
 	// Run the generic copy.
-	return genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, srcSnapshots, false, allowInconsistent, op)
+	return genericVFSCopyVolume(d, d.setupInitialQuota, vol.Volume, srcVol.Volume, srcSnapshots, false, allowInconsistent, op)
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *dir) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *dir) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	return genericVFSCreateVolumeFromMigration(d, d.setupInitialQuota, vol, conn, volTargetArgs, preFiller, op)
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *dir) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error {
-	return genericVFSCopyVolume(d, d.setupInitialQuota, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+func (d *dir) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
+	return genericVFSCopyVolume(d, d.setupInitialQuota, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
@@ -413,13 +417,13 @@ func (d *dir) RenameVolume(vol Volume, newVolName string, op *operations.Operati
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *dir) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
-	return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+func (d *dir) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+	return genericVFSMigrateVolume(d, d.state, vol.Volume, conn, volSrcArgs, op)
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *dir) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *dir) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
 }
 
@@ -569,7 +573,8 @@ func (d *dir) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *dir) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *dir) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
+	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 	snapVol, err := vol.NewSnapshot(snapshotName)
 	if err != nil {
 		return err

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -81,22 +81,22 @@ func (d *mock) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 }
 
 // CreateVolumeFromBackup restores a backup tarball onto the storage device.
-func (d *mock) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *mock) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	return nil, nil, nil
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *mock) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *mock) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *mock) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	return nil
 }
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
-func (d *mock) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error {
+func (d *mock) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	return nil
 }
 
@@ -170,13 +170,13 @@ func (d *mock) RenameVolume(vol Volume, newVolName string, op *operations.Operat
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *mock) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *mock) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
-func (d *mock) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *mock) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	return nil
 }
 
@@ -207,7 +207,7 @@ func (d *mock) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, 
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *mock) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *mock) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -338,13 +338,13 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 }
 
 // CreateVolumeFromBackup re-creates a volume from its exported state.
-func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
+func (d *zfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error) {
 	// Handle the non-optimized tarballs through the generic unpacker.
 	if !*srcBackup.OptimizedStorage {
 		return genericVFSBackupUnpack(d, d.state.OS, vol, srcBackup.Snapshots, srcData, op)
 	}
 
-	volExists, err := d.HasVolume(vol)
+	volExists, err := d.HasVolume(vol.Volume)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -366,7 +366,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		}
 
 		// And lastly the main volume.
-		_ = d.DeleteVolume(vol, op)
+		_ = d.DeleteVolume(vol.Volume, op)
 	}
 
 	// Only execute the revert function if we have had an error internally.
@@ -422,7 +422,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 		vols = append(vols, vol.NewVMBlockFilesystemVolume())
 	}
 
-	vols = append(vols, vol)
+	vols = append(vols, vol.Volume)
 
 	for _, v := range vols {
 		// Find the compression algorithm used for backup source data.
@@ -547,7 +547,7 @@ func (d *zfs) CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData 
 }
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
-func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error {
+func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
 	var err error
 
 	// Revert handling
@@ -567,22 +567,22 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	// For VMs, also copy the filesystem dataset.
 	if vol.IsVMBlock() {
 		// For VMs, also copy the filesystem volume.
-		srcFSVol := srcVol.NewVMBlockFilesystemVolume()
-		fsVol := vol.NewVMBlockFilesystemVolume()
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
 
-		err = d.CreateVolumeFromCopy(fsVol, srcFSVol, copySnapshots, false, op)
+		err = d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
 		if err != nil {
 			return err
 		}
 
 		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(fsVol, op) })
+		revert.Add(func() { _ = d.DeleteVolume(fsVol.Volume, op) })
 	}
 
 	// Retrieve snapshots on the source.
 	snapshots := []string{}
-	if !srcVol.IsSnapshot() && copySnapshots {
-		snapshots, err = d.VolumeSnapshots(srcVol, op)
+	if !srcVol.IsSnapshot() && len(vol.Snapshots) > 0 {
+		snapshots, err = d.VolumeSnapshots(srcVol.Volume, op)
 		if err != nil {
 			return err
 		}
@@ -604,12 +604,12 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 	var srcSnapshot string
 	if srcVol.volType == VolumeTypeImage {
-		srcSnapshot = fmt.Sprintf("%s@readonly", d.dataset(srcVol, false))
+		srcSnapshot = fmt.Sprintf("%s@readonly", d.dataset(srcVol.Volume, false))
 	} else if srcVol.IsSnapshot() {
-		srcSnapshot = d.dataset(srcVol, false)
+		srcSnapshot = d.dataset(srcVol.Volume, false)
 	} else {
 		// Create a new snapshot for copy.
-		srcSnapshot = fmt.Sprintf("%s@copy-%s", d.dataset(srcVol, false), uuid.New().String())
+		srcSnapshot = fmt.Sprintf("%s@copy-%s", d.dataset(srcVol.Volume, false), uuid.New().String())
 
 		_, err := shared.RunCommand("zfs", "snapshot", "-r", srcSnapshot)
 		if err != nil {
@@ -644,7 +644,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	}
 
 	// Delete the volume created on failure.
-	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+	revert.Add(func() { _ = d.DeleteVolume(vol.Volume, op) })
 
 	// If zfs.clone_copy is disabled or source volume has snapshots, then use full copy mode.
 	if shared.IsFalse(d.config["zfs.clone_copy"]) || len(snapshots) > 0 {
@@ -653,10 +653,10 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		// Send/receive the snapshot.
 		var sender *exec.Cmd
 		var receiver *exec.Cmd
-		if vol.ContentType() == ContentTypeBlock || d.isBlockBacked(vol) {
-			receiver = exec.Command("zfs", "receive", d.dataset(vol, false))
+		if vol.ContentType() == ContentTypeBlock || d.isBlockBacked(vol.Volume) {
+			receiver = exec.Command("zfs", "receive", d.dataset(vol.Volume, false))
 		} else {
-			receiver = exec.Command("zfs", "receive", "-x", "mountpoint", d.dataset(vol, false))
+			receiver = exec.Command("zfs", "receive", "-x", "mountpoint", d.dataset(vol.Volume, false))
 		}
 
 		// Handle transferring snapshots.
@@ -675,7 +675,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			args := []string{"send"}
 
 			// Check if nesting is required.
-			if d.needsRecursion(d.dataset(srcVol, false)) {
+			if d.needsRecursion(d.dataset(srcVol.Volume, false)) {
 				args = append(args, "-R")
 
 				if zfsRaw {
@@ -685,7 +685,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 			if d.config["zfs.clone_copy"] == "rebase" {
 				var err error
-				origin := d.dataset(srcVol, false)
+				origin := d.dataset(srcVol.Volume, false)
 				for {
 					fields := strings.SplitN(origin, "@", 2)
 
@@ -764,14 +764,14 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 
 		// Delete the snapshot.
-		_, err = shared.RunCommand("zfs", "destroy", "-r", fmt.Sprintf("%s@%s", d.dataset(vol, false), snapName))
+		_, err = shared.RunCommand("zfs", "destroy", "-r", fmt.Sprintf("%s@%s", d.dataset(vol.Volume, false), snapName))
 		if err != nil {
 			return err
 		}
 
 		// Cleanup unexpected snapshots.
 		if len(snapshots) > 0 {
-			children, err := d.getDatasets(d.dataset(vol, false), "snapshot")
+			children, err := d.getDatasets(d.dataset(vol.Volume, false), "snapshot")
 			if err != nil {
 				return err
 			}
@@ -786,7 +786,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 				}
 
 				// Delete the rest.
-				_, err := shared.RunCommand("zfs", "destroy", fmt.Sprintf("%s%s", d.dataset(vol, false), entry))
+				_, err := shared.RunCommand("zfs", "destroy", fmt.Sprintf("%s%s", d.dataset(vol.Volume, false), entry))
 				if err != nil {
 					return err
 				}
@@ -801,7 +801,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			args = append(args, "-o", "volmode=none")
 		}
 
-		args = append(args, srcSnapshot, d.dataset(vol, false))
+		args = append(args, srcSnapshot, d.dataset(vol.Volume, false))
 
 		// Clone the snapshot.
 		_, err := shared.RunCommand("zfs", args...)
@@ -812,26 +812,26 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 	// Apply the properties.
 	if vol.contentType == ContentTypeFS {
-		if !d.isBlockBacked(srcVol) {
-			err := d.setDatasetProperties(d.dataset(vol, false), "mountpoint=legacy", "canmount=noauto")
+		if !d.isBlockBacked(srcVol.Volume) {
+			err := d.setDatasetProperties(d.dataset(vol.Volume, false), "mountpoint=legacy", "canmount=noauto")
 			if err != nil {
 				return err
 			}
 
 			// Apply the blocksize.
-			err = d.setBlocksizeFromConfig(vol)
+			err = d.setBlocksizeFromConfig(vol.Volume)
 			if err != nil {
 				return err
 			}
 		}
 
-		if d.isBlockBacked(srcVol) && renegerateFilesystemUUIDNeeded(vol.ConfigBlockFilesystem()) {
-			_, err := d.activateVolume(vol)
+		if d.isBlockBacked(srcVol.Volume) && renegerateFilesystemUUIDNeeded(vol.ConfigBlockFilesystem()) {
+			_, err := d.activateVolume(vol.Volume)
 			if err != nil {
 				return err
 			}
 
-			volPath, err := d.GetVolumeDiskPath(vol)
+			volPath, err := d.GetVolumeDiskPath(vol.Volume)
 			if err != nil {
 				return err
 			}
@@ -857,13 +857,13 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 	// leaving the filesystem in an inconsistent state if the resize couldn't be completed. This is because if
 	// the resize fails we will delete the volume anyway so don't have to worry about it being inconsistent.
 	var allowUnsafeResize bool
-	if d.isBlockBacked(vol) && vol.contentType == ContentTypeFS {
+	if d.isBlockBacked(vol.Volume) && vol.contentType == ContentTypeFS {
 		allowUnsafeResize = true
 	}
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol, vol.config["size"], allowUnsafeResize, op)
+	err = d.SetVolumeQuota(vol.Volume, vol.config["size"], allowUnsafeResize, op)
 	if err != nil {
 		return err
 	}
@@ -874,7 +874,7 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
-func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
+func (d *zfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error {
 	// Handle simple rsync and block_and_rsync through generic.
 	if volTargetArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volTargetArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		return genericVFSCreateVolumeFromMigration(d, nil, vol, conn, volTargetArgs, preFiller, op)
@@ -904,7 +904,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 
 	// If we're refreshing, send back all snapshots of the target.
 	if volTargetArgs.Refresh && shared.ValueInSlice(migration.ZFSFeatureMigrationHeader, volTargetArgs.MigrationType.Features) {
-		snapshots, err := vol.Snapshots(op)
+		snapshots, err := vol.Volume.Snapshots(op)
 		if err != nil {
 			return fmt.Errorf("Failed getting volume snapshots: %w", err)
 		}
@@ -1022,7 +1022,7 @@ func (d *zfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 		}
 	}
 
-	return d.createVolumeFromMigrationOptimized(vol, conn, volTargetArgs, volumeOnly, preFiller, op)
+	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, volumeOnly, preFiller, op)
 }
 
 func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, volumeOnly bool, preFiller *VolumeFiller, op *operations.Operation) error {
@@ -1046,9 +1046,7 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 
 		if len(snapshots) > 0 {
 			lastIdenticalSnapshot := snapshots[len(snapshots)-1]
-			_, lastIdenticalSnapshotOnlyName, _ := api.GetParentAndSnapshotName(lastIdenticalSnapshot.Name())
-
-			err = d.RestoreVolume(vol, lastIdenticalSnapshotOnlyName, op)
+			err = d.RestoreVolume(vol, lastIdenticalSnapshot, op)
 			if err != nil {
 				return err
 			}
@@ -1210,19 +1208,19 @@ func (d *zfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCl
 }
 
 // RefreshVolume updates an existing volume to match the state of another.
-func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error {
+func (d *zfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
 	var err error
 	var targetSnapshots []Volume
 	var srcSnapshotsAll []Volume
 
 	if !srcVol.IsSnapshot() {
 		// Get target snapshots
-		targetSnapshots, err = vol.Snapshots(op)
+		targetSnapshots, err = vol.Volume.Snapshots(op)
 		if err != nil {
 			return fmt.Errorf("Failed to get target snapshots: %w", err)
 		}
 
-		srcSnapshotsAll, err = srcVol.Snapshots(op)
+		srcSnapshotsAll, err = srcVol.Volume.Snapshots(op)
 		if err != nil {
 			return fmt.Errorf("Failed to get source snapshots: %w", err)
 		}
@@ -1232,12 +1230,12 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 	// We cannot use generic vfs volume copy here, as zfs will complain if a generic
 	// copy/refresh is followed by an optimized refresh.
 	if len(targetSnapshots) == 0 || len(srcSnapshotsAll) == 0 {
-		err = d.DeleteVolume(vol, op)
+		err = d.DeleteVolume(vol.Volume, op)
 		if err != nil {
 			return err
 		}
 
-		return d.CreateVolumeFromCopy(vol, srcVol, len(srcSnapshots) > 0, false, op)
+		return d.CreateVolumeFromCopy(vol, srcVol, false, op)
 	}
 
 	transfer := func(src Volume, target Volume, origin Volume) error {
@@ -1307,13 +1305,13 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 	_, lastIdenticalSnapshotOnlyName, _ := api.GetParentAndSnapshotName(lastIdenticalSnapshot.Name())
 
 	// Rollback target volume to the latest identical snapshot
-	err = d.RestoreVolume(vol, lastIdenticalSnapshotOnlyName, op)
+	err = d.RestoreVolume(vol.Volume, lastIdenticalSnapshot, op)
 	if err != nil {
 		return fmt.Errorf("Failed to restore volume: %w", err)
 	}
 
 	// Create all missing snapshots on the target using an incremental stream
-	for i, snap := range srcSnapshots {
+	for i, refreshSnapshot := range refreshSnapshots {
 		var originSnap Volume
 
 		if i == 0 {
@@ -1322,16 +1320,24 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 				return fmt.Errorf("Failed to create new snapshot volume: %w", err)
 			}
 		} else {
-			originSnap = srcSnapshots[i-1]
+			originSnap, err = srcVol.NewSnapshot(refreshSnapshots[i-1])
+			if err != nil {
+				return fmt.Errorf("Failed to create new snapshot volume: %w", err)
+			}
 		}
 
-		err = transfer(snap, vol, originSnap)
+		snap, err := srcVol.NewSnapshot(refreshSnapshot)
+		if err != nil {
+			return err
+		}
+
+		err = transfer(snap, vol.Volume, originSnap)
 		if err != nil {
 			// Don't fail here. If it's not possible to perform an optimized refresh, do a generic
 			// refresh instead.
 			if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 				d.logger.Debug("Unable to perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-				return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+				return genericVFSCopyVolume(d, nil, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 			}
 
 			return fmt.Errorf("Failed to transfer snapshot %q: %w", snap.name, err)
@@ -1348,7 +1354,7 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 				// refresh instead.
 				if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 					d.logger.Debug("Unable to perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-					return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+					return genericVFSCopyVolume(d, nil, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 				}
 
 				return fmt.Errorf("Failed to transfer snapshot %q: %w", snap.name, err)
@@ -1371,13 +1377,13 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 
 	latestSnapVol := srcSnapshotsAll[len(srcSnapshotsAll)-1]
 
-	err = transfer(srcSnap, vol, latestSnapVol)
+	err = transfer(srcSnap, vol.Volume, latestSnapVol)
 	if err != nil {
 		// Don't fail here. If it's not possible to perform an optimized refresh, do a generic
 		// refresh instead.
 		if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 			d.logger.Debug("Unable to perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-			return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+			return genericVFSCopyVolume(d, nil, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 		}
 
 		return fmt.Errorf("Failed to transfer main volume: %w", err)
@@ -1394,7 +1400,7 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 			// refresh instead.
 			if errors.Is(err, ErrSnapshotDoesNotMatchIncrementalSource) {
 				d.logger.Debug("Unable to perform an optimized refresh, doing a generic refresh", logger.Ctx{"err": err})
-				return genericVFSCopyVolume(d, nil, vol, srcVol, srcSnapshots, true, allowInconsistent, op)
+				return genericVFSCopyVolume(d, nil, vol.Volume, srcVol.Volume, refreshSnapshots, true, allowInconsistent, op)
 			}
 
 			return fmt.Errorf("Failed to transfer main volume: %w", err)
@@ -1402,7 +1408,7 @@ func (d *zfs) RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, al
 	}
 
 	// Restore target volume from main source snapshot.
-	err = d.RestoreVolume(vol, snapUUID, op)
+	err = d.RestoreVolume(vol.Volume, srcSnap, op)
 	if err != nil {
 		return err
 	}
@@ -2400,7 +2406,7 @@ func (d *zfs) DelegateVolume(vol Volume, pid int) error {
 }
 
 // MigrateVolume sends a volume for migration.
-func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
+func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
 	if !volSrcArgs.AllowInconsistent && vol.contentType == ContentTypeFS && vol.IsBlockBacked() {
 		// When migrating using zfs volumes (not datasets), ensure that the filesystem is synced
 		// otherwise the source and target volumes may differ. Tests have shown that only calling
@@ -2423,7 +2429,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 		// If volume is filesystem type, create a fast snapshot to ensure migration is consistent.
 		// TODO add support for temporary snapshots of block volumes here.
 		if vol.contentType == ContentTypeFS && !vol.IsSnapshot() {
-			snapshotPath, cleanup, err := d.readonlySnapshot(vol)
+			snapshotPath, cleanup, err := d.readonlySnapshot(vol.Volume)
 			if err != nil {
 				return err
 			}
@@ -2435,7 +2441,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSMigrateVolume(d, d.state, vol, conn, volSrcArgs, op)
+		return genericVFSMigrateVolume(d, d.state, vol.Volume, conn, volSrcArgs, op)
 	} else if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_ZFS {
 		return ErrNotSupported
 	}
@@ -2450,13 +2456,13 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 
 	// The target will validate the GUIDs and if successful proceed with the refresh.
 	if shared.ValueInSlice(migration.ZFSFeatureMigrationHeader, volSrcArgs.MigrationType.Features) {
-		snapshots, err := d.VolumeSnapshots(vol, op)
+		snapshots, err := d.VolumeSnapshots(vol.Volume, op)
 		if err != nil {
 			return err
 		}
 
 		// Fill the migration header with the snapshot names and dataset GUIDs.
-		srcMigrationHeader, err = d.datasetHeader(vol, snapshots)
+		srcMigrationHeader, err = d.datasetHeader(vol.Volume, snapshots)
 		if err != nil {
 			return err
 		}
@@ -2479,7 +2485,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	}
 
 	// If we haven't negotiated zvol support, ensure volume is not a zvol.
-	if !shared.ValueInSlice(migration.ZFSFeatureZvolFilesystems, volSrcArgs.MigrationType.Features) && d.isBlockBacked(vol) {
+	if !shared.ValueInSlice(migration.ZFSFeatureZvolFilesystems, volSrcArgs.MigrationType.Features) && d.isBlockBacked(vol.Volume) {
 		return fmt.Errorf("Filesystem zvol detected in source but target does not support receiving zvols")
 	}
 
@@ -2524,7 +2530,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 		}
 	}
 
-	return d.migrateVolumeOptimized(vol, conn, volSrcArgs, incrementalStream, op)
+	return d.migrateVolumeOptimized(vol.Volume, conn, volSrcArgs, incrementalStream, op)
 }
 
 func (d *zfs) migrateVolumeOptimized(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, incremental bool, op *operations.Operation) error {
@@ -2681,14 +2687,14 @@ func (d *zfs) readonlySnapshot(vol Volume) (string, revert.Hook, error) {
 }
 
 // BackupVolume creates an exported version of a volume.
-func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
+func (d *zfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
 	// Handle the non-optimized tarballs through the generic packer.
 	if !optimized {
 		// Because the generic backup method will not take a consistent backup if files are being modified
 		// as they are copied to the tarball, as ZFS allows us to take a quick snapshot without impacting
 		// the parent volume we do so here to ensure the backup taken is consistent.
-		if vol.contentType == ContentTypeFS && !d.isBlockBacked(vol) {
-			snapshotPath, cleanup, err := d.readonlySnapshot(vol)
+		if vol.contentType == ContentTypeFS && !d.isBlockBacked(vol.Volume) {
+			snapshotPath, cleanup, err := d.readonlySnapshot(vol.Volume)
 			if err != nil {
 				return err
 			}
@@ -2715,7 +2721,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 
 	// Backup VM config volumes first.
 	if vol.IsVMBlock() {
-		fsVol := vol.NewVMBlockFilesystemVolume()
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
 		err := d.BackupVolume(fsVol, tarWriter, optimized, snapshots, op)
 		if err != nil {
 			return err
@@ -2811,7 +2817,7 @@ func (d *zfs) BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWrit
 	}
 
 	// Create a temporary read-only snapshot.
-	srcSnapshot := fmt.Sprintf("%s@backup-%s", d.dataset(vol, false), uuid.New().String())
+	srcSnapshot := fmt.Sprintf("%s@backup-%s", d.dataset(vol.Volume, false), uuid.New().String())
 	_, err := shared.RunCommand("zfs", "snapshot", "-r", srcSnapshot)
 	if err != nil {
 		return err
@@ -3268,12 +3274,14 @@ func (d *zfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, e
 }
 
 // RestoreVolume restores a volume from a snapshot.
-func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error {
+func (d *zfs) RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error {
 	// Get the list of snapshots.
 	entries, err := d.getDatasets(d.dataset(vol, false), "snapshot")
 	if err != nil {
 		return err
 	}
+
+	_, snapshotName, _ := api.GetParentAndSnapshotName(snapVol.name)
 
 	// Check if more recent snapshots exist.
 	idx := -1
@@ -3352,7 +3360,8 @@ func (d *zfs) RestoreVolume(vol Volume, snapshotName string, op *operations.Oper
 	// For VM images, restore the associated filesystem dataset too.
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
-		err := d.RestoreVolume(fsVol, snapshotName, op)
+		fsSnapVol := snapVol.NewVMBlockFilesystemVolume()
+		err := d.RestoreVolume(fsVol, fsSnapVol, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -65,8 +65,8 @@ type Driver interface {
 	FillVolumeConfig(vol Volume) error
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
 	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
-	CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, allowInconsistent bool, op *operations.Operation) error
-	RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, allowInconsistent bool, op *operations.Operation) error
+	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error
+	RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error
 	DeleteVolume(vol Volume, op *operations.Operation) error
 	RenameVolume(vol Volume, newName string, op *operations.Operation) error
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
@@ -99,14 +99,14 @@ type Driver interface {
 	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error
 	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error
 	VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error)
-	RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error
+	RestoreVolume(vol Volume, snapVol Volume, op *operations.Operation) error
 
 	// Migration.
 	MigrationTypes(contentType ContentType, refresh bool, copySnapshots bool) []migration.Type
-	MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error
-	CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
+	MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error
+	CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
 
 	// Backup.
-	BackupVolume(vol Volume, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
-	CreateVolumeFromBackup(vol Volume, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
+	BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error
+	CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, srcData io.ReadSeeker, op *operations.Operation) (VolumePostHook, revert.Hook, error)
 }

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -99,6 +99,12 @@ type Volume struct {
 	hasSource            bool   // Whether the volume is created from a source volume.
 }
 
+// VolumeCopy represents a volume and its snapshots for copy and refresh operations.
+type VolumeCopy struct {
+	Volume
+	Snapshots []Volume
+}
+
 // NewVolume instantiates a new Volume struct.
 func NewVolume(driver Driver, poolName string, volType VolumeType, contentType ContentType, volName string, volConfig map[string]string, poolConfig map[string]string) Volume {
 	return Volume{
@@ -577,4 +583,12 @@ func (v Volume) Clone() Volume {
 	}
 
 	return NewVolume(v.driver, v.pool, v.volType, v.contentType, v.name, newConfig, newPoolConfig)
+}
+
+// NewVolumeCopy returns a container for copying a volume and its snapshots.
+func NewVolumeCopy(vol Volume, snapshots ...Volume) VolumeCopy {
+	return VolumeCopy{
+		Volume:    vol,
+		Snapshots: snapshots,
+	}
 }


### PR DESCRIPTION
This is a requirement for https://github.com/canonical/lxd/pull/12840 in order to be able to pass down volume's information like the upcoming snapshot's `volatile.uuid` field into the respective storage driver.

The new struct `VolumeCopy` contains not only the volume that requires modification but also all of its snapshots as they were created in the database.
The already existing approach of identifying snapshots that require a refresh is kept. Only for `CreateVolumeFromCopy` the `copySnapshots` field got removed as this information can now be retrieved by checking if the target volume has any snapshots.

Having this information present in the storage drivers allows driver internal logic to access resources that were previously hidden from the driver. That is especially useful for the upcoming Dell PowerFlex driver https://github.com/canonical/lxd/pull/12304 as we need to be able to access the volumes config to generate storage volume names based on its UUID.