### PR TITLE
Avoid race between operation and events listener

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -426,6 +426,7 @@ type InstanceServer interface {
 	DeleteWarning(UUID string) (err error)
 
 	// Authorization functions
+	SupportsAuthentication() bool
 	GetAuthGroupNames() (groupNames []string, err error)
 	GetAuthGroups() (groups []api.AuthGroup, err error)
 	GetAuthGroup(groupName string) (group *api.AuthGroup, ETag string, err error)

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -399,11 +399,10 @@ func (r *ProtocolLXD) queryOperation(method string, path string, data any, ETag 
 
 	// Setup an Operation wrapper
 	op := operation{
-		Operation:    *respOperation,
-		r:            r,
-		listener:     listener,
-		chActive:     make(chan bool),
-		skipListener: !useEventListener,
+		Operation: *respOperation,
+		r:         r,
+		listener:  listener,
+		chActive:  make(chan bool),
 	}
 
 	// Log the data

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -44,6 +44,10 @@ type ProtocolLXD struct {
 	httpProtocol    string
 	httpUserAgent   string
 
+	// supportsAuthentication returns whether the client can attempt to make trusted connections to its target server.
+	// A unix client, or an http client with TLS certificates will be considered to support authentication.
+	supportsAuthentication bool
+
 	requireAuthenticated bool
 
 	clusterTarget string

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -176,6 +176,12 @@ func (r *ProtocolLXD) addClientHeaders(req *http.Request) {
 	}
 }
 
+// SupportsAuthentication returns whether the client can attempt to make trusted connections to its target server.
+// A unix client, or an http client with TLS certificates will be considered to support authentication.
+func (r *ProtocolLXD) SupportsAuthentication() bool {
+	return r.supportsAuthentication
+}
+
 // RequireAuthenticated sets whether we expect to be authenticated with the server.
 func (r *ProtocolLXD) RequireAuthenticated(authenticated bool) {
 	r.requireAuthenticated = authenticated

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -207,8 +207,10 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 
 			rop.targetOp = op
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.supportsAuthentication {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -570,8 +572,10 @@ func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, re
 
 			rop.targetOp = op
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if source.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -1262,8 +1266,10 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, contain
 
 			rop.targetOp = op
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if source.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()

--- a/client/lxd_events.go
+++ b/client/lxd_events.go
@@ -29,6 +29,10 @@ func (r *ProtocolLXD) getEvents(allProjects bool) (*EventListener, error) {
 		ctxCancel: cancel,
 	}
 
+	if !r.supportsAuthentication {
+		return nil, fmt.Errorf("Failed to connect to the Events interface, the client does not support authentication")
+	}
+
 	connInfo, _ := r.GetConnectionInfo()
 	if connInfo.Project == "" {
 		return nil, fmt.Errorf("Unexpected empty project in connection info")

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -653,8 +653,10 @@ func (r *ProtocolLXD) tryCopyImage(req api.ImagesPost, urls []string) (RemoteOpe
 			rop.targetOp = op
 			rop.handlerLock.Unlock()
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.supportsAuthentication {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -854,8 +856,10 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 			rop.targetOp = op
 			rop.handlerLock.Unlock()
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.supportsAuthentication {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -495,6 +495,16 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 		return nil, err
 	}
 
+	// Set up the events listener before making the request so that
+	// the operation doesn't complete and emit the event before we've begun listening.
+	var listener *EventListener
+	if r.supportsAuthentication {
+		listener, err = r.getEvents(false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	req, err := http.NewRequest("POST", reqURL, body)
 	if err != nil {
 		return nil, err
@@ -567,6 +577,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 	op := operation{
 		Operation: *respOperation,
 		r:         r,
+		listener:  listener,
 		chActive:  make(chan bool),
 	}
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -266,8 +266,10 @@ func (r *ProtocolLXD) tryRebuildInstance(instanceName string, req api.InstanceRe
 			rop.targetOp = op
 			rop.handlerLock.Unlock()
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.supportsAuthentication {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -754,8 +756,10 @@ func (r *ProtocolLXD) tryCreateInstance(req api.InstancesPost, urls []string, op
 			rop.targetOp = op
 			rop.handlerLock.Unlock()
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.supportsAuthentication {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -1111,8 +1115,10 @@ func (r *ProtocolLXD) tryMigrateInstance(source InstanceServer, name string, req
 
 			rop.targetOp = op
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if source.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -2110,8 +2116,10 @@ func (r *ProtocolLXD) tryMigrateInstanceSnapshot(source InstanceServer, instance
 
 			rop.targetOp = op
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if source.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -101,21 +101,22 @@ func (r *ProtocolLXD) GetServerResources() (*api.Resources, error) {
 // UseProject returns a client that will use a specific project.
 func (r *ProtocolLXD) UseProject(name string) InstanceServer {
 	return &ProtocolLXD{
-		ctx:                  r.ctx,
-		ctxConnected:         r.ctxConnected,
-		ctxConnectedCancel:   r.ctxConnectedCancel,
-		server:               r.server,
-		http:                 r.http,
-		httpCertificate:      r.httpCertificate,
-		httpBaseURL:          r.httpBaseURL,
-		httpProtocol:         r.httpProtocol,
-		httpUserAgent:        r.httpUserAgent,
-		requireAuthenticated: r.requireAuthenticated,
-		clusterTarget:        r.clusterTarget,
-		project:              name,
-		eventConns:           make(map[string]*websocket.Conn),  // New project specific listener conns.
-		eventListeners:       make(map[string][]*EventListener), // New project specific listeners.
-		oidcClient:           r.oidcClient,
+		ctx:                    r.ctx,
+		ctxConnected:           r.ctxConnected,
+		ctxConnectedCancel:     r.ctxConnectedCancel,
+		server:                 r.server,
+		http:                   r.http,
+		httpCertificate:        r.httpCertificate,
+		httpBaseURL:            r.httpBaseURL,
+		httpProtocol:           r.httpProtocol,
+		httpUserAgent:          r.httpUserAgent,
+		supportsAuthentication: r.supportsAuthentication,
+		requireAuthenticated:   r.requireAuthenticated,
+		clusterTarget:          r.clusterTarget,
+		project:                name,
+		eventConns:             make(map[string]*websocket.Conn),  // New project specific listener conns.
+		eventListeners:         make(map[string][]*EventListener), // New project specific listeners.
+		oidcClient:             r.oidcClient,
 	}
 }
 
@@ -124,21 +125,22 @@ func (r *ProtocolLXD) UseProject(name string) InstanceServer {
 // placement, preparing a new storage pool or network, ...
 func (r *ProtocolLXD) UseTarget(name string) InstanceServer {
 	return &ProtocolLXD{
-		ctx:                  r.ctx,
-		ctxConnected:         r.ctxConnected,
-		ctxConnectedCancel:   r.ctxConnectedCancel,
-		server:               r.server,
-		http:                 r.http,
-		httpCertificate:      r.httpCertificate,
-		httpBaseURL:          r.httpBaseURL,
-		httpProtocol:         r.httpProtocol,
-		httpUserAgent:        r.httpUserAgent,
-		requireAuthenticated: r.requireAuthenticated,
-		project:              r.project,
-		eventConns:           make(map[string]*websocket.Conn),  // New target specific listener conns.
-		eventListeners:       make(map[string][]*EventListener), // New target specific listeners.
-		oidcClient:           r.oidcClient,
-		clusterTarget:        name,
+		ctx:                    r.ctx,
+		ctxConnected:           r.ctxConnected,
+		ctxConnectedCancel:     r.ctxConnectedCancel,
+		server:                 r.server,
+		http:                   r.http,
+		httpCertificate:        r.httpCertificate,
+		httpBaseURL:            r.httpBaseURL,
+		httpProtocol:           r.httpProtocol,
+		httpUserAgent:          r.httpUserAgent,
+		supportsAuthentication: r.supportsAuthentication,
+		requireAuthenticated:   r.requireAuthenticated,
+		project:                r.project,
+		eventConns:             make(map[string]*websocket.Conn),  // New target specific listener conns.
+		eventListeners:         make(map[string][]*EventListener), // New target specific listeners.
+		oidcClient:             r.oidcClient,
+		clusterTarget:          name,
 	}
 }
 

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -438,8 +438,10 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool st
 				chDone:   make(chan bool),
 			}
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if source.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()
@@ -500,8 +502,10 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 				chDone:   make(chan bool),
 			}
 
-			for _, handler := range rop.handlers {
-				_, _ = rop.targetOp.AddHandler(handler)
+			if r.SupportsAuthentication() {
+				for _, handler := range rop.handlers {
+					_, _ = rop.targetOp.AddHandler(handler)
+				}
 			}
 
 			err = rop.targetOp.Wait()

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -1034,6 +1034,16 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromISO(pool string, args StoragePo
 	req.Header.Set("X-LXD-name", args.Name)
 	req.Header.Set("X-LXD-type", "iso")
 
+	// Set up the events listener before making the request so that
+	// the operation doesn't complete and emit the event before we've begun listening.
+	var listener *EventListener
+	if r.supportsAuthentication {
+		listener, err = r.getEvents(false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Send the request.
 	resp, err := r.DoHTTP(req)
 	if err != nil {
@@ -1057,6 +1067,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromISO(pool string, args StoragePo
 	// Setup an Operation wrapper.
 	op := operation{
 		Operation: *respOperation,
+		listener:  listener,
 		r:         r,
 		chActive:  make(chan bool),
 	}
@@ -1097,6 +1108,16 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromBackup(pool string, args Storag
 		req.Header.Set("X-LXD-name", args.Name)
 	}
 
+	// Set up the events listener before making the request so that
+	// the operation doesn't complete and emit the event before we've begun listening.
+	var listener *EventListener
+	if r.supportsAuthentication {
+		listener, err = r.getEvents(false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Send the request.
 	resp, err := r.DoHTTP(req)
 	if err != nil {
@@ -1120,6 +1141,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeFromBackup(pool string, args Storag
 	// Setup an Operation wrapper.
 	op := operation{
 		Operation: *respOperation,
+		listener:  listener,
 		r:         r,
 		chActive:  make(chan bool),
 	}

--- a/client/operations.go
+++ b/client/operations.go
@@ -194,16 +194,6 @@ func (op *operation) setupListener() error {
 
 	op.handlerReady = true
 
-	// Get a new listener
-	if op.listener == nil {
-		listener, err := op.r.GetEvents()
-		if err != nil {
-			return err
-		}
-
-		op.listener = listener
-	}
-
 	// Setup the handler
 	chReady := make(chan bool)
 	_, err := op.listener.AddHandler([]string{"operation"}, func(event api.Event) {

--- a/client/operations.go
+++ b/client/operations.go
@@ -21,17 +21,12 @@ type operation struct {
 	listener     *EventListener
 	handlerReady bool
 	handlerLock  sync.Mutex
-	skipListener bool
 
 	chActive chan bool
 }
 
 // AddHandler adds a function to be called whenever an event is received.
 func (op *operation) AddHandler(function func(api.Operation)) (*EventTarget, error) {
-	if op.skipListener {
-		return nil, fmt.Errorf("Cannot add handler, client operation does not support event listeners")
-	}
-
 	// Make sure we have a listener setup
 	err := op.setupListener()
 	if err != nil {
@@ -83,10 +78,6 @@ func (op *operation) GetWebsocket(secret string) (*websocket.Conn, error) {
 
 // RemoveHandler removes a function to be called whenever an event is received.
 func (op *operation) RemoveHandler(target *EventTarget) error {
-	if op.skipListener {
-		return fmt.Errorf("Cannot remove handler, client operation does not support event listeners")
-	}
-
 	// Make sure we're not racing with ourselves
 	op.handlerLock.Lock()
 	defer op.handlerLock.Unlock()
@@ -120,7 +111,7 @@ func (op *operation) Wait() error {
 
 // WaitContext lets you wait until the operation reaches a final state with context.Context.
 func (op *operation) WaitContext(ctx context.Context) error {
-	if op.skipListener {
+	if op.listener == nil {
 		timeout := -1
 		deadline, ok := ctx.Deadline()
 		if ok {
@@ -179,7 +170,7 @@ func (op *operation) WaitContext(ctx context.Context) error {
 // It adds handlers to process events, monitors the listener for completion or errors,
 // and triggers a manual refresh of the operation's state to prevent race conditions.
 func (op *operation) setupListener() error {
-	if op.skipListener {
+	if op.listener == nil {
 		return fmt.Errorf("Cannot set up event listener, client operation does not support event listeners")
 	}
 

--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -463,10 +463,12 @@ func convertContainer(d lxd.ContainerServer, container *liblxc.Container, storag
 		}
 
 		progress := cli.ProgressRenderer{Format: "Transferring container: %s"}
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return err
+		if d.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return err
+			}
 		}
 
 		rootfs, _ := getRootfs(conf)

--- a/lxc/action.go
+++ b/lxc/action.go
@@ -183,10 +183,12 @@ func (c *cmdAction) doActionAll(action string, resource remoteResource) error {
 		Quiet: c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if d.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	err = cli.CancelableWait(op, &progress)
@@ -274,10 +276,12 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		Quiet: c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if d.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for operation to finish

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1254,10 +1254,12 @@ func (c *cmdClusterEvacuateAction) Run(cmd *cobra.Command, args []string) error 
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if resource.server.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	err = op.Wait()

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -337,10 +337,12 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if dest.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for the copy to complete
@@ -381,10 +383,12 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 			Quiet:  c.global.flagQuiet,
 		}
 
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return err
+		if dest.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return err
+			}
 		}
 
 		// Wait for the copy to complete

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -87,10 +87,12 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if d.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait until backup is done

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -264,10 +264,12 @@ func (c *cmdImageCopy) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if destinationServer.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for operation to finish
@@ -1373,9 +1375,11 @@ func (c *cmdImageRefresh) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Register progress handler
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			return err
+		if resource.server.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Wait for the refresh to happen

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -361,10 +361,12 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 			Quiet:  c.global.flagQuiet,
 		}
 
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return nil, "", err
+		if d.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return nil, "", err
+			}
 		}
 
 		err = cli.CancelableWait(op, &progress)

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -92,10 +92,12 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 		Quiet: c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if d.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for operation to finish

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -315,11 +315,14 @@ func moveClusterInstance(conf *config.Config, sourceResource string, destResourc
 		Quiet:  quiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if source.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
+
 	// Wait for the move to complete
 	err = cli.CancelableWait(op, &progress)
 	if err != nil {

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -254,10 +254,12 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if s.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for the copy to complete

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -97,10 +97,12 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			Quiet: c.global.flagQuiet,
 		}
 
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return err
+		if d.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return err
+			}
 		}
 
 		err = cli.CancelableWait(op, &progress)
@@ -141,10 +143,12 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			Quiet: c.global.flagQuiet,
 		}
 
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return err
+		if d.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return err
+			}
 		}
 
 		// Wait for operation to finish
@@ -189,10 +193,12 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			Quiet: c.global.flagQuiet,
 		}
 
-		_, err = op.AddHandler(progress.UpdateOp)
-		if err != nil {
-			progress.Done("")
-			return err
+		if d.SupportsAuthentication() {
+			_, err = op.AddHandler(progress.UpdateOp)
+			if err != nil {
+				progress.Done("")
+				return err
+			}
 		}
 
 		err = cli.CancelableWait(op, &progress)

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -489,10 +489,12 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if dstServer.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait for operation to finish
@@ -2333,10 +2335,12 @@ func (c *cmdStorageVolumeExport) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if d.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	// Wait until backup is done

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -567,10 +567,12 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 	})
 
 	progress := cli.ProgressRenderer{Format: "Transferring instance: %s"}
-	_, err = op.AddHandler(progress.UpdateOp)
-	if err != nil {
-		progress.Done("")
-		return err
+	if server.SupportsAuthentication() {
+		_, err = op.AddHandler(progress.UpdateOp)
+		if err != nil {
+			progress.Done("")
+			return err
+		}
 	}
 
 	err = transferRootfs(ctx, server, op, fullPath, c.flagRsyncArgs, config.InstanceArgs.Type)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -775,9 +775,11 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 			_ = op.UpdateMetadata(newOp.Metadata)
 		}
 
-		_, err = destOp.AddHandler(handler)
-		if err != nil {
-			return err
+		if dest.SupportsAuthentication() {
+			_, err = destOp.AddHandler(handler)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = destOp.Wait()


### PR DESCRIPTION
Closes #12994 

If we implicitly create the events listener after the operation has fired, then there's a chance the operation will have completed and emitted the corresponding event before we even begin listening. In many cases, the opposite happens too where the operation finishes so quickly after we start creating the events listener that we receive it on the first HTTP request and then never actually use the events listener.

This leads to an obscure race condition where a client which is authenticated with a temporary key tries to open an events listener, which only supports TLS authentication. Most of the time, the operation returns promptly enough that we never actually end up connecting to the events API which would return an `unauthorized` error if we hit it.

To avoid having to keep track of all of these pathways and avoid running into obscure races, we shouldn't try to create an events listener automatically when setting up the wait process as we have no way of determining the current state of an operation at this point.

If we want an events listener with our operation, we should make sure to set it up before making the operation request. To do this, we need to make sure the client can actually talk to the events API. We can determine this by checking whether or not the client has any TLS certificates. If it does, then we may be able to authenticate with the `/1.0/events` API, but if not then we definitely can't.

* Adds a `supportsAuthentication` field to `protocolLXD` which determines whether the client should also try to target the `/1.0/events` API automatically to set up an event websocket, in the special cases (for image creation, for example) where we re-implement the logic from `queryOperation`.

* Ensures we always try to create the `/1.0/events` listener before sending the request for the operation to be started.

* Removes the now redundant `skipListener` field, as the operation wait process will not spawn its own listener if the one from the client is `nil`. 

* Ensures all calls to `AddHandler` are on an operation that was created with a client that has TLS authentication support.