### PR TITLE
Storage: Send snapshot creation and expiry when migrating

### DIFF
--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -498,6 +498,6 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolumeSnapshot) *migration.Snapsho
 		Stateful:     proto.Bool(false),
 		CreationDate: proto.Int64(vol.CreatedAt.UnixNano()),
 		LastUsedDate: proto.Int64(0),
-		ExpiryDate:   proto.Int64(0),
+		ExpiryDate:   proto.Int64(vol.ExpiresAt.UnixNano()),
 	}
 }

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -349,7 +349,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		for _, sourceSnap := range sourceSnapshots {
 			sourceSnapshotComparable = append(sourceSnapshotComparable, storagePools.ComparableSnapshot{
 				Name:         sourceSnap.GetName(),
-				CreationDate: time.Unix(sourceSnap.GetCreationDate(), 0),
+				CreationDate: time.Unix(0, sourceSnap.GetCreationDate()),
 			})
 		}
 
@@ -496,7 +496,7 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolumeSnapshot) *migration.Snapsho
 		LocalDevices: []*migration.Device{},
 		Architecture: proto.Int32(0),
 		Stateful:     proto.Bool(false),
-		CreationDate: proto.Int64(0),
+		CreationDate: proto.Int64(vol.CreatedAt.UnixNano()),
 		LastUsedDate: proto.Int64(0),
 		ExpiryDate:   proto.Int64(0),
 	}


### PR DESCRIPTION
This makes https://github.com/canonical/lxd/pull/12708 obsolete and finally fixes the issue when migrating custom storage volumes that the target side cannot compare the snapshots based on its timestamp which will always cause a retransmission. 

Unlike mentioned in https://github.com/canonical/lxd/pull/12708 it's not that the nanosecond portion of the timestamp is missing, the timestamp isn't transferred at all when doing a migration.