### PR TITLE
VM: Don't leak file descriptor when probing for Direct I/O support

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3887,9 +3887,11 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 			} else {
 				// Use host cache, with neither O_DSYNC nor O_DIRECT semantics if filesystem
 				// doesn't support Direct I/O.
-				_, err := os.OpenFile(srcDevPath, unix.O_DIRECT|unix.O_RDONLY, 0)
+				f, err := os.OpenFile(srcDevPath, unix.O_DIRECT|unix.O_RDONLY, 0)
 				if err != nil {
 					cacheMode = "writeback"
+				} else {
+					_ = f.Close() // Don't leak FD.
 				}
 			}
 


### PR DESCRIPTION
Fixes #12808

Aside from being an undesirable FD leak, it was also preventing clean unmount of the VM's config volume on some pool drivers.

Also added cleanup of the config.iso file if the cloud-init drive is removed from the instance (whether or not it is running).