### PR TITLE
lxd/db: Don't propagate expected errors

### DIFF
--- a/lxd/db/network_peers.go
+++ b/lxd/db/network_peers.go
@@ -110,7 +110,7 @@ func (c *ClusterTx) CreateNetworkPeer(ctx context.Context, networkID int64, info
 		}
 	}
 
-	return localPeerID, targetPeerNetworkID > -1, err
+	return localPeerID, targetPeerNetworkID > -1, nil
 }
 
 // networkPeerConfigAdd inserts Network peer config keys.


### PR DESCRIPTION
Fixes this error in the CI tests: https://github.com/canonical/lxd-ci/actions/runs/8062199894/job/22021469170#step:6:3297

This was recently refactored here:

https://github.com/canonical/lxd/pull/12754/files#diff-6ba9a4d3cf752f98f07e5a8ff4ba755b19eb813013b0550931532405b46ba9b9

At the end of this block, we return the `err` var. Previously this block was wrapped in a transaction which was assigned to an error, but the transaction itself would assign `err` to `nil` if we received a `sql.ErrNoRows` error. When the transaction was removed, the `return nil` line was removed as well, and so the `sql.ErrNoRows` error was being propagated to the caller, instead of `nil`.