### PR TITLE
VM: Don't leak file descriptor when probing for Direct I/O support (stable-5.0)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3442,9 +3442,11 @@ func (d *qemu) addDriveConfig(bootIndexes map[string]int, driveConf deviceConfig
 			} else {
 				// Use host cache, with neither O_DSYNC nor O_DIRECT semantics if filesystem
 				// doesn't support Direct I/O.
-				_, err := os.OpenFile(srcDevPath, unix.O_DIRECT|unix.O_RDONLY, 0)
+				f, err := os.OpenFile(srcDevPath, unix.O_DIRECT|unix.O_RDONLY, 0)
 				if err != nil {
 					cacheMode = "writeback"
+				} else {
+					_ = f.Close() // Don't leak FD.
 				}
 			}
 


### PR DESCRIPTION
Fixes #12808

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit d0b991dca948d400b31f724a5d4ea6b274bf6763)