### PR TITLE
Resources: exposing server cpu flags

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2334,3 +2334,8 @@ The value of the claim will be extracted and might be used to make authorization
 Adds a new `loki.instance` server configuration key to customize the `instance` field in Loki events.
 This can be used to expose the name of the cluster rather than the individual system name sending
 the event as that's usually already covered by the `location` field.
+
+## `resources_v3`
+
+Export the CPU feature flags over `/1.0/resources`. For example, this is useful to prevent a VM live migration from happening
+if the destination node doesn't support the same CPU features as the source node.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4043,6 +4043,17 @@ definitions:
                 x-go-name: Threads
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    ResourcesCPUFeatureSet:
+        properties:
+            flags:
+                description: List of CPU flags
+                items:
+                    type: string
+                type: array
+                x-go-name: Flags
+        title: ResourcesCPUFeatureSet represents the cpu flags currently set on a CPU.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     ResourcesCPUSocket:
         description: ResourcesCPUSocket represents a CPU socket on the system
         properties:
@@ -4058,6 +4069,8 @@ definitions:
                     $ref: '#/definitions/ResourcesCPUCore'
                 type: array
                 x-go-name: Cores
+            feature_set:
+                $ref: '#/definitions/ResourcesCPUFeatureSet'
             frequency:
                 description: Current CPU frequency (Mhz)
                 example: 3499

--- a/lxd/resources/cpu.go
+++ b/lxd/resources/cpu.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/digitalocean/go-smbios/smbios"
+	"github.com/klauspost/cpuid/v2"
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/lxd/shared"
@@ -479,6 +480,10 @@ func GetCPU() (*api.ResourcesCPU, error) {
 		if coreFrequencyCount > 0 {
 			socket.Frequency = coreFrequency / coreFrequencyCount
 		}
+
+		// Record the features
+		featureSet := &api.ResourcesCPUFeatureSet{Flags: cpuid.CPU.FeatureSet()}
+		socket.FeatureSet = featureSet
 
 		sort.SliceStable(socket.Cores, func(i int, j int) bool { return socket.Cores[i].Core < socket.Cores[j].Core })
 		cpu.Sockets = append(cpu.Sockets, *socket)

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -98,6 +98,19 @@ type ResourcesCPUSocket struct {
 	// Maximum CPU frequency (Mhz)
 	// Example: 3500
 	FrequencyTurbo uint64 `json:"frequency_turbo,omitempty" yaml:"frequency_turbo,omitempty"`
+
+	// CPU feature flags
+	FeatureSet *ResourcesCPUFeatureSet `json:"feature_set" yaml:"feature_set"`
+}
+
+// ResourcesCPUFeatureSet represents the cpu flags currently set on a CPU.
+//
+// swagger:model
+//
+// API extension: resources_v3.
+type ResourcesCPUFeatureSet struct {
+	// List of CPU flags
+	Flags []string `json:"flags" yaml:"flags"`
 }
 
 // ResourcesCPUCache represents a CPU cache

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -394,6 +394,7 @@ var APIExtensions = []string{
 	"server_version_lts",
 	"oidc_groups_claim",
 	"loki_config_instance",
+	"resources_v3",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Exposing CPU flags of LXD servers will become handy in VM live migration scenarios:

* We should prevent a live VM migration if a destination host does not have some flags from the source node.
* We should **not** prevent a live VM migration if the destination node CPU flag set is a 'superset' of the source CPU flags. 