### PR TITLE
API: Ensure request project name isn't passed to storage layer directly when copying/refreshing volumes

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -842,8 +842,6 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 }
 
 func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
-	var run func(op *operations.Operation) error
-
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
@@ -859,7 +857,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		return response.SmartError(err)
 	}
 
-	run = func(op *operations.Operation) error {
+	run := func(op *operations.Operation) error {
 		if req.Source.Name == "" {
 			// Use an empty operation for this sync response to pass the requestor
 			op := &operations.Operation{}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -811,14 +811,12 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 }
 
 func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
-	var run func(op *operations.Operation) error
-
 	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	run = func(op *operations.Operation) error {
+	run := func(op *operations.Operation) error {
 		revert := revert.New()
 		defer revert.Fail()
 

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -816,6 +816,14 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 		return response.SmartError(err)
 	}
 
+	var srcProjectName string
+	if req.Source.Project != "" {
+		srcProjectName, err = project.StorageVolumeProject(s.DB.Cluster, req.Source.Project, cluster.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	run := func(op *operations.Operation) error {
 		revert := revert.New()
 		defer revert.Fail()
@@ -824,7 +832,7 @@ func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName s
 			return fmt.Errorf("No source volume name supplied")
 		}
 
-		err = pool.RefreshCustomVolume(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		err = pool.RefreshCustomVolume(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -855,6 +855,14 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		return response.SmartError(err)
 	}
 
+	var srcProjectName string
+	if req.Source.Project != "" {
+		srcProjectName, err = project.StorageVolumeProject(s.DB.Cluster, req.Source.Project, cluster.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	volumeDBContentType, err := storagePools.VolumeContentTypeNameToContentType(req.ContentType)
 	if err != nil {
 		return response.SmartError(err)
@@ -873,7 +881,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 			return pool.CreateCustomVolume(projectName, req.Name, req.Description, req.Config, contentType, op)
 		}
 
-		return pool.CreateCustomVolumeFromCopy(projectName, req.Source.Project, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
+		return pool.CreateCustomVolumeFromCopy(projectName, srcProjectName, req.Name, req.Description, req.Config, req.Source.Pool, req.Source.Name, !req.Source.VolumeOnly, op)
 	}
 
 	// If no source name supplied then this a volume create operation.


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/security/code-scanning/147

Was not an actual security issue though because the storage subsystem tried to load the volume record from the DB and was failing with:

```
Error: Failed generating volume refresh config: Storage volume "vol1" in project "foo2" of type "custom" does not exist on pool "default": Storage volume not found
```

So the raw request was never passed to the storage layer directly.
However this was a bug which is now fixed.