### PR TITLE
Set minimum Go version to 1.21.5 to accomodate forthcoming openga package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,8 +224,7 @@ jobs:
         if: matrix.go == '1.21.x'
         run: |
           set -eux
-          GOSHORTVER="$(go env GOVERSION | sed -n 's/^go\([0-9]\+\.[0-9]\+\).*/\1/p')"
-          go mod tidy -go="${GOSHORTVER}"
+          go mod tidy -go=1.21.5
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOPATH ?= $(shell go env GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
+GOMIN=1.21
 
 ifneq "$(wildcard vendor)" ""
 	RAFT_PATH=$(CURDIR)/vendor/raft
@@ -92,14 +93,12 @@ ifneq "$(LXD_OFFLINE)" ""
 	exit 1
 endif
 	go get -t -v -d -u ./...
-	go get go@1.21
-	go get toolchain@go1.21
-	go mod tidy
+	go mod tidy -go=$(GOMIN)
+	go get toolchain@none
 
 	cd test/mini-oidc && go get -t -v -d -u ./...
-	cd test/mini-oidc && go get go@1.21
-	cd test/mini-oidc && go get toolchain@go1.21
-	cd test/mini-oidc && go mod tidy
+	cd test/mini-oidc && go mod tidy -go=$(GOMIN)
+	cd test/mini-oidc && go get toolchain@none
 
 	@echo "Dependencies updated"
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOPATH ?= $(shell go env GOPATH)
 CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
-GOMIN=1.21
+GOMIN=1.21.5
 
 ifneq "$(wildcard vendor)" ""
 	RAFT_PATH=$(CURDIR)/vendor/raft

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd
 
-go 1.21.7
+go 1.21
 
 require (
 	github.com/Rican7/retry v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd
 
-go 1.21
+go 1.21.5
 
 require (
 	github.com/Rican7/retry v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/tools v0.18.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240221002015-b0ce06bbee7c // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/grpc v1.62.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -908,8 +908,8 @@ google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240221002015-b0ce06bbee7c h1:NUsgEN92SQQqzfA+YtqYNqYmB3DMMYLlIwUZAQFVFbo=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240221002015-b0ce06bbee7c/go.mod h1:H4O17MA/PE9BsGx3w+a+W2VOLLD1Qf7oJneAoU6WktY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de h1:cZGRis4/ot9uVm639a+rHCUaG0JJHEsdyzSQTMX+suY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:H4O17MA/PE9BsGx3w+a+W2VOLLD1Qf7oJneAoU6WktY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/test/mini-oidc/go.mod
+++ b/test/mini-oidc/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd/test/mini-oidc
 
-go 1.21
+go 1.21.5
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12

--- a/test/mini-oidc/go.mod
+++ b/test/mini-oidc/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd/test/mini-oidc
 
-go 1.21.7
+go 1.21
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12


### PR DESCRIPTION
Also switches back to using `go mod tidy` for Go version enforcement as `go get go@` was modifying pinned dependencies automatically which is not desired (rather than erroring).