### PR TITLE
lxd: Fix incorrect network device attach warnings

### DIFF
--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -694,7 +694,7 @@ func (c *ClusterTx) GetNetworkWithInterface(ctx context.Context, devName string)
 	}
 
 	if id == -1 {
-		return -1, nil, fmt.Errorf("No network found for interface: %s", devName)
+		return -1, nil, api.StatusErrorf(http.StatusNotFound, "No network found for interface: %s", devName)
 	}
 
 	network := api.Network{

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -664,7 +664,7 @@ func deviceEventListener(stateFunc func() *state.State) {
 			logger.Debugf("Scheduler: network: %s has been added: updating network priorities", e[0])
 			err = networkAutoAttach(s.DB.Cluster, e[0])
 			if err != nil {
-				logger.Warn("Failed to auto-attach network", logger.Ctx{"err": err})
+				logger.Warn("Failed to auto-attach network", logger.Ctx{"err": err, "dev": e[0]})
 			}
 
 		case e := <-chUSB:


### PR DESCRIPTION
The PR https://github.com/canonical/lxd/pull/12754 introduced a commit https://github.com/canonical/lxd/commit/011affcdc4a300cc6db7815d207de8e2224059de which incorrectly started logging warnings if `networkAutoAttach` wasn't able to find a matching network for the network device.

This is incorrect because the majority (possibly all) of new network devices that appear on a system won't be candidates for auto attach. In fact only if a bridge network specifies `bridge.external_interface` will this be potentially relevant.

So this was causing lots of log noise unnecessarily.

However the old implementation also didn't differentiate between a "not found" DB error and a problem performing the query (which we should log about) so this PR fixes those issues.