### PR TITLE
DB: Add columns to identities table for auditing.

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -47,6 +47,9 @@ CREATE TABLE identities (
     identifier TEXT NOT NULL,
     name TEXT NOT NULL,
     metadata TEXT NOT NULL,
+    first_seen_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z",
+    last_seen_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z",
+    updated_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z",
     UNIQUE (auth_method, identifier),
     UNIQUE (type, identifier)
 );
@@ -665,5 +668,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (71, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (72, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -108,6 +108,20 @@ var updates = map[int]schema.Update{
 	69: updateFromV68,
 	70: updateFromV69,
 	71: updateFromV70,
+	72: updateFromV71,
+}
+
+func updateFromV71(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE identities ADD COLUMN first_seen_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z";
+ALTER TABLE identities ADD COLUMN last_seen_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z";
+ALTER TABLE identities ADD COLUMN updated_date DATETIME NOT NULL DEFAULT "0001-01-01T00:00:00Z";
+`)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func updateFromV70(ctx context.Context, tx *sql.Tx) error {


### PR DESCRIPTION
This PR adds three columns to the identities table: `first_seen_date`, `last_seen_date`, and `updated_date`. The columns are unused and have a default value. They will be used in future to remove users that have not been seen recently so that the identities table cannot grow indefinitely.