### PR TITLE
Instance: Check if VM is running earlier to prevent etag errors when setting UEFI vars

### DIFF
--- a/lxd/instance_uefi_vars.go
+++ b/lxd/instance_uefi_vars.go
@@ -186,6 +186,10 @@ func instanceUEFIVarsPut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("UEFI variables manipulation supported for VM type instances only"))
 	}
 
+	if inst.IsRunning() {
+		return response.BadRequest(fmt.Errorf("UEFI variables editing is allowed for stopped VM instances only"))
+	}
+
 	instanceUEFI, err := inst.(instance.VM).UEFIVars()
 	if err != nil {
 		return response.SmartError(err)


### PR DESCRIPTION
Fixes etag conflict error when trying to set UEFI vars whilst VM is booting:

```
lxc config uefi set v1 testvar-8be4df61-93ca-11d2-aa0d-00e098032b8c=48656c6c6f2066726f6d204c5844
==> Try to set EFI variable while VM is running (should fail)
Error: ETag doesn't match: 53b5a2ee77d20eb5df6039fdff5defc03cdf99260ee805b9a54e19a855391682 vs f2f48344528a8477ccbba077ba5a6d62f6d09a7e94250a1697c1a6e90aa53417
```