### PR TITLE
lxd/device: Bump base VM filesystem volume to 500MiB

### DIFF
--- a/lxd/device/config/consts.go
+++ b/lxd/device/config/consts.go
@@ -1,4 +1,4 @@
 package config
 
 // DefaultVMBlockFilesystemSize is the size of a VM root device block volume's associated filesystem volume.
-const DefaultVMBlockFilesystemSize = "100MiB"
+const DefaultVMBlockFilesystemSize = "500MiB"


### PR DESCRIPTION
Addresses https://discourse.ubuntu.com/t/failed-launching-an-instance-vm-with-lvm-xfs-backend-disk-too-small-lxd-5-0-2/42466/5

(cherry picked from commit 1f54dbb29b56cfdbe7ab4fcbf9e5bb96fa632ba8)

License: Apache-2.0