### PR TITLE
Storage: Fix block volume patch

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -867,7 +867,7 @@ func (d *ceph) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	// when using custom filesystem volumes. LXD will create the filesystem
 	// for these volumes, and use the mount options. When attaching a regular block volume to a VM,
 	// these are not mounted by LXD and therefore don't need these config keys.
-	if vol.IsVMBlock() || vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
 		delete(commonRules, "block.filesystem")
 		delete(commonRules, "block.mount_options")
 	}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -329,7 +329,7 @@ func (d *lvm) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	// when using custom filesystem volumes. LXD will create the filesystem
 	// for these volumes, and use the mount options. When attaching a regular block volume to a VM,
 	// these are not mounted by LXD and therefore don't need these config keys.
-	if vol.IsVMBlock() || vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
 		delete(commonRules, "block.filesystem")
 		delete(commonRules, "block.mount_options")
 	}

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -487,7 +487,7 @@ func (d *powerflex) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	// when using custom filesystem volumes. LXD will create the filesystem
 	// for these volumes, and use the mount options. When attaching a regular block volume to a VM,
 	// these are not mounted by LXD and therefore don't need these config keys.
-	if vol.IsVMBlock() || vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
+	if vol.volType == VolumeTypeCustom && vol.contentType == ContentTypeBlock {
 		delete(commonRules, "block.filesystem")
 		delete(commonRules, "block.mount_options")
 	}


### PR DESCRIPTION
In https://github.com/canonical/lxd/pull/12813 we have removed the `block.*` config keys for custom block volumes and VM block volumes. But the latter requires those settings in order to successfully mount the VMs filesystem volume. 

This PR adapts the patch `patchStorageUnsetInvalidBlockSettings` (added in https://github.com/canonical/lxd/pull/12813) to only remove those settings from custom block volumes and reverts the same in the three block backed drivers Ceph, LVM and PowerFlex (changed in https://github.com/canonical/lxd/pull/12805).