### PR TITLE
lxd-metadata: Annotate codebase for `nic` device config keys

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -170,6 +170,926 @@ You can omit the `MIG-` prefix when specifying this option.
 ```
 
 <!-- config group device-gpu-sriov-device-conf end -->
+<!-- config group device-nic-bridged-device-conf start -->
+```{config:option} boot.priority device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} host_name device-nic-bridged-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the host"
+:type: "string"
+
+```
+
+```{config:option} hwaddr device-nic-bridged-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv4 address to assign to the instance through DHCP"
+:type: "string"
+Set this option to `none` to restrict all IPv4 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv4_filtering` is set.
+```
+
+```{config:option} ipv4.routes device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv4 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.
+```
+
+```{config:option} ipv4.routes.external device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv4 static routes to route to NIC"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network (BGP).
+```
+
+```{config:option} ipv6.address device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv6 address to assign to the instance through DHCP"
+:type: "string"
+Set this option to `none` to restrict all IPv6 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv6_filtering` is set.
+```
+
+```{config:option} ipv6.routes device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv6 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.
+```
+
+```{config:option} ipv6.routes.external device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "IPv6 static routes to route to NIC"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network (BGP).
+```
+
+```{config:option} limits.egress device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "I/O limit for outgoing traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.ingress device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "I/O limit for incoming traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.max device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "I/O limit for both incoming and outgoing traffic"
+:type: "string"
+This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.
+
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.priority device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "`skb->priority` value for outgoing traffic"
+:type: "integer"
+The `skb->priority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.
+Specify the value as a 32-bit unsigned integer.
+
+The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.
+Consult the kernel qdisc documentation before setting this value.
+```
+
+```{config:option} maas.subnet.ipv4 device-nic-bridged-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv4 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 device-nic-bridged-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv6 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} mtu device-nic-bridged-device-conf
+:defaultdesc: "parent MTU"
+:managed: "yes"
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-bridged-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} network device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "Managed network to link the device to"
+:type: "string"
+You can specify this option instead of specifying the `nictype` directly.
+```
+
+```{config:option} parent device-nic-bridged-device-conf
+:managed: "yes"
+:required: "if specifying the `nictype` directly"
+:shortdesc: "Name of the host device"
+:type: "string"
+
+```
+
+```{config:option} queue.tx.length device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "Transmit queue length for the NIC"
+:type: "integer"
+
+```
+
+```{config:option} security.ipv4_filtering device-nic-bridged-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to prevent the instance from spoofing an IPv4 address"
+:type: "bool"
+Set this option to `true` to prevent the instance from spoofing another instance’s IPv4 address.
+This option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.
+```
+
+```{config:option} security.ipv6_filtering device-nic-bridged-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to prevent the instance from spoofing an IPv6 address"
+:type: "bool"
+Set this option to `true` to prevent the instance from spoofing another instance’s IPv6 address.
+This option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.
+```
+
+```{config:option} security.mac_filtering device-nic-bridged-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to prevent the instance from spoofing a MAC address"
+:type: "bool"
+Set this option to `true` to prevent the instance from spoofing another instance’s MAC address.
+```
+
+```{config:option} security.port_isolation device-nic-bridged-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to respect port isolation"
+:type: "bool"
+Set this option to `true` to prevent the NIC from communicating with other NICs in the network that have port isolation enabled.
+```
+
+```{config:option} vlan device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "VLAN ID to use for non-tagged traffic"
+:type: "integer"
+Set this option to `none` to remove the port from the default VLAN.
+```
+
+```{config:option} vlan.tagged device-nic-bridged-device-conf
+:managed: "no"
+:shortdesc: "VLAN IDs or VLAN ranges to join for tagged traffic"
+:type: "integer"
+Specify the VLAN IDs or ranges as a comma-delimited list.
+```
+
+<!-- config group device-nic-bridged-device-conf end -->
+<!-- config group device-nic-ipvlan-device-conf start -->
+```{config:option} gvrp device-nic-ipvlan-device-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to use GARP VLAN Registration Protocol"
+:type: "bool"
+This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+```
+
+```{config:option} hwaddr device-nic-ipvlan-device-conf
+:defaultdesc: "randomly assigned"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address device-nic-ipvlan-device-conf
+:shortdesc: "IPv4 static addresses to add to the instance"
+:type: "string"
+Specify a comma-delimited list of IPv4 static addresses to add to the instance.
+In `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/24`.
+```
+
+```{config:option} ipv4.gateway device-nic-ipvlan-device-conf
+:defaultdesc: "`auto` (`l3s`), `-` (`l2`)"
+:shortdesc: "IPv4 gateway"
+:type: "string"
+In `l3s` mode, the option specifies whether to add an automatic default IPv4 gateway.
+Possible values are `auto` and `none`.
+
+In `l2` mode, this option specifies the IPv4 address of the gateway.
+```
+
+```{config:option} ipv4.host_table device-nic-ipvlan-device-conf
+:shortdesc: "Custom policy routing table ID to add IPv4 static routes to"
+:type: "integer"
+The custom policy routing table is in addition to the main routing table.
+```
+
+```{config:option} ipv6.address device-nic-ipvlan-device-conf
+:shortdesc: "IPv6 static addresses to add to the instance"
+:type: "string"
+Specify a comma-delimited list of IPv6 static addresses to add to the instance.
+In `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/64`.
+```
+
+```{config:option} ipv6.gateway device-nic-ipvlan-device-conf
+:defaultdesc: "`auto` (`l3s`), `-` (`l2`)"
+:shortdesc: "IPv6 gateway"
+:type: "string"
+In `l3s` mode, the option specifies whether to add an automatic default IPv6 gateway.
+Possible values are `auto` and `none`.
+
+In `l2` mode, this option specifies the IPv6 address of the gateway.
+```
+
+```{config:option} ipv6.host_table device-nic-ipvlan-device-conf
+:shortdesc: "Custom policy routing table ID to add IPv6 static routes to"
+:type: "integer"
+The custom policy routing table is in addition to the main routing table.
+```
+
+```{config:option} mode device-nic-ipvlan-device-conf
+:defaultdesc: "`l3s`"
+:shortdesc: "IPVLAN mode"
+:type: "string"
+Possible values are `l2` and `l3s`.
+```
+
+```{config:option} mtu device-nic-ipvlan-device-conf
+:defaultdesc: "parent MTU"
+:shortdesc: "The MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-ipvlan-device-conf
+:defaultdesc: "kernel assigned"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} parent device-nic-ipvlan-device-conf
+:required: "yes"
+:shortdesc: "Name of the host device"
+:type: "string"
+
+```
+
+```{config:option} vlan device-nic-ipvlan-device-conf
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-ipvlan-device-conf end -->
+<!-- config group device-nic-macvlan-device-conf start -->
+```{config:option} boot.priority device-nic-macvlan-device-conf
+:managed: "no"
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} gvrp device-nic-macvlan-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to use GARP VLAN Registration Protocol"
+:type: "bool"
+This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+```
+
+```{config:option} hwaddr device-nic-macvlan-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv4 device-nic-macvlan-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv4 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 device-nic-macvlan-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv6 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} mtu device-nic-macvlan-device-conf
+:defaultdesc: "parent MTU"
+:managed: "yes"
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-macvlan-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} network device-nic-macvlan-device-conf
+:managed: "no"
+:shortdesc: "Managed network to link the device to"
+:type: "string"
+You can specify this option instead of specifying the `nictype` directly.
+```
+
+```{config:option} parent device-nic-macvlan-device-conf
+:managed: "yes"
+:required: "if specifying the `nictype` directly"
+:shortdesc: "Name of the host device"
+:type: "string"
+
+```
+
+```{config:option} vlan device-nic-macvlan-device-conf
+:managed: "no"
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-macvlan-device-conf end -->
+<!-- config group device-nic-ovn-device-conf start -->
+```{config:option} acceleration device-nic-ovn-device-conf
+:defaultdesc: "`none`"
+:managed: "no"
+:shortdesc: "Enable hardware offloading"
+:type: "string"
+Possible values are `none`, `sriov`, or `vdpa`.
+See {ref}`devices-nic-hw-acceleration` for more information.
+```
+
+```{config:option} boot.priority device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} host_name device-nic-ovn-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the host"
+:type: "string"
+
+```
+
+```{config:option} hwaddr device-nic-ovn-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv4 address to assign to the instance through DHCP"
+:type: "string"
+
+```
+
+```{config:option} ipv4.routes device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv4 static routes to route for the NIC"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes to route for this NIC.
+```
+
+```{config:option} ipv4.routes.external device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv4 static routes to route to NIC"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network.
+```
+
+```{config:option} ipv6.address device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv6 address to assign to the instance through DHCP"
+:type: "string"
+
+```
+
+```{config:option} ipv6.routes device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv6 static routes to route to the NIC"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes to route to the NIC.
+```
+
+```{config:option} ipv6.routes.external device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "IPv6 static routes to route to NIC"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network.
+```
+
+```{config:option} name device-nic-ovn-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} nested device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "Parent NIC name to nest this NIC under"
+:type: "string"
+See also {config:option}`device-nic-ovn-device-conf:vlan`.
+```
+
+```{config:option} network device-nic-ovn-device-conf
+:managed: "yes"
+:required: "yes"
+:shortdesc: "Managed network to link the device to"
+:type: "string"
+
+```
+
+```{config:option} security.acls device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "Network ACLs to apply"
+:type: "string"
+Specify a comma-separated list
+```
+
+```{config:option} security.acls.default.egress.action device-nic-ovn-device-conf
+:defaultdesc: "`reject`"
+:managed: "no"
+:shortdesc: "Default action to use for egress traffic"
+:type: "string"
+The specified action is used for all egress traffic that doesn’t match any ACL rule.
+```
+
+```{config:option} security.acls.default.egress.logged device-nic-ovn-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to log egress traffic that doesn’t match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} security.acls.default.ingress.action device-nic-ovn-device-conf
+:defaultdesc: "`reject`"
+:managed: "no"
+:shortdesc: "Default action to use for ingress traffic"
+:type: "string"
+The specified action is used for all ingress traffic that doesn’t match any ACL rule.
+```
+
+```{config:option} security.acls.default.ingress.logged device-nic-ovn-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to log ingress traffic that doesn’t match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} vlan device-nic-ovn-device-conf
+:managed: "no"
+:shortdesc: "VLAN ID to use when nesting"
+:type: "integer"
+See also {config:option}`device-nic-ovn-device-conf:nested`.
+```
+
+<!-- config group device-nic-ovn-device-conf end -->
+<!-- config group device-nic-p2p-device-conf start -->
+```{config:option} boot.priority device-nic-p2p-device-conf
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} host_name device-nic-p2p-device-conf
+:defaultdesc: "randomly assigned"
+:shortdesc: "Name of the interface inside the host"
+:type: "string"
+
+```
+
+```{config:option} hwaddr device-nic-p2p-device-conf
+:defaultdesc: "randomly assigned"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.routes device-nic-p2p-device-conf
+:shortdesc: "IPv4 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.
+```
+
+```{config:option} ipv6.routes device-nic-p2p-device-conf
+:shortdesc: "IPv6 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.
+```
+
+```{config:option} limits.egress device-nic-p2p-device-conf
+:shortdesc: "I/O limit for outgoing traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.ingress device-nic-p2p-device-conf
+:shortdesc: "I/O limit for incoming traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.max device-nic-p2p-device-conf
+:shortdesc: "I/O limit for both incoming and outgoing traffic"
+:type: "string"
+This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.
+
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.priority device-nic-p2p-device-conf
+:shortdesc: "`skb->priority` value for outgoing traffic"
+:type: "integer"
+The `skb->priority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.
+Specify the value as a 32-bit unsigned integer.
+
+The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.
+Consult the kernel qdisc documentation before setting this value.
+```
+
+```{config:option} mtu device-nic-p2p-device-conf
+:defaultdesc: "kernel assigned"
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-p2p-device-conf
+:defaultdesc: "kernel assigned"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} queue.tx.length device-nic-p2p-device-conf
+:shortdesc: "Transmit queue length for the NIC"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-p2p-device-conf end -->
+<!-- config group device-nic-physical-device-conf start -->
+```{config:option} boot.priority device-nic-physical-device-conf
+:managed: "no"
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} gvrp device-nic-physical-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to use GARP VLAN Registration Protocol"
+:type: "bool"
+This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+```
+
+```{config:option} hwaddr device-nic-physical-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv4 device-nic-physical-device-conf
+:managed: "no"
+:shortdesc: "MAAS IPv4 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 device-nic-physical-device-conf
+:managed: "no"
+:shortdesc: "MAAS IPv6 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} mtu device-nic-physical-device-conf
+:defaultdesc: "parent MTU"
+:managed: "no"
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-physical-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} network device-nic-physical-device-conf
+:managed: "no"
+:shortdesc: "Managed network to link the device to"
+:type: "string"
+You can specify this option instead of specifying the `nictype` directly.
+```
+
+```{config:option} parent device-nic-physical-device-conf
+:managed: "yes"
+:required: "if specifying the `nictype` directly"
+:shortdesc: "Name of the host device"
+:type: "string"
+
+```
+
+```{config:option} vlan device-nic-physical-device-conf
+:managed: "no"
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-physical-device-conf end -->
+<!-- config group device-nic-routed-device-conf start -->
+```{config:option} gvrp device-nic-routed-device-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to use GARP VLAN Registration Protocol"
+:type: "bool"
+This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+```
+
+```{config:option} host_name device-nic-routed-device-conf
+:defaultdesc: "randomly assigned"
+:shortdesc: "Name of the interface inside the host"
+:type: "string"
+
+```
+
+```{config:option} hwaddr device-nic-routed-device-conf
+:defaultdesc: "randomly assigned"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.address device-nic-routed-device-conf
+:shortdesc: "IPv4 static addresses to add to the instance"
+:type: "string"
+Specify a comma-delimited list of IPv4 static addresses to add to the instance.
+```
+
+```{config:option} ipv4.gateway device-nic-routed-device-conf
+:defaultdesc: "`auto`"
+:shortdesc: "Whether to add an automatic default IPv4 gateway"
+:type: "string"
+Possible values are `auto` and `none`.
+```
+
+```{config:option} ipv4.host_address device-nic-routed-device-conf
+:defaultdesc: "`192.254.0.1`"
+:shortdesc: "IPv4 address to add to the host-side `veth` interface"
+:type: "string"
+
+```
+
+```{config:option} ipv4.host_table device-nic-routed-device-conf
+:shortdesc: "Custom policy routing table ID to add IPv4 static routes to"
+:type: "integer"
+The custom policy routing table is in addition to the main routing table.
+```
+
+```{config:option} ipv4.neighbor_probe device-nic-routed-device-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to probe the parent network for IPv4 address availability"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.routes device-nic-routed-device-conf
+:shortdesc: "IPv4 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).
+```
+
+```{config:option} ipv6.address device-nic-routed-device-conf
+:shortdesc: "IPv6 static addresses to add to the instance"
+:type: "string"
+Specify a comma-delimited list of IPv6 static addresses to add to the instance.
+```
+
+```{config:option} ipv6.gateway device-nic-routed-device-conf
+:defaultdesc: "`auto`"
+:shortdesc: "Whether to add an automatic default IPv6 gateway"
+:type: "string"
+Possible values are `auto` and `none`.
+```
+
+```{config:option} ipv6.host_address device-nic-routed-device-conf
+:defaultdesc: "`fe80::1`"
+:shortdesc: "IPv6 address to add to the host-side `veth` interface"
+:type: "string"
+
+```
+
+```{config:option} ipv6.host_table device-nic-routed-device-conf
+:shortdesc: "Custom policy routing table ID to add IPv6 static routes to"
+:type: "integer"
+The custom policy routing table is in addition to the main routing table.
+```
+
+```{config:option} ipv6.neighbor_probe device-nic-routed-device-conf
+:defaultdesc: "`true`"
+:shortdesc: "Whether to probe the parent network for IPv6 address availability"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.routes device-nic-routed-device-conf
+:shortdesc: "IPv6 static routes for the NIC to add on the host"
+:type: "string"
+Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).
+```
+
+```{config:option} limits.egress device-nic-routed-device-conf
+:shortdesc: "I/O limit for outgoing traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.ingress device-nic-routed-device-conf
+:shortdesc: "I/O limit for incoming traffic"
+:type: "string"
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.max device-nic-routed-device-conf
+:shortdesc: "I/O limit for both incoming and outgoing traffic"
+:type: "string"
+This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.
+
+Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+```
+
+```{config:option} limits.priority device-nic-routed-device-conf
+:shortdesc: "`skb->priority` value for outgoing traffic"
+:type: "integer"
+The `skb->priority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.
+Specify the value as a 32-bit unsigned integer.
+
+The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.
+Consult the kernel qdisc documentation before setting this value.
+```
+
+```{config:option} mtu device-nic-routed-device-conf
+:defaultdesc: "parent MTU"
+:shortdesc: "The MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-routed-device-conf
+:defaultdesc: "kernel assigned"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} parent device-nic-routed-device-conf
+:shortdesc: "Name of the host device to join the instance to"
+:type: "string"
+
+```
+
+```{config:option} queue.tx.length device-nic-routed-device-conf
+:shortdesc: "Transmit queue length for the NIC"
+:type: "integer"
+
+```
+
+```{config:option} vlan device-nic-routed-device-conf
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-routed-device-conf end -->
+<!-- config group device-nic-sriov-device-conf start -->
+```{config:option} boot.priority device-nic-sriov-device-conf
+:managed: "no"
+:shortdesc: "Boot priority for VMs"
+:type: "integer"
+A higher value for this option means that the VM boots first.
+```
+
+```{config:option} hwaddr device-nic-sriov-device-conf
+:defaultdesc: "randomly assigned"
+:managed: "no"
+:shortdesc: "MAC address of the new interface"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv4 device-nic-sriov-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv4 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 device-nic-sriov-device-conf
+:managed: "yes"
+:shortdesc: "MAAS IPv6 subnet to register the instance in"
+:type: "string"
+
+```
+
+```{config:option} mtu device-nic-sriov-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "yes"
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} name device-nic-sriov-device-conf
+:defaultdesc: "kernel assigned"
+:managed: "no"
+:shortdesc: "Name of the interface inside the instance"
+:type: "string"
+
+```
+
+```{config:option} network device-nic-sriov-device-conf
+:managed: "no"
+:shortdesc: "Managed network to link the device to"
+:type: "string"
+You can specify this option instead of specifying the `nictype` directly.
+```
+
+```{config:option} parent device-nic-sriov-device-conf
+:managed: "yes"
+:required: "if specifying the `nictype` directly"
+:shortdesc: "Name of the host device"
+:type: "string"
+
+```
+
+```{config:option} security.mac_filtering device-nic-sriov-device-conf
+:defaultdesc: "`false`"
+:managed: "no"
+:shortdesc: "Whether to prevent the instance from spoofing a MAC address"
+:type: "bool"
+Set this option to `true` to prevent the instance from spoofing another instance’s MAC address.
+```
+
+```{config:option} vlan device-nic-sriov-device-conf
+:managed: "no"
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group device-nic-sriov-device-conf end -->
 <!-- config group device-pci-device-conf start -->
 ```{config:option} address device-pci-device-conf
 :required: "yes"

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -74,34 +74,11 @@ A `bridged` NIC uses an existing bridge on the host and creates a virtual device
 
 NIC devices of type `bridged` have the following device options:
 
-Key                      | Type    | Default           | Managed | Description
-:--                      | :--     | :--               | :--     | :--
-`boot.priority`          | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`host_name`              | string  | randomly assigned | no      | The name of the interface inside the host
-`hwaddr`                 | string  | randomly assigned | no      | The MAC address of the new interface
-`ipv4.address`           | string  | -                 | no      | An IPv4 address to assign to the instance through DHCP (can be `none` to restrict all IPv4 traffic when `security.ipv4_filtering` is set)
-`ipv4.routes`            | string  | -                 | no      | Comma-delimited list of IPv4 static routes to add on host to NIC
-`ipv4.routes.external`   | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC and publish on uplink network (BGP)
-`ipv6.address`           | string  | -                 | no      | An IPv6 address to assign to the instance through DHCP (can be `none` to restrict all IPv6 traffic when `security.ipv6_filtering` is set)
-`ipv6.routes`            | string  | -                 | no      | Comma-delimited list of IPv6 static routes to add on host to NIC
-`ipv6.routes.external`   | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC and publish on uplink network (BGP)
-`limits.egress`          | string  | -                 | no      | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.ingress`         | string  | -                 | no      | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.max`             | string  | -                 | no      | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
-`limits.priority`        | integer | -                 | no      | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
-`maas.subnet.ipv4`       | string  | -                 | yes     | MAAS IPv4 subnet to register the instance in
-`maas.subnet.ipv6`       | string  | -                 | yes     | MAAS IPv6 subnet to register the instance in
-`mtu`                    | integer | parent MTU        | yes     | The MTU of the new interface
-`name`                   | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`                | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
-`parent`                 | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
-`queue.tx.length`        | integer | -                 | no      | The transmit queue length for the NIC
-`security.ipv4_filtering`| bool    | `false`           | no      | Prevent the instance from spoofing another instance's IPv4 address (enables `security.mac_filtering`)
-`security.ipv6_filtering`| bool    | `false`           | no      | Prevent the instance from spoofing another instance's IPv6 address (enables `security.mac_filtering`)
-`security.mac_filtering` | bool    | `false`           | no      | Prevent the instance from spoofing another instance's MAC address
-`security.port_isolation`| bool    | `false`           | no      | Prevent the NIC from communicating with other NICs in the network that have port isolation enabled
-`vlan`                   | integer | -                 | no      | The VLAN ID to use for non-tagged traffic (can be `none` to remove port from default VLAN)
-`vlan.tagged`            | integer | -                 | no      | Comma-delimited list of VLAN IDs or VLAN ranges to join for tagged traffic
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-bridged-device-conf start -->
+    :end-before: <!-- config group device-nic-bridged-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -134,18 +111,11 @@ Both the host and the instances can talk to the gateway, but they cannot communi
 
 NIC devices of type `macvlan` have the following device options:
 
