### PR TITLE
Storage: Pass right volume name when refreshing custom volumes

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1355,13 +1355,11 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			}
 
 			// Generate source snapshot volumes list.
-			srcSnapVolumeName := drivers.GetSnapshotVolumeName(srcVolName, srcSnap.Name)
-			srcSnapVolStorageName := project.StorageVolume(projectName, srcSnapVolumeName)
-			srcSnapVol := b.GetNewVolume(drivers.VolumeTypeCustom, contentType, srcSnapVolStorageName, srcSnap.Config)
-			srcSnapVols = append(srcSnapVols, srcSnap.Name)
+			targetSnapVolStorageName := project.StorageVolume(projectName, newSnapshotName)
+			targetSnapVol := b.GetNewVolume(drivers.VolumeTypeCustom, contentType, targetSnapVolStorageName, srcSnap.Config)
 
 			// Validate config and create database entry for new storage volume from source volume config.
-			err = VolumeDBCreate(b, projectName, newSnapshotName, srcSnap.Description, drivers.VolumeTypeCustom, true, srcSnapVol.Config(), srcSnap.CreatedAt, snapExpiryDate, contentType, false, true)
+			err = VolumeDBCreate(b, projectName, newSnapshotName, srcSnap.Description, drivers.VolumeTypeCustom, true, targetSnapVol.Config(), srcSnap.CreatedAt, snapExpiryDate, contentType, false, true)
 			if err != nil {
 				return err
 			}
@@ -1369,7 +1367,10 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 			revert.Add(func() { _ = VolumeDBDelete(b, projectName, newSnapshotName, vol.Type()) })
 
 			// Extend the list of target snaphots to not require loading all of them again from DB.
-			targetSnapshots = append(targetSnapshots, srcSnapVol)
+			targetSnapshots = append(targetSnapshots, targetSnapVol)
+
+			// Extend the list of snapshots that require refresh.
+			srcSnapVols = append(srcSnapVols, srcSnap.Name)
 		}
 
 		volCopy := drivers.NewVolumeCopy(vol, targetSnapshots...)


### PR DESCRIPTION
This fixes a situation in which the list of target volume snapshots gets appended with the right snapshot but wrong parent volume (source instead of target volume). 

When printing the passed volumes in a storage driver you will see this when looping on the `VolumeCopy.Snapshots` field of the target volume. In this case the target vol `vol2` is missing `snap5`:

```bash
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap0
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap1
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap2
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap3
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap4
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # source vol: default_vol/snap5
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol2/snap0
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol2/snap1
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol2/snap2
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol2/snap3
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol2/snap4
Feb 22 17:46:56 thinkpad lxd.daemon[191505]: # target vol: default_vol/snap5
```

Additionally this renames the variables to be more descriptive about their actual use case.

I saw this whilst implementing the new Ceph RBD refresh mechanism that requires this information to be correct. 