### PR TITLE
lxd/storage/drivers: Always use default block.filesysem for VM volumes

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -805,15 +805,20 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
 	if vol.ContentType() == ContentTypeFS || vol.IsVMBlock() {
-		// Inherit filesystem from pool if not set.
-		if vol.config["block.filesystem"] == "" {
-			vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
-		}
-
-		// Default filesystem if neither volume nor pool specify an override.
-		if vol.config["block.filesystem"] == "" {
-			// Unchangeable volume property: Set unconditionally.
+		// VM volumes will always use the default filesystem.
+		if vol.IsVMBlock() {
 			vol.config["block.filesystem"] = DefaultFilesystem
+		} else {
+			// Inherit filesystem from pool if not set.
+			if vol.config["block.filesystem"] == "" {
+				vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
+			}
+
+			// Default filesystem if neither volume nor pool specify an override.
+			if vol.config["block.filesystem"] == "" {
+				// Unchangeable volume property: Set unconditionally.
+				vol.config["block.filesystem"] = DefaultFilesystem
+			}
 		}
 
 		// Inherit filesystem mount options from pool if not set.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -257,15 +257,20 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
 	if vol.ContentType() == ContentTypeFS || vol.IsVMBlock() {
-		// Inherit filesystem from pool if not set.
-		if vol.config["block.filesystem"] == "" {
-			vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
-		}
-
-		// Default filesystem if neither volume nor pool specify an override.
-		if vol.config["block.filesystem"] == "" {
-			// Unchangeable volume property: Set unconditionally.
+		// VM volumes will always use the default filesystem.
+		if vol.IsVMBlock() {
 			vol.config["block.filesystem"] = DefaultFilesystem
+		} else {
+			// Inherit filesystem from pool if not set.
+			if vol.config["block.filesystem"] == "" {
+				vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
+			}
+
+			// Default filesystem if neither volume nor pool specify an override.
+			if vol.config["block.filesystem"] == "" {
+				// Unchangeable volume property: Set unconditionally.
+				vol.config["block.filesystem"] = DefaultFilesystem
+			}
 		}
 
 		// Inherit filesystem mount options from pool if not set.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -385,15 +385,20 @@ func (d *powerflex) FillVolumeConfig(vol Volume) error {
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
 	if vol.ContentType() == ContentTypeFS || vol.IsVMBlock() {
-		// Inherit filesystem from pool if not set.
-		if vol.config["block.filesystem"] == "" {
-			vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
-		}
-
-		// Default filesystem if neither volume nor pool specify an override.
-		if vol.config["block.filesystem"] == "" {
-			// Unchangeable volume property: Set unconditionally.
+		// VM volumes will always use the default filesystem.
+		if vol.IsVMBlock() {
 			vol.config["block.filesystem"] = DefaultFilesystem
+		} else {
+			// Inherit filesystem from pool if not set.
+			if vol.config["block.filesystem"] == "" {
+				vol.config["block.filesystem"] = d.config["volume.block.filesystem"]
+			}
+
+			// Default filesystem if neither volume nor pool specify an override.
+			if vol.config["block.filesystem"] == "" {
+				// Unchangeable volume property: Set unconditionally.
+				vol.config["block.filesystem"] = DefaultFilesystem
+			}
 		}
 
 		// Inherit filesystem mount options from pool if not set.


### PR DESCRIPTION
For VM type volumes on `ceph`, `lvm`, and `powerflex` storage pools, always set the block volume filesystem to `ext4`, regardless of what is set in `volume.block.filesystem`.

Closes #12921 

Initial discussion in #12907