### PR TITLE
Auth: Set OIDC relying party HTTP client to comply with proxy configuration.

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -1003,7 +1003,12 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			d.oidcVerifier = nil
 		} else {
 			var err error
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+
+			httpClientFunc := func() (*http.Client, error) {
+				return util.HTTPClient("", d.proxy)
+			}
+
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -600,19 +600,12 @@ func (o *Verifier) secureCookieFromSession(sessionID uuid.UUID) (*securecookie.S
 
 // Opts contains optional configurable fields for the Verifier.
 type Opts struct {
-	ConfigExpiryInterval time.Duration
-	GroupsClaim          string
+	GroupsClaim string
 }
 
 // NewVerifier returns a Verifier.
 func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, options *Opts) (*Verifier, error) {
-	opts := &Opts{
-		ConfigExpiryInterval: defaultConfigExpiryInterval,
-	}
-
-	if options != nil && options.ConfigExpiryInterval > 0 {
-		opts.ConfigExpiryInterval = options.ConfigExpiryInterval
-	}
+	opts := &Opts{}
 
 	if options != nil && options.GroupsClaim != "" {
 		opts.GroupsClaim = options.GroupsClaim
@@ -625,7 +618,7 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 		identityCache:        identityCache,
 		groupsClaim:          opts.GroupsClaim,
 		clusterCert:          clusterCert,
-		configExpiryInterval: opts.ConfigExpiryInterval,
+		configExpiryInterval: defaultConfigExpiryInterval,
 	}
 
 	return verifier, nil

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -359,6 +359,12 @@ func (*Verifier) IsRequest(r *http.Request) bool {
 	return false
 }
 
+// ExpireConfig sets the expiry time of the current configuration to zero. This forces the verifier to reconfigure the
+// relying party the next time a user authenticates.
+func (o *Verifier) ExpireConfig() {
+	o.configExpiry = time.Now()
+}
+
 // ensureConfig ensures that the relyingParty and accessTokenVerifier fields of the Verifier are non-nil. Additionally,
 // if the given host is different from the Verifier host we reset the relyingParty to ensure the callback URL is set
 // correctly.

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -47,11 +47,12 @@ type Verifier struct {
 	relyingParty        rp.RelyingParty
 	identityCache       *identity.Cache
 
-	clientID    string
-	issuer      string
-	audience    string
-	groupsClaim string
-	clusterCert func() *shared.CertInfo
+	clientID       string
+	issuer         string
+	audience       string
+	groupsClaim    string
+	clusterCert    func() *shared.CertInfo
+	httpClientFunc func() (*http.Client, error)
 
 	// host is used for setting a valid callback URL when setting the relyingParty.
 	// When creating the relyingParty, the OIDC library performs discovery (e.g. it calls the /well-known/oidc-configuration endpoint).
@@ -604,7 +605,7 @@ type Opts struct {
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, options *Opts) (*Verifier, error) {
+func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, httpClientFunc func() (*http.Client, error), options *Opts) (*Verifier, error) {
 	opts := &Opts{}
 
 	if options != nil && options.GroupsClaim != "" {
@@ -619,6 +620,7 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 		groupsClaim:          opts.GroupsClaim,
 		clusterCert:          clusterCert,
 		configExpiryInterval: defaultConfigExpiryInterval,
+		httpClientFunc:       httpClientFunc,
 	}
 
 	return verifier, nil

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -404,11 +404,17 @@ func (o *Verifier) setRelyingParty(host string) error {
 		return errors.New("Failed to generate a secure cookie hash key")
 	}
 
+	httpClient, err := o.httpClientFunc()
+	if err != nil {
+		return fmt.Errorf("Failed to get a HTTP client: %w", err)
+	}
+
 	cookieHandler := httphelper.NewCookieHandler(cookieHashKey, cookieBlockKey)
 	options := []rp.Option{
 		rp.WithCookieHandler(cookieHandler),
 		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
 		rp.WithPKCE(cookieHandler),
+		rp.WithHTTPClient(httpClient),
 	}
 
 	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1434,7 +1434,11 @@ func (d *Daemon) init() error {
 
 	// Setup OIDC authentication.
 	if oidcIssuer != "" && oidcClientID != "" {
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		httpClientFunc := func() (*http.Client, error) {
+			return util.HTTPClient("", d.proxy)
+		}
+
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -45,4 +45,8 @@ func daemonConfigSetProxy(d *Daemon, config *clusterConfig.Config) {
 		config.ProxyHTTP(),
 		config.ProxyIgnoreHosts(),
 	)
+
+	if d.oidcVerifier != nil {
+		d.oidcVerifier.ExpireConfig()
+	}
 }


### PR DESCRIPTION
The HTTP requests that are performed as part of OIDC discovery and authentication should comply with the `core.proxy_http(s)` settings. This PR adds a `httpClientFunc` field to the OIDC verifier so that it can get a fresh HTTP client when it refreshes it's config. The caller is responsible for passing in a `httpClientFunc` that returns a client that will correctly proxy requests.

To ensure the verifier is updated when the proxy settings are applied, a new `ForceConfgRefresh` method is exported. This method sets the config expiry to zero so that a new HTTP client will be used for the next call.