### PR TITLE
Instance: Allow a stateful VM to be started even if its root disk `size.state` parameter is not set

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1094,23 +1094,6 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 		return fmt.Errorf("Stateful start requires migration.stateful to be set to true")
 	}
 
-	// The "size.state" of the instance root disk device must be larger than the instance memory.
-	// Otherwise, there will not be enough disk space to write the instance state to disk during any subsequent stops.
-	// (Only check when migration.stateful is true, otherwise the memory won't be dumped when this instance stops).
-	if shared.IsTrue(d.expandedConfig["migration.stateful"]) {
-		pool, err := d.getStoragePool()
-		if err != nil {
-			return err
-		}
-
-		if !pool.Driver().Info().Remote {
-			err = d.validateRootDiskStatefulStop()
-			if err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This allows a user to do:

```
lxc launch ubuntu:jammy v1 --vm --config migration.stateful=true -s local
```

Whereas it was only working with a `remote` storage backend before.
The root disk's `size.state` related error will only arise when a user attempts to do a stateful operation like `lxc stop v1 --stateful`