### PR TITLE
lxd/apparmor/pyuefivars: allow reading bin/ directory

### DIFF
--- a/lxd/apparmor/pyuefivars.go
+++ b/lxd/apparmor/pyuefivars.go
@@ -31,6 +31,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   /snap/lxd/*/lib/**.so* mr,
 
   # Snap-specific Python locations
+  /snap/lxd/*/bin**/ r,
   /snap/lxd/*/bin**/*.py r,
   /snap/lxd/*/usr/lib/python** r,
   /snap/lxd/*/lib/python** r,


### PR DESCRIPTION
Fixes issue found by lxd-ci: https://github.com/canonical/lxd-ci/actions/runs/8053199642/job/21995023738?pr=74#step:6:557:
```
Feb 26 17:37:42 kernel: audit: type=1400 audit(1708969062.731:160): apparmor="STATUS" operation="profile_load" profile="unconfined" name="lxd_pyuefivars-<var-snap-lxd-common-lxd-virtual-machines-v1-qemu.nvram>" pid=4041 comm="apparmor_parser"
Feb 26 17:37:42 kernel: audit: type=1400 audit(1708969062.887:161): apparmor="DENIED" operation="open" class="file" profile="lxd_pyuefivars-<var-snap-lxd-common-lxd-virtual-machines-v1-qemu.nvram>" name="/snap/lxd/27360/bin/" pid=4042 comm="python3" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
Feb 26 17:37:43 kernel: audit: type=1400 audit(1708969063.111:162): apparmor="DENIED" operation="open" class="file" profile="lxd_pyuefivars-<var-snap-lxd-common-lxd-virtual-machines-v1-qemu.nvram>" name="/snap/lxd/27360/bin/" pid=4042 comm="python3" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
Feb 26 17:37:43 kernel: audit: type=1400 audit(1708969063.151:163): apparmor="DENIED" operation="open" class="file" profile="lxd_pyuefivars-<var-snap-lxd-common-lxd-virtual-machines-v1-qemu.nvram>" name="/snap/lxd/27360/bin/" pid=4042 comm="python3" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
```