### PR TITLE
Auth: Use email address as identifier for OIDC users.

### DIFF
--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -64,7 +64,7 @@ func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 var errRefreshAccessToken = fmt.Errorf("Failed refreshing access token")
-var oidcScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail}
+var oidcScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
 
 type oidcClient struct {
 	httpClient    *http.Client

--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -151,7 +151,7 @@ func (o *oidcClient) getProvider(issuer string, clientID string, groupsClaim str
 		return nil, err
 	}
 
-	cookieHandler := httphelper.NewCookieHandler(hashKey, encryptKey, httphelper.WithUnsecure())
+	cookieHandler := httphelper.NewCookieHandler(hashKey, encryptKey)
 	options := []rp.Option{
 		rp.WithCookieHandler(cookieHandler),
 		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -991,7 +991,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -69,6 +69,7 @@ type AuthenticationResult struct {
 	IdentityType           string
 	Subject                string
 	Email                  string
+	Name                   string
 	IdentityProviderGroups []string
 }
 
@@ -172,6 +173,7 @@ func (o *Verifier) authenticateIDToken(ctx context.Context, w http.ResponseWrite
 				IdentityType:           api.IdentityTypeOIDCClient,
 				Subject:                claims.Subject,
 				Email:                  claims.Email,
+				Name:                   claims.Name,
 				IdentityProviderGroups: o.getGroupsFromClaims(claims.Claims),
 			}, nil
 		}
@@ -215,6 +217,7 @@ func (o *Verifier) authenticateIDToken(ctx context.Context, w http.ResponseWrite
 		IdentityType:           api.IdentityTypeOIDCClient,
 		Subject:                claims.Subject,
 		Email:                  claims.Email,
+		Name:                   claims.Name,
 		IdentityProviderGroups: o.getGroupsFromClaims(claims.Claims),
 	}, nil
 }

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zitadel/oidc/v2/pkg/op"
 	"golang.org/x/crypto/hkdf"
 
