### PR TITLE
Doc: Add some device examples

### DIFF
--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -18,58 +18,35 @@ Virtual machines share host-side mounts or directories through `9p` or `virtiofs
 ## Types of disk devices
 
 You can create disk devices from different sources.
-The value that you specify for the `source` option specifies the type of disk device that is added:
+The value that you specify for the `source` option specifies the type of disk device that is added.
+See {ref}`devices-disk-examples` for more detailed information on how to add each type of disk device.
 
 Storage volume
 : The most common type of disk device is a storage volume.
-  To add a storage volume, specify its name as the `source` of the device:
-
-      lxc config device add <instance_name> <device_name> disk pool=<pool_name> source=<volume_name> [path=<path_in_instance>]
-
-  The path is required for file system volumes, but not for block volumes.
-
-  Alternatively, you can use the [`lxc storage volume attach`](lxc_storage_volume_attach.md) command to {ref}`storage-attach-volume`.
-  Both commands use the same mechanism to add a storage volume as a disk device.
+  Specify the storage volume name as the source to add a storage volume as a disk device.
 
 Path on the host
-: You can share a path on your host (either a file system or a block device) to your instance by adding it as a disk device with the host path as the `source`:
-
-      lxc config device add <instance_name> <device_name> disk source=<path_on_host> [path=<path_in_instance>]
-
-  The path is required for file systems, but not for block devices.
+: You can share a path on your host (either a file system or a block device) to your instance.
+  Specify the host path as the source to add it as a disk device.
 
 Ceph RBD
-: LXD can use Ceph to manage an internal file system for the instance, but if you have an existing, externally managed Ceph RBD that you would like to use for an instance, you can add it with the following command:
-
-      lxc config device add <instance_name> <device_name> disk source=ceph:<pool_name>/<volume_name> ceph.user_name=<user_name> ceph.cluster_name=<cluster_name> [path=<path_in_instance>]
-
-  The path is required for file systems, but not for block devices.
+: LXD can use Ceph to manage an internal file system for the instance, but if you have an existing, externally managed Ceph RBD that you would like to use for an instance, you can add it by specifying `ceph:<pool_name>/<volume_name>` as the source.
 
 CephFS
-: LXD can use Ceph to manage an internal file system for the instance, but if you have an existing, externally managed Ceph file system that you would like to use for an instance, you can add it with the following command:
-
-      lxc config device add <instance_name> <device_name> disk source=cephfs:<fs_name>/<path> ceph.user_name=<user_name> ceph.cluster_name=<cluster_name> path=<path_in_instance>
+: LXD can use Ceph to manage an internal file system for the instance, but if you have an existing, externally managed Ceph file system that you would like to use for an instance, you can add it by specifying `cephfs:<fs_name>/<path>` as the source.
 
 ISO file
-: You can add an ISO file as a disk device for a virtual machine.
+: You can add an ISO file as a disk device for a virtual machine by specifying its file path as the source.
   It is added as a ROM device inside the VM.
 
   This source type is applicable only to VMs.
 
-  To add an ISO file, specify its file path as the `source`:
-
-      lxc config device add <instance_name> <device_name> disk source=<file_path_on_host>
-
 (vm-cloud-init-config)=
 VM `cloud-init`
-: You can generate a `cloud-init` configuration ISO from the {config:option}`instance-cloud-init:cloud-init.vendor-data` and {config:option}`instance-cloud-init:cloud-init.user-data` configuration keys and attach it to a virtual machine.
+: You can generate a `cloud-init` configuration ISO from the {config:option}`instance-cloud-init:cloud-init.vendor-data` and {config:option}`instance-cloud-init:cloud-init.user-data` configuration keys and attach it to a virtual machine by specifying `cloud-init:config` as the source.
   The `cloud-init` that is running inside the VM then detects the drive on boot and applies the configuration.
 
   This source type is applicable only to VMs.
-
-  To add such a device, use the following command:
-
-      lxc config device add <instance_name> <device_name> disk source=cloud-init:config
 
   Adding such a configuration disk might be needed if the VM image that is used includes `cloud-init` but not the `lxd-agent`. This is the case for official Ubuntu images prior to `20.04`. On such images, the following steps enable the LXD agent and thus provide the ability to use `lxc exec` to access the VM:
 
@@ -136,3 +113,49 @@ Key                 | Type      | Default       | Required  | Description
 `size`              | string    | -             | no        | Disk size in bytes (various suffixes supported, see {ref}`instances-limit-units`) - only supported for the `rootfs` (`/`)
 `size.state`        | string    | -             | no        | Same as `size`, but applies to the file-system volume used for saving runtime state in VMs
 `source`            | string    | -             | yes       | Source of a file system or block device (see {ref}`devices-disk-types` for details)
+
+(devices-disk-examples)=
+## Configuration examples
+
+How to add a disk device depends on its {ref}`type <devices-disk-types>`.
+
+Storage volume
+: To add a storage volume, specify its name as the `source` of the device:
+
+      lxc config device add <instance_name> <device_name> disk pool=<pool_name> source=<volume_name> [path=<path_in_instance>]
+
+  The path is required for file system volumes, but not for block volumes.
+
+  Alternatively, you can use the [`lxc storage volume attach`](lxc_storage_volume_attach.md) command to {ref}`storage-attach-volume`.
+  Both commands use the same mechanism to add a storage volume as a disk device.
+
+Path on the host
+: To add a host device, specify the host path as the `source`:
+
+      lxc config device add <instance_name> <device_name> disk source=<path_on_host> [path=<path_in_instance>]
+
+  The path is required for file systems, but not for block devices.
+
+Ceph RBD
+: To add an existing Ceph RBD volume, specify its pool and volume name:
+
+      lxc config device add <instance_name> <device_name> disk source=ceph:<pool_name>/<volume_name> ceph.user_name=<user_name> ceph.cluster_name=<cluster_name> [path=<path_in_instance>]
+
+  The path is required for file systems, but not for block devices.
+
+CephFS
+: To add an existing CephFS file system, specify its name and path:
+
+      lxc config device add <instance_name> <device_name> disk source=cephfs:<fs_name>/<path> ceph.user_name=<user_name> ceph.cluster_name=<cluster_name> path=<path_in_instance>
+
+ISO file
+: To add an ISO file, specify its file path as the `source`:
+
+      lxc config device add <instance_name> <device_name> disk source=<file_path_on_host>
+
+VM `cloud-init`
+: To add `cloud-init` configuration, specify `cloud-init:config` as the source:
+
+      lxc config device add <instance_name> <device_name> disk source=cloud-init:config
+
+See {ref}`instances-configure-devices` for more information.

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -177,6 +177,34 @@ Key                     | Type    | Default           | Managed | Description
 `security.mac_filtering`| bool    | `false`           | no      | Prevent the instance from spoofing another instance's MAC address
 `vlan`                  | integer | -                 | no      | The VLAN ID to attach to
 
+(nic-physical)=
+### `nictype`: `physical`
+
+```{note}
+- You can select this NIC type through the `nictype` option or the `network` option (see {ref}`network-physical` for information about the managed `physical` network).
+- You can have only one `physical` NIC for each parent device.
+```
+
+A `physical` NIC provides straight physical device pass-through from the host.
+The targeted device will vanish from the host and appear in the instance (which means that you can have only one `physical` NIC for each targeted device).
+
+#### Device options
+
+NIC devices of type `physical` have the following device options:
+
+Key                     | Type    | Default           | Managed | Description
+:--                     | :--     | :--               | :--     | :--
+`boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
+`gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
+`hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
+`maas.subnet.ipv4`      | string  | -                 | no      | MAAS IPv4 subnet to register the instance in
+`maas.subnet.ipv6`      | string  | -                 | no      | MAAS IPv6 subnet to register the instance in
+`mtu`                   | integer | parent MTU        | no      | The MTU of the new interface
+`name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
+`network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
+`parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
+`vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+
 (nic-ovn)=
 ### `nictype`: `ovn`
 