-Key                     | Type    | Default           | Managed | Description
-:--                     | :--     | :--               | :--     | :--
-`boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
-`hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
-`maas.subnet.ipv4`      | string  | -                 | yes     | MAAS IPv4 subnet to register the instance in
-`maas.subnet.ipv6`      | string  | -                 | yes     | MAAS IPv6 subnet to register the instance in
-`mtu`                   | integer | parent MTU        | yes     | The MTU of the new interface
-`name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
-`parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
-`vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-macvlan-device-conf start -->
+    :end-before: <!-- config group device-nic-macvlan-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -192,18 +162,11 @@ VF allocation
 
 NIC devices of type `sriov` have the following device options:
 
-Key                     | Type    | Default           | Managed | Description
-:--                     | :--     | :--               | :--     | :--
-`boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
-`maas.subnet.ipv4`      | string  | -                 | yes     | MAAS IPv4 subnet to register the instance in
-`maas.subnet.ipv6`      | string  | -                 | yes     | MAAS IPv6 subnet to register the instance in
-`mtu`                   | integer | kernel assigned   | yes     | The MTU of the new interface
-`name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
-`parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
-`security.mac_filtering`| bool    | `false`           | no      | Prevent the instance from spoofing another instance's MAC address
-`vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-sriov-device-conf start -->
+    :end-before: <!-- config group device-nic-sriov-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -233,18 +196,11 @@ The targeted device will vanish from the host and appear in the instance (which 
 
 NIC devices of type `physical` have the following device options:
 
-Key                     | Type    | Default           | Managed | Description
-:--                     | :--     | :--               | :--     | :--
-`boot.priority`         | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`gvrp`                  | bool    | `false`           | no      | Register VLAN using GARP VLAN Registration Protocol
-`hwaddr`                | string  | randomly assigned | no      | The MAC address of the new interface
-`maas.subnet.ipv4`      | string  | -                 | no      | MAAS IPv4 subnet to register the instance in
-`maas.subnet.ipv6`      | string  | -                 | no      | MAAS IPv6 subnet to register the instance in
-`mtu`                   | integer | parent MTU        | no      | The MTU of the new interface
-`name`                  | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`               | string  | -                 | no      | The managed network to link the device to (instead of specifying the `nictype` directly)
-`parent`                | string  | -                 | yes     | The name of the host device (required if specifying the `nictype` directly)
-`vlan`                  | integer | -                 | no      | The VLAN ID to attach to
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-physical-device-conf start -->
+    :end-before: <!-- config group device-nic-physical-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -307,27 +263,11 @@ VDPA hardware acceleration
 
 NIC devices of type `ovn` have the following device options:
 
