### PR TITLE
Smaller lxc and lxd-migrate binaries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -386,14 +386,14 @@ jobs:
           CGO_ENABLED: 0
           GOARCH: amd64
         run: |
-          go build -o bin/lxc.x86_64 ./lxc
+          go build -o trimpath -o bin/lxc.x86_64 ./lxc
 
       - name: Build static lxc (aarch64)
         env:
           CGO_ENABLED: 0
           GOARCH: arm64
         run: |
-          go build -o bin/lxc.aarch64 ./lxc
+          go build -o trimpath -o bin/lxc.aarch64 ./lxc
 
       - name: Build static lxd-migrate
         if: runner.os == 'Linux'
@@ -401,8 +401,8 @@ jobs:
           CGO_ENABLED: 0
         run: |
           set -eux
-          GOARCH=amd64 go build -o bin/lxd-migrate.x86_64 ./lxd-migrate
-          GOARCH=arm64 go build -o bin/lxd-migrate.aarch64 ./lxd-migrate
+          GOARCH=amd64 go build -o trimpath -o bin/lxd-migrate.x86_64 ./lxd-migrate
+          GOARCH=arm64 go build -o trimpath -o bin/lxd-migrate.aarch64 ./lxd-migrate
 
       - name: Unit tests (client)
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -404,6 +404,10 @@ jobs:
           GOARCH=amd64 go build -o trimpath -o bin/lxd-migrate.x86_64 ./lxd-migrate
           GOARCH=arm64 go build -o trimpath -o bin/lxd-migrate.aarch64 ./lxd-migrate
 
+      - name: Strip lxc and lxd-migrate native binaries
+        if: runner.os != 'macOS'     # macOS doesn't have strip
+        run: strip -s bin/lx*.x86_64 # non-native binaries cannot be strip'ed
+
       - name: Unit tests (client)
         env:
           CGO_ENABLED: 0


### PR DESCRIPTION
Essentially do what `strip -s` does but using just `go build` as `strip` couldn't work on foreign arches (arm64 bins compiled on amd64).

This leads to smaller artifacts for Chocolatey and also produces smaller artifacts attached to each test runs.