### PR TITLE
Storage: Clone PowerFlex volume copies by default

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2520,7 +2520,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-lvm-volume-conf end -->
 <!-- config group storage-powerflex-pool-conf start -->
 ```{config:option} powerflex.clone_copy storage-powerflex-pool-conf
-:defaultdesc: "`false`"
+:defaultdesc: "`true`"
 :shortdesc: "Make a non-sparse copy when creating a snapshot of instances or custom volumes (see the [limitations](storage-powerflex-limitations))"
 :type: "bool"
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2741,7 +2741,7 @@
 				"keys": [
 					{
 						"powerflex.clone_copy": {
-							"defaultdesc": "`false`",
+							"defaultdesc": "`true`",
 							"longdesc": "",
 							"shortdesc": "Make a non-sparse copy when creating a snapshot of instances or custom volumes (see the [limitations](storage-powerflex-limitations))",
 							"type": "bool"

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -233,7 +233,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//
 		// ---
 		//  type: bool
-		//  defaultdesc: `false`
+		//  defaultdesc: `true`
 		//  shortdesc: Make a non-sparse copy when creating a snapshot of instances or custom volumes (see the [limitations](storage-powerflex-limitations))
 		"powerflex.clone_copy": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=volume.size)

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -794,7 +794,7 @@ func (d *powerflex) createNVMeHost() (string, error) {
 	return hostID, nil
 }
 
-// deleteNVMeHost delets this NVMe host in PowerFlex.
+// deleteNVMeHost deletes this NVMe host in PowerFlex.
 // The operation is idempotent and locked using lock name powerflex.host.
 func (d *powerflex) deleteNVMeHost() error {
 	unlock, err := locking.Lock(d.state.ShutdownCtx, "powerflex.host")

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -189,7 +189,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 	// If the source volume is of type image, lazy copying is enforced which prevents using optimized image storage
 	// but effectively allows to circumvent the PowerFlex limit of 126 snapshots.
 	client := d.client()
-	if len(vol.Snapshots) == 0 && shared.IsFalseOrEmpty(d.config["powerflex.clone_copy"]) {
+	if len(vol.Snapshots) == 0 && shared.IsFalse(d.config["powerflex.clone_copy"]) {
 		pool, err := d.resolvePool()
 		if err != nil {
 			return err

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -57,6 +57,8 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 		return err
 	}
 
+	// In case of error delete the volume with mode "ONLY_ME".
+	// This removes the given volume only without any parent(s) or child(s).
 	revert.Add(func() { _ = client.deleteVolume(id, "ONLY_ME") })
 
 	volumeFilesystem := vol.ConfigBlockFilesystem()


### PR DESCRIPTION
This is a follow up on https://github.com/canonical/lxd/pull/12304.

To prevent a user from hitting the PowerFlex snapshot limit of 126, LXD supports the creation of volume clones to circumvent this limitation. This can be controlled using the `powerflex.clone_copy` setting. 

The PR ensures `powerflex.clone_copy` is set to `true` by default so that a user who isn't aware of this limitation doesn't run into issues during operations.
If the user is aware of the limit, the PowerFlex snapshot feature for copying volumes can be activated by setting `powerflex.clone_copy` to `false`.

Additionally this PR fixes two docstrings in the PowerFlex driver.