-Key                                   | Type    | Default           | Managed | Description
-:--                                   | :--     | :--               | :--     | :--
-`acceleration`                        | string  | `none`            | no      | Enable hardware offloading (either `none`, `sriov` or `vdpa`, see {ref}`devices-nic-hw-acceleration`)
-`boot.priority`                       | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`host_name`                           | string  | randomly assigned | no      | The name of the interface inside the host
-`hwaddr`                              | string  | randomly assigned | no      | The MAC address of the new interface
-`ipv4.address`                        | string  | -                 | no      | An IPv4 address to assign to the instance through DHCP
-`ipv4.routes`                         | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC
-`ipv4.routes.external`                | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC and publish on uplink network
-`ipv6.address`                        | string  | -                 | no      | An IPv6 address to assign to the instance through DHCP
-`ipv6.routes`                         | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC
-`ipv6.routes.external`                | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC and publish on uplink network
-`name`                                | string  | kernel assigned   | no      | The name of the interface inside the instance
-`nested`                              | string  | -                 | no      | The parent NIC name to nest this NIC under (see also `vlan`)
-`network`                             | string  | -                 | yes     | The managed network to link the device to (required)
-`security.acls`                       | string  | -                 | no      | Comma-separated list of network ACLs to apply
-`security.acls.default.egress.action` | string  | `reject`          | no      | Action to use for egress traffic that doesn't match any ACL rule
-`security.acls.default.egress.logged` | bool    | `false`           | no      | Whether to log egress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.action`| string  | `reject`          | no      | Action to use for ingress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.logged`| bool    | `false`           | no      | Whether to log ingress traffic that doesn't match any ACL rule
-`vlan`                                | integer | -                 | no      | The VLAN ID to use when nesting (see also `nested`)
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-ovn-device-conf start -->
+    :end-before: <!-- config group device-nic-ovn-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -377,21 +317,11 @@ DNS
 
 NIC devices of type `ipvlan` have the following device options:
 