@@ -249,34 +277,6 @@ Key                                   | Type    | Default           | Managed | 
 `security.acls.default.ingress.action`| string  | `reject`          | no      | Action to use for ingress traffic that doesn't match any ACL rule
 `security.acls.default.ingress.logged`| bool    | `false`           | no      | Whether to log ingress traffic that doesn't match any ACL rule
 `vlan`                                | integer | -                 | no      | The VLAN ID to use when nesting (see also `nested`)
-
-(nic-physical)=
-### `nictype`: `physical`
-
-```{note}
-- You can select this NIC type through the `nictype` option or the `network` option (see {ref}`network-physical` for information about the managed `physical` network).
-- You can have only one `physical` NIC for each parent device.
-```
-
-A `physical` NIC provides straight physical device pass-through from the host.
-The targeted device will vanish from the host and appear in the instance (which means that you can have only one `physical` NIC for each targeted device).
-
-#### Device options
-
-NIC devices of type `physical` have the following device options:
-
-Key                     | Type    | Default           | Managed | Description
-:--                     | :--     | :--               | :--     | :--
-`boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
-`hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
-`maas.subnet.ipv4`      | string  | -                 | no      | MAAS IPv4 subnet to register the instance in
-`maas.subnet.ipv6`      | string  | -                 | no      | MAAS IPv6 subnet to register the instance in
-`mtu`                   | integer | parent MTU        | no      | The MTU of the new interface
-`name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
-`parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
-`vlan`                  | integer | -                 | no      | The VLAN ID to attach to
 
 (nic-ipvlan)=
 ### `nictype`: `ipvlan`

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -103,6 +103,21 @@ Key                      | Type    | Default           | Managed | Description
 `vlan`                   | integer | -                 | no      | The VLAN ID to use for non-tagged traffic (can be `none` to remove port from default VLAN)
 `vlan.tagged`            | integer | -                 | no      | Comma-delimited list of VLAN IDs or VLAN ranges to join for tagged traffic
 
