### PR TITLE
Storage: Don't use storage name when creating source snapshots

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -733,7 +733,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 	sourceSnapshots := make([]drivers.Volume, 0, len(srcBackup.Config.VolumeSnapshots))
 	for _, volSnap := range srcBackup.Config.VolumeSnapshots {
-		snapshotName := drivers.GetSnapshotVolumeName(vol.Name(), volSnap.Name)
+		snapshotName := drivers.GetSnapshotVolumeName(srcBackup.Name, volSnap.Name)
 		snapshotStorageName := project.Instance(srcBackup.Project, snapshotName)
 		sourceSnapshots = append(sourceSnapshots, b.GetVolume(volType, contentType, snapshotStorageName, volSnap.Config))
 	}


### PR DESCRIPTION
The final `snapshotStorageName` contains the projects identifier twice if the storage name used to create the vol is used a second time:

```go
// Already using the volStorageName including the project
vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
...
// Produces project_project_vol/snapX since vol.Name() already includes the project
snapshotName := drivers.GetSnapshotVolumeName(vol.Name(), volSnap.Name)
snapshotStorageName := project.Instance(srcBackup.Project, snapshotName)
```

This didn't surface since the `genericVFSBackupUnpack()` function where this is used initially created its snapshot `Volume` construct from the snapshot names passed into the function. For https://github.com/canonical/lxd/pull/12840/ this changes since the snapshot `Volume`s passed into the function are used directly which require them to contain the right project name.