-Key                     | Type    | Default            | Description
-:--                     | :--     | :--                | :--
-`gvrp`                  | bool    | `false`            | Register VLAN using GARP VLAN Registration Protocol
-`hwaddr`                | string  | randomly assigned  | The MAC address of the new interface
-`ipv4.address`          | string  | -                  | Comma-delimited list of IPv4 static addresses to add to the instance (in `l2` mode, these can be specified as CIDR values or singular addresses using a subnet of `/24`)
-`ipv4.gateway`          | string  | `auto` (`l3s`), - (`l2`) | In `l3s` mode, whether to add an automatic default IPv4 gateway (can be `auto` or `none`); in `l2` mode, the IPv4 address of the gateway
-`ipv4.host_table`       | integer | -                  | The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
-`ipv6.address`          | string  | -                  | Comma-delimited list of IPv6 static addresses to add to the instance (in `l2` mode, these can be specified as CIDR values or singular addresses using a subnet of `/64`)
-`ipv6.gateway`          | string  | `auto` (`l3s`), - (`l2`) | In `l3s` mode, whether to add an automatic default IPv6 gateway (can be `auto` or `none`); in `l2` mode, the IPv6 address of the gateway
-`ipv6.host_table`       | integer | -                  | The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
-`mode`                  | string  | `l3s`              | The IPVLAN mode (either `l2` or `l3s`)
-`mtu`                   | integer | parent MTU         | The MTU of the new interface
-`name`                  | string  | kernel assigned    | The name of the interface inside the instance
-`parent`                | string  | -                  | The name of the host device (required)
-`vlan`                  | integer | -                  | The VLAN ID to attach to
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-ipvlan-device-conf start -->
+    :end-before: <!-- config group device-nic-ipvlan-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -417,20 +347,11 @@ A `p2p` NIC creates a virtual device pair, putting one side in the instance and 
 
 NIC devices of type `p2p` have the following device options:
 
