### PR TITLE
Storage: Fix regression when copying VMs

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -364,8 +364,9 @@ func (d *ceph) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInco
 
 	// For VMs, also copy the filesystem volume.
 	if vol.IsVMBlock() {
-		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
-		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+		// We can pass the regular volume's snapshots as only their presence is relevant.
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcVol.Snapshots...)
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), vol.Snapshots...)
 		err := d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -567,8 +567,9 @@ func (d *zfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowIncon
 	// For VMs, also copy the filesystem dataset.
 	if vol.IsVMBlock() {
 		// For VMs, also copy the filesystem volume.
-		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume())
-		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume())
+		// We can pass the regular volume's snapshots as only their presence is relevant.
+		srcFSVol := NewVolumeCopy(srcVol.NewVMBlockFilesystemVolume(), srcVol.Snapshots...)
+		fsVol := NewVolumeCopy(vol.NewVMBlockFilesystemVolume(), vol.Snapshots...)
 
 		err = d.CreateVolumeFromCopy(fsVol, srcFSVol, false, op)
 		if err != nil {


### PR DESCRIPTION
This fixes a regression caused by https://github.com/canonical/lxd/pull/12871. Since the `CreateVolumeFromCopy` function is called recursively, it expects the snapshots to be there also when copying the VMs filesystem volume. Otherwise the snapshots get skipped.

@simondeziel thanks for pointing that out, it's awesome to now have the `lxd-ci` tests. The pipeline failed when trying to delete a volume that has snapshots https://github.com/canonical/lxd-ci/actions/runs/7913899479/job/21615586614