### PR TITLE
Storage: Populate custom volume snapshot creation date

### DIFF
--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -496,7 +496,7 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolumeSnapshot) *migration.Snapsho
 		LocalDevices: []*migration.Device{},
 		Architecture: proto.Int32(0),
 		Stateful:     proto.Bool(false),
-		CreationDate: proto.Int64(0),
+		CreationDate: proto.Int64(vol.CreatedAt.Unix()),
 		LastUsedDate: proto.Int64(0),
 		ExpiryDate:   proto.Int64(0),
 	}

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -365,8 +365,14 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			_, targetSnapName, _ := api.GetParentAndSnapshotName(targetSnap.Name)
 
 			targetSnapshotsComparable = append(targetSnapshotsComparable, storagePools.ComparableSnapshot{
-				Name:         targetSnapName,
-				CreationDate: targetSnap.CreationDate,
+				Name: targetSnapName,
+
+				// The list of source snapshots from the offer header
+				// contains the creation timestamps in seconds granularity.
+				// Also use second based granularity for the target snapshots to be able to compare them.
+				// They are stored with nanoseconds in the database.
+				// Retrieve the timestamp using second based granularity the same way as it's done on the source.
+				CreationDate: time.Unix(targetSnap.CreationDate.Unix(), 0),
 			})
 		}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6070,6 +6070,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 				Name:        snapName, // Snapshot only name, not full name.
 				Config:      dbVolSnaps[i].Config,
 				ContentType: dbVolSnaps[i].ContentType,
+				CreatedAt:   dbVolSnaps[i].CreationDate,
 			}
 
 			config.VolumeSnapshots = append(config.VolumeSnapshots, &snapshot)

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -511,6 +511,16 @@ migration() {
   lxc_remote project switch l1:default
   lxc_remote project delete l1:proj
 
+  # Check snapshot creation dates after migration.
+  lxc_remote init testimage l1:c1
+  lxc_remote snapshot l1:c1
+  ! lxc_remote storage volume show "l1:${remote_pool1}" container/c1 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  ! lxc_remote storage volume show "l1:${remote_pool1}" container/c1/snap0 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  lxc_remote copy l1:c1 l2:c1
+  ! lxc_remote storage volume show "l2:${remote_pool2}" container/c1 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  [ "$(lxc_remote storage volume show "l1:${remote_pool1}" container/c1/snap0 | awk /created_at:/)" = "$(lxc_remote storage volume show "l2:${remote_pool2}" container/c1/snap0 | awk /created_at:/)" ]
+  lxc_remote delete l1:c1 -f
+  lxc_remote delete l2:c1 -f
 
   # Check migration with invalid snapshot config (disks attached with missing source pool and source path).
   lxc_remote init testimage l1:c1

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -298,6 +298,16 @@ snap_restore() {
   lxc snapshot a-b c-d
   lxc restore a-b c-d
   lxc delete -f a-b
+
+  # Check snapshot creation dates.
+  lxc init testimage c1
+  lxc snapshot c1
+  ! lxc storage volume show "${pool}" container/c1 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  ! lxc storage volume show "${pool}" container/c1/snap0 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  lxc copy c1 c2
+  ! lxc storage volume show "${pool}" container/c2 | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  [ "$(lxc storage volume show "${pool}" container/c1/snap0 | awk /created_at:/)" = "$(lxc storage volume show "${pool}" container/c2/snap0 | awk /created_at:/)" ]
+  lxc delete -f c1 c2
 }
 
 restore_and_compare_fs() {

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -247,11 +247,11 @@ test_storage_local_volume_handling() {
 
           # check snapshot volumes (including config) was overridden from new source and that missing snapshot is
           # present and that the missing snapshot has been removed.
-          # Note: Due to a known issue we are currently only diffing the snapshots by name, so infact existing
-          # snapshots of the same name won't be overwritten even if their config or contents is different.
+          # Note: Due to a known issue we are currently only diffing the snapshots by name and creation date, so infact existing
+          # snapshots of the same name and date won't be overwritten even if their config or contents is different.
           lxc storage volume get "${target_pool}" vol5 user.foo | grep -Fx "postsnap1vol5"
-          lxc storage volume get "${target_pool}" vol5/snap0 user.foo | grep -Fx "snap0vol5"
-          lxc storage volume get "${target_pool}" vol5/snap1 user.foo | grep -Fx "snap1vol5"
+          lxc storage volume get "${target_pool}" vol5/snap0 user.foo | grep -Fx "snap0vol6"
+          lxc storage volume get "${target_pool}" vol5/snap1 user.foo | grep -Fx "snap1vol6"
           lxc storage volume get "${target_pool}" vol5/snap2 user.foo | grep -Fx "snap2vol6"
           ! lxc storage volume get "${target_pool}" vol5/snapremove user.foo || false
 

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -233,8 +233,19 @@ test_storage_volume_snapshots() {
   lxc storage volume copy "${storage_pool}/vol1/snap0" "test:${storage_pool}/vol1" --target-project project1
   [ "$(lxc query "/1.0/storage-pools/${storage_pool}/volumes?project=project1" | jq "length == 1")" = "true" ]
   lxc storage volume delete "${storage_pool}" "vol1" --project project1
-
   lxc storage volume delete "${storage_pool}" "vol1"
+
+  # Check snapshot creation dates (remote).
+  lxc storage volume create "${storage_pool}" "vol1"
+  lxc storage volume snapshot "${storage_pool}" "vol1" "snap0"
+  ! lxc storage volume show "${storage_pool}" "vol1" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  ! lxc storage volume show "${storage_pool}" "vol1/snap0" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  lxc storage volume copy "${storage_pool}/vol1" "test:${storage_pool}/vol1-copy"
+  ! lxc storage volume show "${storage_pool}" "test:${storage_pool}" "vol1-copy" | grep -q '^created_at: 0001-01-01T00:00:00Z' || false
+  [ "$(lxc storage volume show "${storage_pool}" "vol1/snap0" | awk /created_at:/)" = "$(lxc storage volume show "test:${storage_pool}" "vol1-copy/snap0" | awk /created_at:/)" ]
+  lxc storage volume delete "${storage_pool}" "vol1"
+  lxc storage volume delete "${storage_pool}" "vol1-copy"
+
   lxc project delete "project1"
   lxc storage delete "${storage_pool}"
   lxc remote remove "test"


### PR DESCRIPTION
When generating a custom volume's backup config, make sure it's creation date is included in the struct. This is currently causing snapshots of copied volumes to not have any creation date:

```bash
julian@thinkpad:~/dev/lxd/test$ lxc storage volume show dir vol2/snap0
description: ""
expires_at: 0001-01-01T00:00:00Z
name: snap0
config: {}
content_type: filesystem
created_at: 0001-01-01T00:00:00Z
```

Additionally this change ensures that when refreshing custom storage volumes and their snapshots, LXD does not re-transfer all of the snapshots. This was caused by:
* the migration header protocol not sending the snapshots creation date
* and the comparison on the target side using different granularity for both source and target timestamps

This PR adds a check for both custom storage volume and instance snapshots. But the date is only missing for custom volume snapshots. It was observed in https://github.com/canonical/lxd/pull/12840.

The fact that LXD refreshes all the snapshots when migration custom storage volumes was first discovered here https://github.com/canonical/lxd/issues/12668.