-Key                     | Type    | Default           | Description
-:--                     | :--     | :--               | :--
-`boot.priority`         | integer | -                 | Boot priority for VMs (higher value boots first)
-`host_name`             | string  | randomly assigned | The name of the interface inside the host
-`hwaddr`                | string  | randomly assigned | The MAC address of the new interface
-`ipv4.routes`           | string  | -                 | Comma-delimited list of IPv4 static routes to add on host to NIC
-`ipv6.routes`           | string  | -                 | Comma-delimited list of IPv6 static routes to add on host to NIC
-`limits.egress`         | string  | -                 | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.ingress`        | string  | -                 | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.max`            | string  | -                 | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
-`limits.priority`       | integer | -                 | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
-`mtu`                   | integer | kernel assigned   | The MTU of the new interface
-`name`                  | string  | kernel assigned   | The name of the interface inside the instance
-`queue.tx.length`       | integer | -                 | The transmit queue length for the NIC
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-p2p-device-conf start -->
+    :end-before: <!-- config group device-nic-p2p-device-conf end -->
+```
 
 #### Configuration examples
 
@@ -507,32 +428,11 @@ Parent interface
 
 NIC devices of type `routed` have the following device options:
 
-Key                     | Type    | Default           | Description
-:--                     | :--     | :--               | :--
-`gvrp`                  | bool    | `false`           | Register VLAN using GARP VLAN Registration Protocol
-`host_name`             | string  | randomly assigned | The name of the interface inside the host
-`hwaddr`                | string  | randomly assigned | The MAC address of the new interface
-`ipv4.address`          | string  | -                 | Comma-delimited list of IPv4 static addresses to add to the instance
-`ipv4.gateway`          | string  | `auto`            | Whether to add an automatic default IPv4 gateway (can be `auto` or `none`)
-`ipv4.host_address`     | string  | `169.254.0.1`     | The IPv4 address to add to the host-side `veth` interface
-`ipv4.host_table`       | integer | -                 | The custom policy routing table ID to add IPv4 static routes to (in addition to the main routing table)
-`ipv4.neighbor_probe`   | bool    | `true`            | Whether to probe the parent network for IP address availability
-`ipv4.routes`           | string  | -                 | Comma-delimited list of IPv4 static routes to add on host to NIC (without L2 ARP/NDP proxy)
-`ipv6.address`          | string  | -                 | Comma-delimited list of IPv6 static addresses to add to the instance
-`ipv6.gateway`          | string  | `auto`            | Whether to add an automatic default IPv6 gateway (can be `auto` or `none`)
-`ipv6.host_address`     | string  | `fe80::1`         | The IPv6 address to add to the host-side `veth` interface
-`ipv6.host_table`       | integer | -                 | The custom policy routing table ID to add IPv6 static routes to (in addition to the main routing table)
-`ipv6.neighbor_probe`   | bool    | `true`            | Whether to probe the parent network for IP address availability
-`ipv6.routes`           | string  | -                 | Comma-delimited list of IPv6 static routes to add on host to NIC (without L2 ARP/NDP proxy)
-`limits.egress`         | string  | -                 | I/O limit in bit/s for outgoing traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.ingress`        | string  | -                 | I/O limit in bit/s for incoming traffic (various suffixes supported, see {ref}`instances-limit-units`)
-`limits.max`            | string  | -                 | I/O limit in bit/s for both incoming and outgoing traffic (same as setting both `limits.ingress` and `limits.egress`)
-`limits.priority`       | integer | -                 | The `skb->priority` value (32-bit unsigned integer) for outgoing traffic, to be used by the kernel queuing discipline (qdisc) to prioritize network packets (The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`. Consult the kernel qdisc documentation before setting this value.)
-`mtu`                   | integer | parent MTU        | The MTU of the new interface
-`name`                  | string  | kernel assigned   | The name of the interface inside the instance
-`parent`                | string  | -                 | The name of the host device to join the instance to
-`queue.tx.length`       | integer | -                 | The transmit queue length for the NIC
-`vlan`                  | integer | -                 | The VLAN ID to attach to
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-nic-routed-device-conf start -->
+    :end-before: <!-- config group device-nic-routed-device-conf end -->
+```
 
 #### Configuration examples
 

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -34,7 +34,7 @@ However, note that when you specify the `network` option, the `nictype` option i
   When using this method, LXD derives the `nictype` option automatically.
   The value is read-only and cannot be changed.
 
-  Other device options that are inherited from the network are marked with a "yes" in the "Managed" column of the NIC-specific tables of device options.
+  Other device options that are inherited from the network are marked with a "yes" in the "Managed" field of the NIC-specific device options.
   You cannot customize these options directly for the NIC if you're using the `network` method.
 
 See {ref}`networks` for more information.
@@ -59,7 +59,7 @@ The following NICs can be added using only the `nictype` option:
 - [`p2p`](nic-p2p): Creates a virtual device pair, putting one side in the instance and leaving the other side on the host.
 - [`routed`](nic-routed): Creates a virtual device pair to connect the host to the instance and sets up static routes and proxy ARP/NDP entries to allow the instance to join the network of a designated parent interface.
 
-The available device options depend on the NIC type and are listed in the tables in the following sections.
+The available device options depend on the NIC type and are listed in the following sections.
 
 (nic-bridged)=
 ### `nictype`: `bridged`

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -14,45 +14,582 @@ import (
 func nicValidationRules(requiredFields []string, optionalFields []string, instConf instance.ConfigReader) map[string]func(value string) error {
 	// Define a set of default validators for each field name.
 	defaultValidators := map[string]func(value string) error{
-		"acceleration":                         validate.Optional(validate.IsOneOf("none", "sriov", "vdpa")),
-		"name":                                 validate.Optional(validate.IsInterfaceName, func(_ string) error { return nicCheckNamesUnique(instConf) }),
-		"parent":                               validate.IsAny,
-		"network":                              validate.IsAny,
-		"mtu":                                  validate.Optional(validate.IsNetworkMTU),
-		"vlan":                                 validate.IsNetworkVLAN,
-		"gvrp":                                 validate.Optional(validate.IsBool),
-		"hwaddr":                               validate.IsNetworkMAC,
-		"host_name":                            validate.IsAny,
-		"limits.ingress":                       validate.IsAny,
-		"limits.egress":                        validate.IsAny,
-		"limits.max":                           validate.IsAny,
-		"limits.priority":                      validate.Optional(validate.IsUint32),
-		"security.mac_filtering":               validate.IsAny,
-		"security.ipv4_filtering":              validate.IsAny,
-		"security.ipv6_filtering":              validate.IsAny,
-		"security.port_isolation":              validate.Optional(validate.IsBool),
-		"maas.subnet.ipv4":                     validate.IsAny,
-		"maas.subnet.ipv6":                     validate.IsAny,
-		"ipv4.address":                         validate.Optional(validate.IsNetworkAddressV4),
-		"ipv6.address":                         validate.Optional(validate.IsNetworkAddressV6),
-		"ipv4.routes":                          validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
-		"ipv6.routes":                          validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
-		"boot.priority":                        validate.Optional(validate.IsUint32),
-		"ipv4.gateway":                         networkValidGateway,
-		"ipv6.gateway":                         networkValidGateway,
-		"ipv4.host_address":                    validate.Optional(validate.IsNetworkAddressV4),
-		"ipv6.host_address":                    validate.Optional(validate.IsNetworkAddressV6),
-		"ipv4.host_table":                      validate.Optional(validate.IsUint32),
-		"ipv6.host_table":                      validate.Optional(validate.IsUint32),
-		"queue.tx.length":                      validate.Optional(validate.IsUint32),
-		"ipv4.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
-		"ipv6.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
-		"nested":                               validate.IsAny,
-		"security.acls":                        validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=acceleration)
+		// Possible values are `none`, `sriov`, or `vdpa`.
+		// See {ref}`devices-nic-hw-acceleration` for more information.
+		// ---
+		//  type: string
+		//  defaultdesc: `none`
+		//  managed: no
+		//  shortdesc: Enable hardware offloading
+		"acceleration": validate.Optional(validate.IsOneOf("none", "sriov", "vdpa")),
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical+ovn}; group=device-conf; key=name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: kernel assigned
+		//  managed: no
+		//  shortdesc: Name of the interface inside the instance
+
+		// lxdmeta:generate(entities=device-nic-{ipvlan+p2p+routed}; group=device-conf; key=name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: kernel assigned
+		//  shortdesc: Name of the interface inside the instance
+		"name": validate.Optional(validate.IsInterfaceName, func(_ string) error { return nicCheckNamesUnique(instConf) }),
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical}; group=device-conf; key=parent)
+		//
+		// ---
+		//  type: string
+		//  managed: yes
+		//  required: if specifying the `nictype` directly
+		//  shortdesc: Name of the host device
+
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=parent)
+		//
+		// ---
+		//  type: string
+		//  required: yes
+		//  shortdesc: Name of the host device
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=parent)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Name of the host device to join the instance to
+		"parent": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical}; group=device-conf; key=network)
+		// You can specify this option instead of specifying the `nictype` directly.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: Managed network to link the device to
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=network)
+		//
+		// ---
+		//  type: string
+		//  managed: yes
+		//  required: yes
+		//  shortdesc: Managed network to link the device to
+		"network": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan}; group=device-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: parent MTU
+		//  managed: yes
+		//  shortdesc: MTU of the new interface
+
+		// lxdmeta:generate(entities=device-nic-sriov; group=device-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: kernel assigned
+		//  managed: yes
+		//  shortdesc: MTU of the new interface
+
+		// lxdmeta:generate(entities=device-nic-physical; group=device-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: parent MTU
+		//  managed: no
+		//  shortdesc: MTU of the new interface
+
+		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: parent MTU
+		//  shortdesc: The MTU of the new interface
+
+		// lxdmeta:generate(entities=device-nic-p2p; group=device-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  defaultdesc: kernel assigned
+		//  shortdesc: MTU of the new interface
+		"mtu": validate.Optional(validate.IsNetworkMTU),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=vlan)
+		// Set this option to `none` to remove the port from the default VLAN.
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: VLAN ID to use for non-tagged traffic
+
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=vlan.tagged)
+		// Specify the VLAN IDs or ranges as a comma-delimited list.
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: VLAN IDs or VLAN ranges to join for tagged traffic
+
+		// lxdmeta:generate(entities=device-nic-{macvlan+sriov+physical}; group=device-conf; key=vlan)
+		//
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: VLAN ID to attach to
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=vlan)
+		// See also {config:option}`device-nic-ovn-device-conf:nested`.
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: VLAN ID to use when nesting
+
+		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=vlan)
+		//
+		// ---
+		//  type: integer
+		//  shortdesc: VLAN ID to attach to
+		"vlan": validate.IsNetworkVLAN,
+		// lxdmeta:generate(entities=device-nic-{macvlan+physical}; group=device-conf; key=gvrp)
+		// This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to use GARP VLAN Registration Protocol
+
+		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=gvrp)
+		// This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  shortdesc: Whether to use GARP VLAN Registration Protocol
+		"gvrp": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical+ovn}; group=device-conf; key=hwaddr)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: randomly assigned
+		//  managed: no
+		//  shortdesc: MAC address of the new interface
+
+		// lxdmeta:generate(entities=device-nic-{ipvlan+p2p+routed}; group=device-conf; key=hwaddr)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: randomly assigned
+		//  shortdesc: MAC address of the new interface
+		"hwaddr": validate.IsNetworkMAC,
+		// lxdmeta:generate(entities=device-nic-{bridged+ovn}; group=device-conf; key=host_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: randomly assigned
+		//  managed: no
+		//  shortdesc: Name of the interface inside the host
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=host_name)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: randomly assigned
+		//  shortdesc: Name of the interface inside the host
+		"host_name": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=limits.ingress)
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: I/O limit for incoming traffic
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=limits.ingress)
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  shortdesc: I/O limit for incoming traffic
+		"limits.ingress": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=limits.egress)
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: I/O limit for outgoing traffic
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=limits.egress)
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  shortdesc: I/O limit for outgoing traffic
+		"limits.egress": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=limits.max)
+		// This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.
+		//
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: I/O limit for both incoming and outgoing traffic
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=limits.max)
+		// This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.
+		//
+		// Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).
+		// ---
+		//  type: string
+		//  shortdesc: I/O limit for both incoming and outgoing traffic
+		"limits.max": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=limits.priority)
+		// The `skb->priority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.
+		// Specify the value as a 32-bit unsigned integer.
+		//
+		// The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.
+		// Consult the kernel qdisc documentation before setting this value.
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: `skb->priority` value for outgoing traffic
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=limits.priority)
+		// The `skb->priority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.
+		// Specify the value as a 32-bit unsigned integer.
+		//
+		// The effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.
+		// Consult the kernel qdisc documentation before setting this value.
+		// ---
+		//  type: integer
+		//  shortdesc: `skb->priority` value for outgoing traffic
+		"limits.priority": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=device-nic-{bridged+sriov}; group=device-conf; key=security.mac_filtering)
+		// Set this option to `true` to prevent the instance from spoofing another instance’s MAC address.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to prevent the instance from spoofing a MAC address
+		"security.mac_filtering": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=security.ipv4_filtering)
+		// Set this option to `true` to prevent the instance from spoofing another instance’s IPv4 address.
+		// This option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to prevent the instance from spoofing an IPv4 address
+		"security.ipv4_filtering": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=security.ipv6_filtering)
+		// Set this option to `true` to prevent the instance from spoofing another instance’s IPv6 address.
+		// This option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to prevent the instance from spoofing an IPv6 address
+		"security.ipv6_filtering": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=security.port_isolation)
+		// Set this option to `true` to prevent the NIC from communicating with other NICs in the network that have port isolation enabled.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to respect port isolation
+		"security.port_isolation": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov}; group=device-conf; key=maas.subnet.ipv4)
+		//
+		// ---
+		//  type: string
+		//  managed: yes
+		//  shortdesc: MAAS IPv4 subnet to register the instance in
+
+		// lxdmeta:generate(entities=device-nic-physical; group=device-conf; key=maas.subnet.ipv4)
+		//
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: MAAS IPv4 subnet to register the instance in
+		"maas.subnet.ipv4": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov}; group=device-conf; key=maas.subnet.ipv6)
+		//
+		// ---
+		//  type: string
+		//  managed: yes
+		//  shortdesc: MAAS IPv6 subnet to register the instance in
+
+		// lxdmeta:generate(entities=device-nic-physical; group=device-conf; key=maas.subnet.ipv6)
+		//
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: MAAS IPv6 subnet to register the instance in
+		"maas.subnet.ipv6": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv4.address)
+		// Set this option to `none` to restrict all IPv4 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv4_filtering` is set.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 address to assign to the instance through DHCP
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv4.address)
+		//
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 address to assign to the instance through DHCP
+
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=ipv4.address)
+		// Specify a comma-delimited list of IPv4 static addresses to add to the instance.
+		// In `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/24`.
+		// ---
+		//  type: string
+		//  shortdesc: IPv4 static addresses to add to the instance
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv4.address)
+		// Specify a comma-delimited list of IPv4 static addresses to add to the instance.
+		// ---
+		//  type: string
+		//  shortdesc: IPv4 static addresses to add to the instance
+		"ipv4.address": validate.Optional(validate.IsNetworkAddressV4),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv6.address)
+		// Set this option to `none` to restrict all IPv6 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv6_filtering` is set.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 address to assign to the instance through DHCP
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv6.address)
+		//
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 address to assign to the instance through DHCP
+
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=ipv6.address)
+		// Specify a comma-delimited list of IPv6 static addresses to add to the instance.
+		// In `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/64`.
+		// ---
+		//  type: string
+		//  shortdesc: IPv6 static addresses to add to the instance
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.address)
+		// Specify a comma-delimited list of IPv6 static addresses to add to the instance.
+		// ---
+		//  type: string
+		//  shortdesc: IPv6 static addresses to add to the instance
+		"ipv6.address": validate.Optional(validate.IsNetworkAddressV6),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv4.routes)
+		// Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 static routes for the NIC to add on the host
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv4.routes)
+		// Specify a comma-delimited list of IPv4 static routes to route for this NIC.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 static routes to route for the NIC
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv4.routes)
+		// Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).
+		// ---
+		//  type: string
+		//  shortdesc: IPv4 static routes for the NIC to add on the host
+
+		// lxdmeta:generate(entities=device-nic-p2p; group=device-conf; key=ipv4.routes)
+		// Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.
+		// ---
+		//  type: string
+		//  shortdesc: IPv4 static routes for the NIC to add on the host
+		"ipv4.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv6.routes)
+		// Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 static routes for the NIC to add on the host
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv6.routes)
+		// Specify a comma-delimited list of IPv6 static routes to route to the NIC.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 static routes to route to the NIC
+
+		// lxdmeta:generate(entities=device-nic-p2p; group=device-conf; key=ipv6.routes)
+		// Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.
+		// ---
+		//  type: string
+		//  shortdesc: IPv6 static routes for the NIC to add on the host
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.routes)
+		// Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).
+		// ---
+		//  type: string
+		//  shortdesc: IPv6 static routes for the NIC to add on the host
+		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical+ovn}; group=device-conf; key=boot.priority)
+		// A higher value for this option means that the VM boots first.
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: Boot priority for VMs
+
+		// lxdmeta:generate(entities=device-nic-p2p; group=device-conf; key=boot.priority)
+		// A higher value for this option means that the VM boots first.
+		// ---
+		//  type: integer
+		//  shortdesc: Boot priority for VMs
+		"boot.priority": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=ipv4.gateway)
+		// In `l3s` mode, the option specifies whether to add an automatic default IPv4 gateway.
+		// Possible values are `auto` and `none`.
+		//
+		// In `l2` mode, this option specifies the IPv4 address of the gateway.
+		// ---
+		//  type: string
+		//  defaultdesc: `auto` (`l3s`), `-` (`l2`)
+		//  shortdesc: IPv4 gateway
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv4.gateway)
+		// Possible values are `auto` and `none`.
+		// ---
+		//  type: string
+		//  defaultdesc: `auto`
+		//  shortdesc: Whether to add an automatic default IPv4 gateway
+		"ipv4.gateway": networkValidGateway,
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=mode)
+		// Possible values are `l2` and `l3s`.
+		// ---
+		//  type: string
+		//  defaultdesc: `l3s`
+		//  shortdesc: IPVLAN mode
+
+		// lxdmeta:generate(entities=device-nic-ipvlan; group=device-conf; key=ipv6.gateway)
+		// In `l3s` mode, the option specifies whether to add an automatic default IPv6 gateway.
+		// Possible values are `auto` and `none`.
+		//
+		// In `l2` mode, this option specifies the IPv6 address of the gateway.
+		// ---
+		//  type: string
+		//  defaultdesc: `auto` (`l3s`), `-` (`l2`)
+		//  shortdesc: IPv6 gateway
+
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.gateway)
+		// Possible values are `auto` and `none`.
+		// ---
+		//  type: string
+		//  defaultdesc: `auto`
+		//  shortdesc: Whether to add an automatic default IPv6 gateway
+		"ipv6.gateway": networkValidGateway,
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv4.host_address)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `192.254.0.1`
+		//  shortdesc: IPv4 address to add to the host-side `veth` interface
+		"ipv4.host_address": validate.Optional(validate.IsNetworkAddressV4),
+		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.host_address)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: `fe80::1`
+		//  shortdesc: IPv6 address to add to the host-side `veth` interface
+		"ipv6.host_address": validate.Optional(validate.IsNetworkAddressV6),
+		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=ipv4.host_table)
+		// The custom policy routing table is in addition to the main routing table.
+		// ---
+		//  type: integer
+		//  shortdesc: Custom policy routing table ID to add IPv4 static routes to
+		"ipv4.host_table": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=ipv6.host_table)
+		// The custom policy routing table is in addition to the main routing table.
+		// ---
+		//  type: integer
+		//  shortdesc: Custom policy routing table ID to add IPv6 static routes to
+		"ipv6.host_table": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=queue.tx.length)
+		//
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: Transmit queue length for the NIC
+
+		// lxdmeta:generate(entities=device-nic-{p2p+routed}; group=device-conf; key=queue.tx.length)
+		//
+		// ---
+		//  type: integer
+		//  shortdesc: Transmit queue length for the NIC
+		"queue.tx.length": validate.Optional(validate.IsUint32),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv4.routes.external)
+		// Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network (BGP).
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 static routes to route to NIC
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv4.routes.external)
+		// Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv4 static routes to route to NIC
+		"ipv4.routes.external": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
+		// lxdmeta:generate(entities=device-nic-bridged; group=device-conf; key=ipv6.routes.external)
+		// Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network (BGP).
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 static routes to route to NIC
+
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=ipv6.routes.external)
+		// Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: IPv6 static routes to route to NIC
+		"ipv6.routes.external": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=nested)
+		// See also {config:option}`device-nic-ovn-device-conf:vlan`.
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: Parent NIC name to nest this NIC under
+		"nested": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=security.acls)
+		// Specify a comma-separated list
+		// ---
+		//  type: string
+		//  managed: no
+		//  shortdesc: Network ACLs to apply
+		"security.acls": validate.IsAny,
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=security.acls.default.ingress.action)
+		// The specified action is used for all ingress traffic that doesn’t match any ACL rule.
+		// ---
+		//  type: string
+		//  defaultdesc: `reject`
+		//  managed: no
+		//  shortdesc: Default action to use for ingress traffic
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
-		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=security.acls.default.egress.action)
+		// The specified action is used for all egress traffic that doesn’t match any ACL rule.
+		// ---
+		//  type: string
+		//  defaultdesc: `reject`
+		//  managed: no
+		//  shortdesc: Default action to use for egress traffic
+		"security.acls.default.egress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=security.acls.default.ingress.logged)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to log ingress traffic that doesn’t match any ACL rule
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
-		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=security.acls.default.egress.logged)
+		//
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  managed: no
+		//  shortdesc: Whether to log egress traffic that doesn’t match any ACL rule
+		"security.acls.default.egress.logged": validate.Optional(validate.IsBool),
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -85,7 +85,19 @@ func (d *nicRouted) validateConfig(instConf instance.ConfigReader) error {
 	rules["ipv4.address"] = validate.Optional(validate.IsListOf(validate.IsNetworkAddressV4))
 	rules["ipv6.address"] = validate.Optional(validate.IsListOf(validate.IsNetworkAddressV6))
 	rules["gvrp"] = validate.Optional(validate.IsBool)
+	// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv4.neighbor_probe)
+	//
+	// ---
+	//  type: bool
+	//  defaultdesc: `true`
+	//  shortdesc: Whether to probe the parent network for IPv4 address availability
 	rules["ipv4.neighbor_probe"] = validate.Optional(validate.IsBool)
+	// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.neighbor_probe)
+	//
+	// ---
+	//  type: bool
+	//  defaultdesc: `true`
+	//  shortdesc: Whether to probe the parent network for IPv6 address availability
 	rules["ipv6.neighbor_probe"] = validate.Optional(validate.IsBool)
 
 	err = d.config.Validate(rules)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -214,6 +214,1053 @@
 				]
 			}
 		},
