### PR TITLE
Smaller clients bis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,7 +175,7 @@ jobs:
           sudo snap remove lxd --purge
           # Purge older snap revisions that are disabled/superseded by newer revisions of the same snap
           snap list --all | while read -r name _ rev _ _ notes _; do
-            [ "${notes}" = "disabled" ] && snap remove "${name}" --revision "${rev}" --purge
+            [[ "${notes}" =~ disabled$ ]] && snap remove "${name}" --revision "${rev}" --purge
           done || true
 
           # This was inspired from https://github.com/easimon/maximize-build-space

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -386,14 +386,14 @@ jobs:
           CGO_ENABLED: 0
           GOARCH: amd64
         run: |
-          go build -o trimpath -o bin/lxc.x86_64 ./lxc
+          go build -ldflags "-s -w" -o trimpath -o bin/lxc.x86_64 ./lxc
 
       - name: Build static lxc (aarch64)
         env:
           CGO_ENABLED: 0
           GOARCH: arm64
         run: |
-          go build -o trimpath -o bin/lxc.aarch64 ./lxc
+          go build -ldflags "-s -w" -o trimpath -o bin/lxc.aarch64 ./lxc
 
       - name: Build static lxd-migrate
         if: runner.os == 'Linux'
@@ -401,12 +401,8 @@ jobs:
           CGO_ENABLED: 0
         run: |
           set -eux
-          GOARCH=amd64 go build -o trimpath -o bin/lxd-migrate.x86_64 ./lxd-migrate
-          GOARCH=arm64 go build -o trimpath -o bin/lxd-migrate.aarch64 ./lxd-migrate
-
-      - name: Strip lxc and lxd-migrate native binaries
-        if: runner.os != 'macOS'     # macOS doesn't have strip
-        run: strip -s bin/lx*.x86_64 # non-native binaries cannot be strip'ed
+          GOARCH=amd64 go build -ldflags "-s -w" -o trimpath -o bin/lxd-migrate.x86_64 ./lxd-migrate
+          GOARCH=arm64 go build -ldflags "-s -w" -o trimpath -o bin/lxd-migrate.aarch64 ./lxd-migrate
 
       - name: Unit tests (client)
         env:

--- a/doc/.readthedocs.yaml
+++ b/doc/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
     python: "3.11"
   jobs:
     pre_build:
-      - go build -o lxc.bin ./lxc
+      - go build -ldflags "-s -w" -o trimpath -o lxc.bin ./lxc
     post_build:
       - cd _readthedocs/html; python -m sphinx.ext.intersphinx 'objects.inv' > objects.inv.txt
 


### PR DESCRIPTION
Due to an error on my part (sorry about that), my latest changes didn't go in #12883 so here they are.

This version does a proper job of generating smaller binaries on all OSes and for all arches.