### PR TITLE
Improve GPU SR-IOV allocation - from Incus

### DIFF
--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -81,15 +81,15 @@ func (d *gpuSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}
 	saveData := make(map[string]string)
 
+	// Get global SR-IOV lock to prevent concurent allocations of the VF.
+	sriovMu.Lock()
+	defer sriovMu.Unlock()
+
 	// Make sure that vfio-pci is loaded.
 	err = util.LoadModule("vfio-pci")
 	if err != nil {
 		return nil, fmt.Errorf("Error loading %q module: %w", "vfio-pci", err)
 	}
-
-	// Get global SR-IOV lock to prevent concurent allocations of the VF.
-	sriovMu.Lock()
-	defer sriovMu.Unlock()
 
 	// Get SRIOV VF.
 	parentPCIAddress, vfID, err := d.getVF()

--- a/lxd/device/gpu_sriov.go
+++ b/lxd/device/gpu_sriov.go
@@ -85,6 +85,12 @@ func (d *gpuSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}
 	saveData := make(map[string]string)
 
+	// Make sure that vfio-pci is loaded.
+	err = util.LoadModule("vfio-pci")
+	if err != nil {
+		return nil, fmt.Errorf("Error loading %q module: %w", "vfio-pci", err)
+	}
+
 	// Get global SR-IOV lock to prevent concurent allocations of the VF.
 	sriovMu.Lock()
 	defer sriovMu.Unlock()
@@ -98,12 +104,6 @@ func (d *gpuSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	var parentPCIAddress string
 	var pciParentDev pcidev.Device
 	vfID := -1
-
-	// Make sure that vfio-pci is loaded.
-	err = util.LoadModule("vfio-pci")
-	if err != nil {
-		return nil, fmt.Errorf("Error loading %q module: %w", "vfio-pci", err)
-	}
 
 	// Since there might be multiple GPUs, we iterate through them and get the first free
 	// virtual function.


### PR DESCRIPTION
From https://github.com/lxc/incus/issues/531

> When using SR-IOV or mdev GPUs and more than one card matches the specification, we should be picking from whatever card has the most currently available VFs/mdev rather than the first matching non-full card.

