### PR TITLE
test: Increase minio storage bucket test file size to 5MB

### DIFF
--- a/test/suites/storage_buckets.sh
+++ b/test/suites/storage_buckets.sh
@@ -118,7 +118,7 @@ test_storage_buckets() {
 
   # Test putting a file into a bucket.
   lxdTestFile="bucketfile_${bucketPrefix}.txt"
-  head -c 2M /dev/urandom > "${lxdTestFile}"
+  head -c 5M /dev/urandom > "${lxdTestFile}"
   s3cmdrun "${lxd_backend}" "${adAccessKey}" "${adSecretKey}" put "${lxdTestFile}" "s3://${bucketPrefix}.foo"
   ! s3cmdrun "${lxd_backend}" "${roAccessKey}" "${roSecretKey}" put "${lxdTestFile}" "s3://${bucketPrefix}.foo" || false
 


### PR DESCRIPTION
The latest minio server now relies on the lower level storage subsystem to track usage quotas. And due to storage volume size rounding using 2MB is not sufficient to always trigger storage driver quota detection.

Fixes #12968