### PR TITLE
Auth: Notify cluster members of new or updated OIDC identities

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	lxd "github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	cli "github.com/canonical/lxd/shared/cmd"

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -62,6 +62,7 @@ var apiInternal = []APIEndpoint{
 	internalShutdownCmd,
 	internalSQLCmd,
 	internalWarningCreateCmd,
+	internalIdentityCacheRefreshCmd,
 }
 
 var internalShutdownCmd = APIEndpoint{
@@ -135,6 +136,12 @@ var internalBGPStateCmd = APIEndpoint{
 	Path: "testing/bgp",
 
 	Get: APIEndpointAction{Handler: internalBGPState, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
+}
+
+var internalIdentityCacheRefreshCmd = APIEndpoint{
+	Path: "identity-cache-refresh",
+
+	Post: APIEndpointAction{Handler: internalIdentityCacheRefresh, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
 type internalImageOptimizePost struct {
@@ -1082,4 +1089,10 @@ func internalBGPState(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
 	return response.SyncResponse(true, s.BGP.Debug())
+}
+
+func internalIdentityCacheRefresh(d *Daemon, r *http.Request) response.Response {
+	logger.Debug("Received identity cache update notification - refreshing cache")
+	d.State().UpdateIdentityCache()
+	return response.EmptySyncResponse
 }

--- a/lxd/lifecycle/identity.go
+++ b/lxd/lifecycle/identity.go
@@ -1,0 +1,27 @@
+package lifecycle
+
+import (
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/version"
+)
+
+// IdentityAction represents a lifecycle event action for identities.
+type IdentityAction string
+
+// All supported lifecycle events for identities.
+const (
+	IdentityCreated = IdentityAction(api.EventLifecycleIdentityCreated)
+	IdentityUpdated = IdentityAction(api.EventLifecycleIdentityUpdated)
+)
+
+// Event creates the lifecycle event for an action on a Certificate.
+func (a IdentityAction) Event(authenticationMethod string, identifier string, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
+	u := api.NewURL().Path(version.APIVersion, "auth", "identities", authenticationMethod, identifier)
+
+	return api.EventLifecycle{
+		Action:    string(a),
+		Source:    u.String(),
+		Context:   ctx,
+		Requestor: requestor,
+	}
+}

--- a/shared/api/event_lifecycle.go
+++ b/shared/api/event_lifecycle.go
@@ -119,4 +119,6 @@ const (
 	EventLifecycleWarningAcknowledged               = "warning-acknowledged"
 	EventLifecycleWarningDeleted                    = "warning-deleted"
 	EventLifecycleWarningReset                      = "warning-reset"
+	EventLifecycleIdentityCreated                   = "identity-created"
+	EventLifecycleIdentityUpdated                   = "identity-updated"
 )


### PR DESCRIPTION
When a new OIDC identity authenticates with LXD, they are added to the `identities` table and the identity cache is updated so that authentication does not require calls to the database. However, if the same OIDC identity then makes a request to another cluster member, this will fail because the other member does not have the user in their cache (the other member will attempt to add the user to the database, but this will fail because the identity already exists). This was initially flagged here: see https://github.com/canonical/lxd/pull/12914#discussion_r1497778097.

This PR adds an internal endpoint to be used for updating the identity cache in this scenario, and adds lifecycle events for `identity-created` and `identity-updated`. Additionally, this PR changes the certificates API to use the same internal endpoint for updating the identity cache when a certificate is created, updated, or deleted. This also fixes a bug whereby certificate creation lifecycle events were being emitted once for each cluster member (rather than once for the certificate).

Before:
```
root@node1:~# lxc config set core.https_address=:8443
root@node1:~# lxc config trust add --name mark

mark@RUBIX:~$ lxc remote add node1 https://10.161.10.97:8443
Certificate fingerprint: 3c149654ad775b8f24c7bd9e6b9e1c6117d6241883765b1164142836c3b84a0e
ok (y/n/[fingerprint])? y
Admin password (or token) for node1: 
Client certificate now trusted by server: node1

root@node3:~# lxc monitor --pretty --type lifecycle
INFO   [2024-02-27T12:36:33Z] Action: config-updated, Source: /1.0, Requestor: unix/root (@)
INFO   [2024-02-27T12:36:45Z] Action: operation-cancelled, Source: /1.0/operations/1f91d0bc-0f8b-4c67-a3f7-f5b82feaf069, Requestor: / (10.161.10.1:47678) 
INFO   [2024-02-27T12:36:45Z] Action: certificate-created, Source: /1.0/certificates/e1e06266e36f67431c996d5678e66d732dfd12fe5073c161e62e6360619fc226, Requestor: / () 
INFO   [2024-02-27T12:36:45Z] Action: certificate-created, Source: /1.0/certificates/e1e06266e36f67431c996d5678e66d732dfd12fe5073c161e62e6360619fc226, Requestor: / () 
INFO   [2024-02-27T12:36:45Z] Action: certificate-created, Source: /1.0/certificates/e1e06266e36f67431c996d5678e66d732dfd12fe5073c161e62e6360619fc226, Requestor: / (10.161.10.1:47678)
```
After:
```
root@node1:~# lxc config set core.https_address=:8443
root@node1:~# lxc config trust add --name mark

mark@RUBIX:~$ lxc remote add node1 https://10.161.10.97:8443
Certificate fingerprint: 3c149654ad775b8f24c7bd9e6b9e1c6117d6241883765b1164142836c3b84a0e
ok (y/n/[fingerprint])? y
Admin password (or token) for node1: 
Client certificate now trusted by server: node1

root@node3:~# lxc monitor --pretty --type lifecycle
INFO   [2024-02-27T12:36:33Z] Action: config-updated, Source: /1.0, Requestor: unix/root (@)
INFO   [2024-02-27T12:36:45Z] Action: operation-cancelled, Source: /1.0/operations/1f91d0bc-0f8b-4c67-a3f7-f5b82feaf069, Requestor: / (10.161.10.1:47678) 
INFO   [2024-02-27T12:36:45Z] Action: certificate-created, Source: /1.0/certificates/e1e06266e36f67431c996d5678e66d732dfd12fe5073c161e62e6360619fc226, Requestor: / (10.161.10.1:54366)
```

I have verified that the certificate cache is indeed updated on all cluster members by changing the URL of the `node1` remote above to the addresses of `node2` and `node3` and calling `lxc info | grep core.https_address` (untrusted TLS certs can't see configuration).