### PR TITLE
lxd-metadata: Annotate codebase for `tpm` device config keys

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -179,6 +179,24 @@ You can omit the `MIG-` prefix when specifying this option.
 ```
 
 <!-- config group device-pci-device-conf end -->
+<!-- config group device-tpm-device-conf start -->
+```{config:option} path device-tpm-device-conf
+:condition: "containers"
+:required: "for containers"
+:shortdesc: "Path inside the container"
+:type: "string"
+For example: `/dev/tpm0`
+```
+
+```{config:option} pathrm device-tpm-device-conf
+:condition: "containers"
+:required: "for containers"
+:shortdesc: "Resource manager path inside the container"
+:type: "string"
+For example: `/dev/tpmrm0`
+```
+
+<!-- config group device-tpm-device-conf end -->
 <!-- config group device-unix-block-device-conf start -->
 ```{config:option} gid device-unix-block-device-conf
 :defaultdesc: "`0`"

--- a/doc/reference/devices_tpm.md
+++ b/doc/reference/devices_tpm.md
@@ -22,7 +22,8 @@ For virtual machines, TPM can be used both for sealing certificates and for vali
 
 `tpm` devices have the following device options:
 
-Key                 | Type      | Default   | Required       | Description
-:--                 | :--       | :--       | :--            | :--
-`path`              | string    | -         | for containers | Only for containers: path inside the instance (for example, `/dev/tpm0`)
-`pathrm`            | string    | -         | for containers | Only for containers: resource manager path inside the instance (for example, `/dev/tpmrm0`)
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group device-tpm-device-conf start -->
+    :end-before: <!-- config group device-tpm-device-conf end -->
+```

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -36,6 +36,21 @@ func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 
 	rules := map[string]func(string) error{}
 
+	// lxdmeta:generate(entities=device-tpm; group=device-conf; key=path)
+	// For example: `/dev/tpm0`
+	// ---
+	//  type: string
+	//  required: for containers
+	//  condition: containers
+	//  shortdesc: Path inside the container
+
+	// lxdmeta:generate(entities=device-tpm; group=device-conf; key=pathrm)
+	// For example: `/dev/tpmrm0`
+	// ---
+	//  type: string
+	//  required: for containers
+	//  condition: containers
+	//  shortdesc: Resource manager path inside the container
 	if instConf.Type() == instancetype.Container {
 		rules["path"] = validate.IsNotEmpty
 		rules["pathrm"] = validate.IsNotEmpty

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -228,6 +228,30 @@
 				]
 			}
 		},
+		"device-tpm": {
+			"device-conf": {
+				"keys": [
+					{
+						"path": {
+							"condition": "containers",
+							"longdesc": "For example: `/dev/tpm0`",
+							"required": "for containers",
+							"shortdesc": "Path inside the container",
+							"type": "string"
+						}
+					},
+					{
+						"pathrm": {
+							"condition": "containers",
+							"longdesc": "For example: `/dev/tpmrm0`",
+							"required": "for containers",
+							"shortdesc": "Resource manager path inside the container",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"device-unix-block": {
 			"device-conf": {
 				"keys": [


### PR DESCRIPTION
See the root PR https://github.com/canonical/lxd/pull/12984 for a summary