### PR TITLE
lxd-generate: Return helpful error instead of panicking.

### DIFF
--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -1227,6 +1227,12 @@ func (m *Method) signature(buf *file.Buffer, isInterface bool) error {
 			rets = "error"
 		case "Update":
 			comment = fmt.Sprintf("updates the %s matching the given key parameters.", m.entity)
+			if len(refMapping.NaturalKey()) > 1 {
+				return fmt.Errorf("Cannot generate update method for associative table: Reference table struct %q has more than one natural key", ref)
+			} else if refMapping.Identifier() == nil {
+				return fmt.Errorf("Cannot generate update method for associative table: Identifier for reference table struct %q must be `Name` or `Fingerprint`", ref)
+			}
+
 			args += fmt.Sprintf("%sID int, %s%s []%s", lex.Minuscule(m.config["struct"]), lex.Minuscule(ref), lex.Plural(refMapping.Identifier().Name), refMapping.Identifier().Type.Name)
 			rets = "error"
 		case "DeleteMany":


### PR DESCRIPTION
LXD generate cannot create update method for associative tables if the reference table has more than one "natural key" or if it doesn't have a field called 'Name' or 'Fingerprint'. In the former case it will fail silently (generating incorrect methods). In the latter case it will panic.

This commit returns a helpful error message instead.

I encountered this when trying to generate methods to associate groups to identities and vice-versa. Identities are keyed on authentication method and identifier. I will just write custom queries to update those relations instead.