+#### Configuration examples
+
+Add a `bridged` network device to an instance, connecting to a LXD managed network:
+
+    lxc network create <network_name> --type=bridge
+    lxc config device add <instance_name> <device_name> nic network=<network_name>
+
+Note that `bridge` is the type when creating a managed bridge network, while the device `nictype` that is required when connecting to an unmanaged bridge is `bridged`.
+
+Add a `bridged` network device to an instance, connecting to an existing bridge interface with `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=bridged parent=<existing_bridge>
+
+See {ref}`network-create` and {ref}`instances-configure-devices`for more information.
+
 (nic-macvlan)=
 ### `nictype`: `macvlan`
 
@@ -131,6 +146,19 @@ Key                     | Type    | Default           | Managed | Description
 `network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
 `parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
 `vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+
+#### Configuration examples
+
+Add a `macvlan` network device to an instance, connecting to a LXD managed network:
+
+    lxc network create <network_name> --type=macvlan parent=<existing_NIC>
+    lxc config device add <instance_name> <device_name> nic network=<network_name>
+
+Add a `macvlan` network device to an instance, connecting to an existing network interface with `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=macvlan parent=<existing_NIC>
+
+See {ref}`network-create` and {ref}`instances-configure-devices`for more information.
 
 (nic-sriov)=
 ### `nictype`: `sriov`
@@ -177,6 +205,19 @@ Key                     | Type    | Default           | Managed | Description
 `security.mac_filtering`| bool    | `false`           | no      | Prevent the instance from spoofing another instance's MAC address
 `vlan`                  | integer | -                 | no      | The VLAN ID to attach to
 
+#### Configuration examples
+
+Add a `sriov` network device to an instance, connecting to a LXD managed network:
+
+    lxc network create <network_name> --type=sriov parent=<sriov_enabled_NIC>
+    lxc config device add <instance_name> <device_name> nic network=<network_name>
+
+Add a `sriov` network device to an instance, connecting to an existing SR-IOV-enabled interface with `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=sriov parent=<sriov_enabled_NIC>
+
+See {ref}`network-create` and {ref}`instances-configure-devices`for more information.
+
 (nic-physical)=
 ### `nictype`: `physical`
 
