### PR TITLE
Drop offending legacy config names for syscall filtering

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -37,12 +37,19 @@ Containers with the same priority will shutdown in parallel.  It defaults to 0.
 
 A number of new syscalls related container configuration keys were introduced.
 
-* `security.syscalls.blacklist_default` <!-- wokeignore:rule=blacklist -->
-* `security.syscalls.blacklist_compat` <!-- wokeignore:rule=blacklist -->
-* `security.syscalls.blacklist` <!-- wokeignore:rule=blacklist -->
-* `security.syscalls.whitelist` <!-- wokeignore:rule=whitelist -->
+* `security.syscalls.deny_default`
+* `security.syscalls.deny_compat`
+* `security.syscalls.deny`
+* `security.syscalls.allow`
 
 See [Instance configuration](instance-config) for how to use them.
+
+```{note}
+Initially, those configuration keys were (accidentally) introduced with
+offensive names. They have since been renamed
+(`container_syscall_filtering_allow_deny_syntax`), and the old names are no
+longer accepted.
+```
 
 ## `auth_pki`
 
@@ -1273,6 +1280,8 @@ A number of new syscalls related container configuration keys were updated.
 * `security.syscalls.deny_compat`
 * `security.syscalls.deny`
 * `security.syscalls.allow`
+
+Support for the offensively named variants was removed.
 
 ## `resources_gpu_mdev`
 

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -732,10 +732,6 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	//  shortdesc: List of syscalls to allow
 	"security.syscalls.allow": validate.IsAny,
 
-	"security.syscalls.blacklist_default": validate.Optional(validate.IsBool),
-	"security.syscalls.blacklist_compat":  validate.Optional(validate.IsBool),
-	"security.syscalls.blacklist":         validate.IsAny,
-
 	// lxdmeta:generate(entities=instance; group=security; key=security.syscalls.deny_default)
 	//
 	// ---
@@ -864,8 +860,6 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 	//  condition: container
 	//  shortdesc: Whether to handle the `sysinfo` system call
 	"security.syscalls.intercept.sysinfo": validate.Optional(validate.IsBool),
-
-	"security.syscalls.whitelist": validate.IsAny,
 
 	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.last_state.idmap)
 	//

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -398,6 +398,7 @@ var APIExtensions = []string{
 	"import_instance_devices",
 	"instances_uefi_vars",
 	"instances_migration_stateful",
+	"container_syscall_filtering_allow_deny_syntax",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
api: add a new extension `container_syscall_filtering_allow_deny`
    
Commit 0c987f66b6f1c added support for the respectful config key names
(`security.syscalls.allow` and `security.syscalls.deny*`) but kept support for
the offensive names for backward compatibility. However, that commit did not
add the `container_syscall_filtering_allow_deny` extension to
`shared/version/api.go`, presumably by mistake.
    
Now that we are dropping support for the offensively named configuration keys,
use the API extension name and advertise it properly.
    
Items changed:
   
* doc/api-extensions: rewrite keys `from container_syscall_filtering` and
  update `container_syscall_filtering_allow_deny` description
* shared/version/api: add `container_syscall_filtering_allow_deny` extension
* lxd/instance/instancetype/instance: remove
  `security.syscalls.(black|white)list*` keys
* lxd/instance/instance_utils: remove `security.syscalls.(black|white)list*`
  keys
* lxd/seccomp/seccomp: remove `security.syscalls.(black|white)list*` keys
    
The change in lxd/seccomp/seccomp requires the underlying liblxc to support the
allowlist/denylist which is the case since https://github.com/lxc/lxc/commit/78522aa93657841d7384d0800c4acd144a81c9ad which means lxc 5.0.0 and higher.