### PR TITLE
Project: Don't panic on `StorageVolumeParts`

### DIFF
--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -58,6 +58,12 @@ func StorageVolume(projectName string, storageVolumeName string) string {
 // name as separate variables.
 func StorageVolumeParts(projectStorageVolumeName string) (string, string) {
 	parts := strings.SplitN(projectStorageVolumeName, "_", 2)
+
+	// If the given name doesn't contain any project, only return the volume name.
+	if len(parts) == 1 {
+		return "", projectStorageVolumeName
+	}
+
 	return parts[0], parts[1]
 }
 


### PR DESCRIPTION
Don't panic if the given volume name doesn't contain a project.
I have observed this whilst trying to recover custom storage volumes using `lxd recover`. 