+	"github.com/canonical/lxd/lxd/identity"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -44,6 +45,7 @@ const (
 type Verifier struct {
 	accessTokenVerifier op.AccessTokenVerifier
 	relyingParty        rp.RelyingParty
+	identityCache       *identity.Cache
 
 	clientID    string
 	issuer      string
@@ -583,7 +585,7 @@ type Opts struct {
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, options *Opts) (*Verifier, error) {
+func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, options *Opts) (*Verifier, error) {
 	opts := &Opts{
 		ConfigExpiryInterval: defaultConfigExpiryInterval,
 	}
@@ -597,6 +599,7 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 		issuer:               issuer,
 		clientID:             clientID,
 		audience:             audience,
+		identityCache:        identityCache,
 		groupsClaim:          opts.GroupsClaim,
 		clusterCert:          clusterCert,
 		configExpiryInterval: opts.ConfigExpiryInterval,

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -390,7 +390,7 @@ func (o *Verifier) setRelyingParty(host string) error {
 		rp.WithPKCE(cookieHandler),
 	}
 
-	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail}
+	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
 	if o.groupsClaim != "" {
 		oidcScopes = append(oidcScopes, o.groupsClaim)
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1322,7 +1322,7 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -200,7 +200,7 @@ type IdentityFilter struct {
 	Name       *string
 }
 
-// CertificateMetadata contains metadate for certificate identities. Currently this is only the certificate itself.
+// CertificateMetadata contains metadata for certificate identities. Currently this is only the certificate itself.
 type CertificateMetadata struct {
 	Certificate string `json:"cert"`
 }
@@ -263,4 +263,24 @@ func (i Identity) X509() (*x509.Certificate, error) {
 	}
 
 	return metadata.X509()
+}
+
+// OIDCMetadata contains metadata for OIDC identities.
+type OIDCMetadata struct {
+	Subject string `json:"subject"`
+}
+
+// Subject returns OIDC subject from the identity metadata. The AuthMethod of the Identity must be api.AuthenticationMethodOIDC.
+func (i Identity) Subject() (string, error) {
+	if i.AuthMethod != api.AuthenticationMethodOIDC {
+		return "", fmt.Errorf("Cannot extract subject from identity: Identity has authentication method %q (%q required)", i.AuthMethod, api.AuthenticationMethodOIDC)
+	}
+
+	var metadata OIDCMetadata
+	err := json.Unmarshal([]byte(i.Metadata), &metadata)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unmarshal subject metadata: %w", err)
+	}
+
+	return metadata.Subject, nil
 }

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -53,6 +53,7 @@ func updateIdentityCache(d *Daemon) {
 	for _, id := range identities {
 		cacheEntry := identity.CacheEntry{
 			Identifier:           id.Identifier,
+			Name:                 id.Name,
 			AuthenticationMethod: string(id.AuthMethod),
 			IdentityType:         string(id.Type),
 			Projects:             projects[id.ID],
@@ -66,6 +67,14 @@ func updateIdentityCache(d *Daemon) {
 			}
 
 			cacheEntry.Certificate = cert
+		} else if cacheEntry.AuthenticationMethod == api.AuthenticationMethodOIDC {
+			subject, err := id.Subject()
+			if err != nil {
+				logger.Warn("Failed to extract OIDC subject from OIDC identity metadata", logger.Ctx{"error": err})
+				continue
+			}
+
+			cacheEntry.Subject = subject
 		}
 
 		identityCacheEntries = append(identityCacheEntries, cacheEntry)

--- a/lxd/identity/cache.go
+++ b/lxd/identity/cache.go
@@ -14,7 +14,7 @@ import (
 // Cache represents a thread-safe in-memory cache of the identities in the database.
 type Cache struct {
 	// entries is a map of authentication method to map of identifier to CacheEntry. The identifier is either a
-	// certificate fingerprint (tls) or an OIDC subject (oidc).
+	// certificate fingerprint (tls) or an email address (oidc).
 	entries map[string]map[string]*CacheEntry
 	mu      sync.RWMutex
 }
@@ -22,12 +22,16 @@ type Cache struct {
 // CacheEntry represents an identity.
 type CacheEntry struct {
 	Identifier           string
+	Name                 string
 	AuthenticationMethod string
 	IdentityType         string
 	Projects             []string
 
 	// Certificate is optional. It is pre-computed for identities with AuthenticationMethod api.AuthenticationMethodTLS.
 	Certificate *x509.Certificate
+
+	// Subject is optional. It is only set when AuthenticationMethod is api.AuthenticationMethodOIDC.
+	Subject string
 }
 
 // Get returns a single CacheEntry by its authentication method and identifier.

--- a/lxd/identity/cache.go
+++ b/lxd/identity/cache.go
@@ -57,7 +57,8 @@ func (c *Cache) Get(authenticationMethod string, identifier string) (*CacheEntry
 		return nil, api.StatusErrorf(http.StatusNotFound, "Identity %q (%s) not found", identifier, authenticationMethod)
 	}
 
-	return entry, nil
+	entryCopy := *entry
+	return &entryCopy, nil
 }
 
 // GetByType returns a map of identifier to CacheEntry, where all entries have the given identity type.

--- a/test/includes/oidc.sh
+++ b/test/includes/oidc.sh
@@ -23,4 +23,5 @@ kill_oidc() {
 
 set_oidc() {
   echo "${1}" > "${TEST_DIR}/oidc.user"
+  echo "${2:-}" >> "${TEST_DIR}/oidc.user"
 }

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -9,19 +9,30 @@ test_oidc() {
   lxc config set "oidc.issuer=http://127.0.0.1:$(cat "${TEST_DIR}/oidc.port")/"
   lxc config set "oidc.client.id=device"
 
-  BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
-  [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "unknown" ]
-  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'unknown' AND auth_method = 2" | wc -l)" = 5 ]
-  lxc remote remove oidc
+  # Expect this to fail. No user set.
+  ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
 
+  # Set a user with no email address
   set_oidc test-user
 
+  # Expect this to fail. mini-oidc will issue a token but adding the remote will fail because no email address will be
+  # returned from /userinfo
+  ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false
+
+  # Set a user with an email address
+  set_oidc test-user test-user@example.com
+
+  # This should succeed.
   BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
-  [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "test-user" ]
-  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'test-user' AND auth_method = 2" | wc -l)" = 5 ]
-  lxc remote remove oidc
+
+  # lxc info should show the email address as the username.
+  [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "test-user@example.com" ]
+
+  # OIDC user should be added to identities table.
+  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'test-user@example.com' AND auth_method = 2" | wc -l)" = 5 ]
 
   # Cleanup OIDC
+  lxc remote remove oidc
   kill_oidc
   lxc config unset oidc.issuer
   lxc config unset oidc.client.id


### PR DESCRIPTION
This was deliberated in a meeting with the identity team and some folks working on Juju (JIMM). It turns out that it is possible for the OIDC subject to change when using some identity brokers (e.g. keycloak) in certain circumstances. JIMM are using email addresses translated into UUIDs for their users.

Changing the unique identifier to email from OIDC subject has a few benefits for us:
1. It will be easier to use in the API (e.g. `GET /1.0/auth/identities/oidc/jane.doe@example.com`).
2. Group membership (and therefore permissions) will persist even if an administrator changes the configured OIDC provider for LXD.

However, email addresses are not present in the access tokens that are sent as bearer tokens when using the client. To work around this. This PR does the following:
1. Stores the subject in the identity metadata and keep it as an optional field in the identity cache (like we are doing for TLS certs). 
2. If we receive an access token, we check our cache for a matching subject and get the email from there. If the cache does not contain the subject, call the `/userinfo` endpoint to get it. The userinfo endpoint should return us an email address because the access token was granted with the email scope. 
3. With the email address we check our cache again, if the email is present it is the same user but the subject has changed, otherwise it is a new user. For new users we add them to the identities table and update the cache. If the subject has changed we update that identity to change the metadata and update the cache.