+		"device-nic-bridged": {
+			"device-conf": {
+				"keys": [
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"managed": "no",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"host_name": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the host",
+							"type": "string"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"longdesc": "Set this option to `none` to restrict all IPv4 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv4_filtering` is set.",
+							"managed": "no",
+							"shortdesc": "IPv4 address to assign to the instance through DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.",
+							"managed": "no",
+							"shortdesc": "IPv4 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes.external": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network (BGP).",
+							"managed": "no",
+							"shortdesc": "IPv4 static routes to route to NIC",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.address": {
+							"longdesc": "Set this option to `none` to restrict all IPv6 traffic when {config:option}`device-nic-bridged-device-conf:security.ipv6_filtering` is set.",
+							"managed": "no",
+							"shortdesc": "IPv6 address to assign to the instance through DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.",
+							"managed": "no",
+							"shortdesc": "IPv6 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes.external": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network (BGP).",
+							"managed": "no",
+							"shortdesc": "IPv6 static routes to route to NIC",
+							"type": "string"
+						}
+					},
+					{
+						"limits.egress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"managed": "no",
+							"shortdesc": "I/O limit for outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.ingress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"managed": "no",
+							"shortdesc": "I/O limit for incoming traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.max": {
+							"longdesc": "This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.\n\nSpecify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"managed": "no",
+							"shortdesc": "I/O limit for both incoming and outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.priority": {
+							"longdesc": "The `skb-\u003epriority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.\nSpecify the value as a 32-bit unsigned integer.\n\nThe effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.\nConsult the kernel qdisc documentation before setting this value.",
+							"managed": "no",
+							"shortdesc": "`skb-\u003epriority` value for outgoing traffic",
+							"type": "integer"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv4 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv6 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "You can specify this option instead of specifying the `nictype` directly.",
+							"managed": "no",
+							"shortdesc": "Managed network to link the device to",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"managed": "yes",
+							"required": "if specifying the `nictype` directly",
+							"shortdesc": "Name of the host device",
+							"type": "string"
+						}
+					},
+					{
+						"queue.tx.length": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Transmit queue length for the NIC",
+							"type": "integer"
+						}
+					},
+					{
+						"security.ipv4_filtering": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to prevent the instance from spoofing another instance’s IPv4 address.\nThis option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.",
+							"managed": "no",
+							"shortdesc": "Whether to prevent the instance from spoofing an IPv4 address",
+							"type": "bool"
+						}
+					},
+					{
+						"security.ipv6_filtering": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to prevent the instance from spoofing another instance’s IPv6 address.\nThis option enables {config:option}`device-nic-bridged-device-conf:security.mac_filtering`.",
+							"managed": "no",
+							"shortdesc": "Whether to prevent the instance from spoofing an IPv6 address",
+							"type": "bool"
+						}
+					},
+					{
+						"security.mac_filtering": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to prevent the instance from spoofing another instance’s MAC address.",
+							"managed": "no",
+							"shortdesc": "Whether to prevent the instance from spoofing a MAC address",
+							"type": "bool"
+						}
+					},
+					{
+						"security.port_isolation": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to prevent the NIC from communicating with other NICs in the network that have port isolation enabled.",
+							"managed": "no",
+							"shortdesc": "Whether to respect port isolation",
+							"type": "bool"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "Set this option to `none` to remove the port from the default VLAN.",
+							"managed": "no",
+							"shortdesc": "VLAN ID to use for non-tagged traffic",
+							"type": "integer"
+						}
+					},
+					{
+						"vlan.tagged": {
+							"longdesc": "Specify the VLAN IDs or ranges as a comma-delimited list.",
+							"managed": "no",
+							"shortdesc": "VLAN IDs or VLAN ranges to join for tagged traffic",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-ipvlan": {
+			"device-conf": {
+				"keys": [
+					{
+						"gvrp": {
+							"defaultdesc": "`false`",
+							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
+							"type": "bool"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static addresses to add to the instance.\nIn `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/24`.",
+							"shortdesc": "IPv4 static addresses to add to the instance",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.gateway": {
+							"defaultdesc": "`auto` (`l3s`), `-` (`l2`)",
+							"longdesc": "In `l3s` mode, the option specifies whether to add an automatic default IPv4 gateway.\nPossible values are `auto` and `none`.\n\nIn `l2` mode, this option specifies the IPv4 address of the gateway.",
+							"shortdesc": "IPv4 gateway",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.host_table": {
+							"longdesc": "The custom policy routing table is in addition to the main routing table.",
+							"shortdesc": "Custom policy routing table ID to add IPv4 static routes to",
+							"type": "integer"
+						}
+					},
+					{
+						"ipv6.address": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static addresses to add to the instance.\nIn `l2` mode, you can specify them as CIDR values or singular addresses using a subnet of `/64`.",
+							"shortdesc": "IPv6 static addresses to add to the instance",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.gateway": {
+							"defaultdesc": "`auto` (`l3s`), `-` (`l2`)",
+							"longdesc": "In `l3s` mode, the option specifies whether to add an automatic default IPv6 gateway.\nPossible values are `auto` and `none`.\n\nIn `l2` mode, this option specifies the IPv6 address of the gateway.",
+							"shortdesc": "IPv6 gateway",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.host_table": {
+							"longdesc": "The custom policy routing table is in addition to the main routing table.",
+							"shortdesc": "Custom policy routing table ID to add IPv6 static routes to",
+							"type": "integer"
+						}
+					},
+					{
+						"mode": {
+							"defaultdesc": "`l3s`",
+							"longdesc": "Possible values are `l2` and `l3s`.",
+							"shortdesc": "IPVLAN mode",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"shortdesc": "The MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"required": "yes",
+							"shortdesc": "Name of the host device",
+							"type": "string"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-macvlan": {
+			"device-conf": {
+				"keys": [
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"managed": "no",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"gvrp": {
+							"defaultdesc": "`false`",
+							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"managed": "no",
+							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
+							"type": "bool"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv4 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv6 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "You can specify this option instead of specifying the `nictype` directly.",
+							"managed": "no",
+							"shortdesc": "Managed network to link the device to",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"managed": "yes",
+							"required": "if specifying the `nictype` directly",
+							"shortdesc": "Name of the host device",
+							"type": "string"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-ovn": {
+			"device-conf": {
+				"keys": [
+					{
+						"acceleration": {
+							"defaultdesc": "`none`",
+							"longdesc": "Possible values are `none`, `sriov`, or `vdpa`.\nSee {ref}`devices-nic-hw-acceleration` for more information.",
+							"managed": "no",
+							"shortdesc": "Enable hardware offloading",
+							"type": "string"
+						}
+					},
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"managed": "no",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"host_name": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the host",
+							"type": "string"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "IPv4 address to assign to the instance through DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes to route for this NIC.",
+							"managed": "no",
+							"shortdesc": "IPv4 static routes to route for the NIC",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes.external": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes to route to the NIC and publish on the uplink network.",
+							"managed": "no",
+							"shortdesc": "IPv4 static routes to route to NIC",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.address": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "IPv6 address to assign to the instance through DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes to route to the NIC.",
+							"managed": "no",
+							"shortdesc": "IPv6 static routes to route to the NIC",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes.external": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes to route to the NIC and publish on the uplink network.",
+							"managed": "no",
+							"shortdesc": "IPv6 static routes to route to NIC",
+							"type": "string"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"nested": {
+							"longdesc": "See also {config:option}`device-nic-ovn-device-conf:vlan`.",
+							"managed": "no",
+							"shortdesc": "Parent NIC name to nest this NIC under",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "",
+							"managed": "yes",
+							"required": "yes",
+							"shortdesc": "Managed network to link the device to",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls": {
+							"longdesc": "Specify a comma-separated list",
+							"managed": "no",
+							"shortdesc": "Network ACLs to apply",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.action": {
+							"defaultdesc": "`reject`",
+							"longdesc": "The specified action is used for all egress traffic that doesn’t match any ACL rule.",
+							"managed": "no",
+							"shortdesc": "Default action to use for egress traffic",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.logged": {
+							"defaultdesc": "`false`",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Whether to log egress traffic that doesn’t match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"security.acls.default.ingress.action": {
+							"defaultdesc": "`reject`",
+							"longdesc": "The specified action is used for all ingress traffic that doesn’t match any ACL rule.",
+							"managed": "no",
+							"shortdesc": "Default action to use for ingress traffic",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.ingress.logged": {
+							"defaultdesc": "`false`",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Whether to log ingress traffic that doesn’t match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "See also {config:option}`device-nic-ovn-device-conf:nested`.",
+							"managed": "no",
+							"shortdesc": "VLAN ID to use when nesting",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-p2p": {
+			"device-conf": {
+				"keys": [
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"host_name": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"shortdesc": "Name of the interface inside the host",
+							"type": "string"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host.",
+							"shortdesc": "IPv4 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host.",
+							"shortdesc": "IPv6 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"limits.egress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.ingress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for incoming traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.max": {
+							"longdesc": "This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.\n\nSpecify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for both incoming and outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.priority": {
+							"longdesc": "The `skb-\u003epriority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.\nSpecify the value as a 32-bit unsigned integer.\n\nThe effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.\nConsult the kernel qdisc documentation before setting this value.",
+							"shortdesc": "`skb-\u003epriority` value for outgoing traffic",
+							"type": "integer"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"queue.tx.length": {
+							"longdesc": "",
+							"shortdesc": "Transmit queue length for the NIC",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-physical": {
+			"device-conf": {
+				"keys": [
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"managed": "no",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"gvrp": {
+							"defaultdesc": "`false`",
+							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"managed": "no",
+							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
+							"type": "bool"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAAS IPv4 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAAS IPv6 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "You can specify this option instead of specifying the `nictype` directly.",
+							"managed": "no",
+							"shortdesc": "Managed network to link the device to",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"managed": "yes",
+							"required": "if specifying the `nictype` directly",
+							"shortdesc": "Name of the host device",
+							"type": "string"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-routed": {
+			"device-conf": {
+				"keys": [
+					{
+						"gvrp": {
+							"defaultdesc": "`false`",
+							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
+							"type": "bool"
+						}
+					},
+					{
+						"host_name": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"shortdesc": "Name of the interface inside the host",
+							"type": "string"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static addresses to add to the instance.",
+							"shortdesc": "IPv4 static addresses to add to the instance",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.gateway": {
+							"defaultdesc": "`auto`",
+							"longdesc": "Possible values are `auto` and `none`.",
+							"shortdesc": "Whether to add an automatic default IPv4 gateway",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.host_address": {
+							"defaultdesc": "`192.254.0.1`",
+							"longdesc": "",
+							"shortdesc": "IPv4 address to add to the host-side `veth` interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.host_table": {
+							"longdesc": "The custom policy routing table is in addition to the main routing table.",
+							"shortdesc": "Custom policy routing table ID to add IPv4 static routes to",
+							"type": "integer"
+						}
+					},
+					{
+						"ipv4.neighbor_probe": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to probe the parent network for IPv4 address availability",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv4 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).",
+							"shortdesc": "IPv4 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.address": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static addresses to add to the instance.",
+							"shortdesc": "IPv6 static addresses to add to the instance",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.gateway": {
+							"defaultdesc": "`auto`",
+							"longdesc": "Possible values are `auto` and `none`.",
+							"shortdesc": "Whether to add an automatic default IPv6 gateway",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.host_address": {
+							"defaultdesc": "`fe80::1`",
+							"longdesc": "",
+							"shortdesc": "IPv6 address to add to the host-side `veth` interface",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.host_table": {
+							"longdesc": "The custom policy routing table is in addition to the main routing table.",
+							"shortdesc": "Custom policy routing table ID to add IPv6 static routes to",
+							"type": "integer"
+						}
+					},
+					{
+						"ipv6.neighbor_probe": {
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to probe the parent network for IPv6 address availability",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"longdesc": "Specify a comma-delimited list of IPv6 static routes for this NIC to add on the host (without L2 ARP/NDP proxy).",
+							"shortdesc": "IPv6 static routes for the NIC to add on the host",
+							"type": "string"
+						}
+					},
+					{
+						"limits.egress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.ingress": {
+							"longdesc": "Specify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for incoming traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.max": {
+							"longdesc": "This option is the same as setting both {config:option}`device-nic-bridged-device-conf:limits.ingress` and {config:option}`device-nic-bridged-device-conf:limits.egress`.\n\nSpecify the limit in bit/s. Various suffixes are supported (see {ref}`instances-limit-units`).",
+							"shortdesc": "I/O limit for both incoming and outgoing traffic",
+							"type": "string"
+						}
+					},
+					{
+						"limits.priority": {
+							"longdesc": "The `skb-\u003epriority` value for outgoing traffic is used by the kernel queuing discipline (qdisc) to prioritize network packets.\nSpecify the value as a 32-bit unsigned integer.\n\nThe effect of this value depends on the particular qdisc implementation, for example, `SKBPRIO` or `QFQ`.\nConsult the kernel qdisc documentation before setting this value.",
+							"shortdesc": "`skb-\u003epriority` value for outgoing traffic",
+							"type": "integer"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "parent MTU",
+							"longdesc": "",
+							"shortdesc": "The MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"shortdesc": "Name of the host device to join the instance to",
+							"type": "string"
+						}
+					},
+					{
+						"queue.tx.length": {
+							"longdesc": "",
+							"shortdesc": "Transmit queue length for the NIC",
+							"type": "integer"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
+		"device-nic-sriov": {
+			"device-conf": {
+				"keys": [
+					{
+						"boot.priority": {
+							"longdesc": "A higher value for this option means that the VM boots first.",
+							"managed": "no",
+							"shortdesc": "Boot priority for VMs",
+							"type": "integer"
+						}
+					},
+					{
+						"hwaddr": {
+							"defaultdesc": "randomly assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "MAC address of the new interface",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv4 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MAAS IPv6 subnet to register the instance in",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "yes",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"name": {
+							"defaultdesc": "kernel assigned",
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "Name of the interface inside the instance",
+							"type": "string"
+						}
+					},
+					{
+						"network": {
+							"longdesc": "You can specify this option instead of specifying the `nictype` directly.",
+							"managed": "no",
+							"shortdesc": "Managed network to link the device to",
+							"type": "string"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"managed": "yes",
+							"required": "if specifying the `nictype` directly",
+							"shortdesc": "Name of the host device",
+							"type": "string"
+						}
+					},
+					{
+						"security.mac_filtering": {
+							"defaultdesc": "`false`",
+							"longdesc": "Set this option to `true` to prevent the instance from spoofing another instance’s MAC address.",
+							"managed": "no",
+							"shortdesc": "Whether to prevent the instance from spoofing a MAC address",
+							"type": "bool"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"managed": "no",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
 		"device-pci": {
 			"device-conf": {
 				"keys": [


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/jira/software/c/projects/LXD/boards/54?assignee=63d9eb6128cddcc70770aff1&selectedIssue=LXD-440

* [x] Annotate `nic` devices (this PR)
* [x] Annotate `disk` devices (see https://github.com/canonical/lxd/pull/13005)
* [x] Annotate `unix-{char,block,hotplug,usb}` devices (see https://github.com/canonical/lxd/pull/13007)
* [x] Annotate `gpu` devices (see https://github.com/canonical/lxd/pull/13008)
* [x] Annotate `infiniband` devices (see https://github.com/canonical/lxd/pull/13010)
* [x] Annotate `proxy` devices (see https://github.com/canonical/lxd/pull/13011)
* [x] Annotate `tpm` devices (see https://github.com/canonical/lxd/pull/13012)
* [x] Annotate `pci` devices (see https://github.com/canonical/lxd/pull/13013)

____

Searching for references in `/doc` (more precisely in `doc/*.md,doc/explanation/*.md,doc/howto/*.md,doc/reference/*.md,doc/tutorial/*.md`) of the form `[<key_name>](<section_name>)` to replace:

* [x] `nic` devices
* [x] `disk` devices
* [x] `unix-{char,block,hotplug,usb}` devices
* [x] `gpu` devices
* [x] `infiniband` devices
* [x] `proxy` devices
* [x] `tpm` devices
* [x] `pci` devices