@@ -204,6 +245,16 @@ Key                     | Type    | Default           | Managed | Description
 `network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
 `parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
 `vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+
+#### Configuration examples
+
+Add a `physical` network device to an instance, connecting to an existing physical network interface with `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=physical parent=<physical_NIC>
+
+Adding a `physical` network device to an instance using a managed network is not possible, because the `physical` managed network type is intended to be used only with OVN networks.
+
+See {ref}`instances-configure-devices` for more information.
 
 (nic-ovn)=
 ### `nictype`: `ovn`
@@ -278,6 +329,16 @@ Key                                   | Type    | Default           | Managed | 
 `security.acls.default.ingress.logged`| bool    | `false`           | no      | Whether to log ingress traffic that doesn't match any ACL rule
 `vlan`                                | integer | -                 | no      | The VLAN ID to use when nesting (see also `nested`)
 
+#### Configuration examples
+
+An `ovn` network device must be added using a managed network.
+To do so:
+
+    lxc network create <network_name> --type=ovn network=<parent_network>
+    lxc config device add <instance_name> <device_name> nic network=<network_name>
+
+See {ref}`network-ovn-setup` for full instructions, and {ref}`network-create` and {ref}`instances-configure-devices` for more information.
+
 (nic-ipvlan)=
 ### `nictype`: `ipvlan`
 
@@ -332,6 +393,17 @@ Key                     | Type    | Default            | Description
 `parent`                | string  | -                  | The name of the host device (required)
 `vlan`                  | integer | -                  | The VLAN ID to attach to
 
+#### Configuration examples
+
+Add an `ipvlan` network device to an instance, connecting to an existing network interface with `nictype`:
+
+    lxc stop <instance_name>
+    lxc config device add <instance_name> <device_name> nic nictype=ipvlan parent=<existing_NIC>
+
+Adding an `ipvlan` network device to an instance using a managed network is not possible.
+
+See {ref}`instances-configure-devices` for more information.
+
 (nic-p2p)=
 ### `nictype`: `p2p`
 
@@ -359,6 +431,16 @@ Key                     | Type    | Default           | Description
 `mtu`                   | integer | kernel assigned   | The MTU of the new interface
 `name`                  | string  | kernel assigned   | The name of the interface inside the instance
 `queue.tx.length`       | integer | -                 | The transmit queue length for the NIC
+
+#### Configuration examples
+
+Add a `p2p` network device to an instance using `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=p2p
+
+Adding a `p2p` network device to an instance using a managed network is not possible.
+
+See {ref}`instances-configure-devices` for more information.
 
 (nic-routed)=
 ### `nictype`: `routed`
@@ -450,6 +532,16 @@ Key                     | Type    | Default           | Description
 `parent`                | string  | -                 | The name of the host device to join the instance to
 `queue.tx.length`       | integer | -                 | The transmit queue length for the NIC
 `vlan`                  | integer | -                 | The VLAN ID to attach to
+
+#### Configuration examples
+
+Add a `routed` network device to an instance using `nictype`:
+
+    lxc config device add <instance_name> <device_name> nic nictype=routed ipv4.address=192.0.2.2 ipv6.address=2001:db8::2
+
+Adding a `routed` network device to an instance using a managed network is not possible.
+
+See {ref}`instances-configure-devices` for more information.
 
 ## `bridged`, `macvlan` or `ipvlan` for connection to physical network
 


### PR DESCRIPTION
Add configuration examples for NIC devices, and move the configuration examples for disk devices to a separate section to make it consistent.