### PR TITLE
Storage: Add a `snapshotMatcher` construct for comparison

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1512,14 +1512,14 @@ func (d *btrfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceT
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 	}
 
 	// Optimized backup.
 
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := vol.SnapshotsMatch(snapshots, op)
+		err := vol.SnapshotsMatch(vol.Snapshots, snapshotNameMatcher, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1484,7 +1484,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 
 // BackupVolume creates an exported version of a volume.
 func (d *ceph) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -478,7 +478,7 @@ func (d *cephfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcAr
 
 // BackupVolume creates an exported version of a volume.
 func (d *cephfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 }
 
 // CreateVolumeSnapshot creates a new snapshot.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -424,7 +424,7 @@ func (d *dir) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
 func (d *dir) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -860,7 +860,7 @@ func (d *lvm) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 // BackupVolume copies a volume (and optionally its snapshots) to a specified target path.
 // This driver does not support optimized backups.
 func (d *lvm) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, _ bool, snapshots []string, op *operations.Operation) error {
-	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+	return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 }
 
 // CreateVolumeSnapshot creates a snapshot of a volume.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2707,14 +2707,14 @@ func (d *zfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceTar
 			vol.mountCustomPath = snapshotPath
 		}
 
-		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, op)
+		return genericVFSBackupVolume(d, vol, tarWriter, snapshots, snapshotNameMatcher, op)
 	}
 
 	// Optimized backup.
 
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := vol.SnapshotsMatch(snapshots, op)
+		err := vol.SnapshotsMatch(vol.Snapshots, snapshotNameMatcher, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -483,10 +483,10 @@ func genericVFSGetVolumeDiskPath(vol Volume) (string, error) {
 }
 
 // genericVFSBackupVolume is a generic BackupVolume implementation for VFS-only drivers.
-func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, snapshots []string, op *operations.Operation) error {
+func genericVFSBackupVolume(d Driver, vol VolumeCopy, tarWriter *instancewriter.InstanceTarWriter, snapshots []string, matcher snapshotMatcher, op *operations.Operation) error {
 	if len(snapshots) > 0 {
 		// Check requested snapshot match those in storage.
-		err := vol.SnapshotsMatch(snapshots, op)
+		err := vol.SnapshotsMatch(vol.Snapshots, matcher, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -21,11 +21,27 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 )
 
+// snapshotMatcher implements a function to find a snapshot within a list of snapshots.
+type snapshotMatcher func(findSnapshot Volume, snapshotList []Volume) (bool, error)
+
 // MinBlockBoundary minimum block boundary size to use.
 const MinBlockBoundary = 8192
 
 // blockBackedAllowedFilesystems allowed filesystems for block volumes.
 var blockBackedAllowedFilesystems = []string{"btrfs", "ext4", "xfs"}
+
+// snapshotNameMatcher finds a snapshot in a list of snapshots based on its name.
+var snapshotNameMatcher snapshotMatcher = func(findSnapshot Volume, snapshotList []Volume) (bool, error) {
+	_, findSnapshotName, _ := api.GetParentAndSnapshotName(findSnapshot.name)
+	for _, snapshot := range snapshotList {
+		_, listSnapshotName, _ := api.GetParentAndSnapshotName(snapshot.name)
+		if listSnapshotName == findSnapshotName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
 
 // wipeDirectory empties the contents of a directory, but leaves it in place.
 func wipeDirectory(path string) error {


### PR DESCRIPTION
This allows injecting a custom implementation of a so called matcher in order to be able to compare snapshots from the database with the ones present in storage.

Storage drivers (like Dell PowerFlex https://github.com/canonical/lxd/pull/12304) don't store their volumes based on the provided name which requires having an extra method that allows to compare snapshots using a different approach like the volume's UUID.

Taken from https://github.com/canonical/lxd/pull/12904 to split the number of PRs. This is in preparation for the Dell PowerFlex driver https://github.com/canonical/lxd/pull/12304.