### PR TITLE
Auth: Ensure the default config expiry interval is set.

### DIFF
--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -610,8 +610,11 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 		ConfigExpiryInterval: defaultConfigExpiryInterval,
 	}
 
-	if options != nil {
+	if options != nil && options.ConfigExpiryInterval > 0 {
 		opts.ConfigExpiryInterval = options.ConfigExpiryInterval
+	}
+
+	if options != nil && options.GroupsClaim != "" {
 		opts.GroupsClaim = options.GroupsClaim
 	}
 


### PR DESCRIPTION
When the `oidc.groups.claim` config key was added in #12827, the logic governing optional configuration of the OIDC verifier was incorrect. This caused the config expiry interval to be set to zero if not passed in by the caller.

This caused the verifier to rotate the encryption keys of the relying party on every call. These keys are used to encrypt the `state` and `pkce` cookies that OIDC needs to work. As they had been rotated during the OIDC flow, the callback handler to failed to decrypt the cookies, and so login was failing.