### PR TITLE
lxd-metadata: Annotate codebase for `bridge` network config keys

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2517,6 +2517,463 @@ It is globally unique across all servers and projects.
 ```
 
 <!-- config group instance-volatile end -->
+<!-- config group network-bridge-network-conf start -->
+```{config:option} bgp.ipv4.nexthop network-bridge-network-conf
+:condition: "BGP server"
+:defaultdesc: "local address"
+:shortdesc: "Override the IPv4 next-hop for advertised prefixes"
+:type: "string"
+
+```
+
+```{config:option} bgp.ipv6.nexthop network-bridge-network-conf
+:condition: "BGP server"
+:defaultdesc: "local address"
+:shortdesc: "Override the IPv6 next-hop for advertised prefixes"
+:type: "string"
+
+```
+
+```{config:option} bgp.peers.NAME.address network-bridge-network-conf
+:condition: "BGP server"
+:shortdesc: "Peer address (IPv4 or IPv6)"
+:type: "string"
+
+```
+
+```{config:option} bgp.peers.NAME.asn network-bridge-network-conf
+:condition: "BGP server"
+:shortdesc: "Peer AS number"
+:type: "integer"
+
+```
+
+```{config:option} bgp.peers.NAME.holdtime network-bridge-network-conf
+:condition: "BGP server"
+:defaultdesc: "`180`"
+:required: "no"
+:shortdesc: "Peer session hold time"
+:type: "integer"
+Specify the hold time in seconds.
+```
+
+```{config:option} bgp.peers.NAME.password network-bridge-network-conf
+:condition: "BGP server"
+:defaultdesc: "(no password)"
+:required: "no"
+:shortdesc: "Peer session password"
+:type: "string"
+
+```
+
+```{config:option} bridge.driver network-bridge-network-conf
+:defaultdesc: "`native`"
+:shortdesc: "Bridge driver"
+:type: "string"
+Possible values are `native` and `openvswitch`.
+```
+
+```{config:option} bridge.external_interfaces network-bridge-network-conf
+:shortdesc: "Unconfigured network interfaces to include in the bridge"
+:type: "string"
+Specify a comma-separated list of unconfigured network interfaces to include in the bridge.
+```
+
+```{config:option} bridge.hwaddr network-bridge-network-conf
+:shortdesc: "MAC address for the bridge"
+:type: "string"
+
+```
+
+```{config:option} bridge.mode network-bridge-network-conf
+:defaultdesc: "`standard`"
+:shortdesc: "Bridge operation mode"
+:type: "string"
+Possible values are `standard` and `fan`.
+```
+
+```{config:option} bridge.mtu network-bridge-network-conf
+:defaultdesc: "`1500` if `bridge.mode=standard`, `1480` if `bridge.mode=fan` and `fan.type=ipip`, or `1450` if `bridge.mode=fan` and `fan.type=vxlan`"
+:shortdesc: "Bridge MTU"
+:type: "integer"
+The default value varies depending on whether the bridge uses a tunnel or a fan setup.
+```
+
+```{config:option} dns.domain network-bridge-network-conf
+:defaultdesc: "`lxd`"
+:shortdesc: "Domain to advertise to DHCP clients and use for DNS resolution"
+:type: "string"
+
+```
+
+```{config:option} dns.mode network-bridge-network-conf
+:defaultdesc: "`managed`"
+:shortdesc: "DNS registration mode"
+:type: "string"
+Possible values are `none` for no DNS record, `managed` for LXD-generated static records, and `dynamic` for client-generated records.
+```
+
+```{config:option} dns.search network-bridge-network-conf
+:defaultdesc: "`dns.domain` value"
+:shortdesc: "Full domain search list"
+:type: "string"
+Specify a comma-separated list of domains.
+```
+
+```{config:option} dns.zone.forward network-bridge-network-conf
+:shortdesc: "DNS zone names for forward DNS records"
+:type: "string"
+Specify a comma-separated list of DNS zone names.
+```
+
+```{config:option} dns.zone.reverse.ipv4 network-bridge-network-conf
+:shortdesc: "DNS zone name for IPv4 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} dns.zone.reverse.ipv6 network-bridge-network-conf
+:shortdesc: "DNS zone name for IPv6 reverse DNS records"
+:type: "string"
+
+```
+
+```{config:option} fan.overlay_subnet network-bridge-network-conf
+:condition: "fan mode"
+:defaultdesc: "`240.0.0.0/8`"
+:shortdesc: "Subnet to use as the overlay for the FAN"
+:type: "string"
+Use CIDR notation.
+```
+
+```{config:option} fan.type network-bridge-network-conf
+:condition: "fan mode"
+:defaultdesc: "`vxlan`"
+:shortdesc: "Tunneling type for the FAN"
+:type: "string"
+Possible values are `vxlan` and `ipip`.
+```
+
+```{config:option} fan.underlay_subnet network-bridge-network-conf
+:condition: "fan mode"
+:defaultdesc: "initial value on creation: `auto`"
+:shortdesc: "Subnet to use as the underlay for the FAN"
+:type: "string"
+Use CIDR notation.
+
+You can set the option to `auto` to use the default gateway subnet.
+```
+
+```{config:option} ipv4.address network-bridge-network-conf
+:condition: "standard mode"
+:defaultdesc: "initial value on creation: `auto`"
+:shortdesc: "IPv4 address for the bridge"
+:type: "string"
+Use CIDR notation.
+
+You can set the option to `none` to turn off IPv4, or to `auto` to generate a new random unused subnet.
+```
+
+```{config:option} ipv4.dhcp network-bridge-network-conf
+:condition: "IPv4 address"
+:defaultdesc: "`true`"
+:shortdesc: "Whether to allocate IPv4 addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.dhcp.expiry network-bridge-network-conf
+:condition: "IPv4 DHCP"
+:defaultdesc: "`1h`"
+:shortdesc: "When to expire DHCP leases"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.gateway network-bridge-network-conf
+:condition: "IPv4 DHCP"
+:defaultdesc: "IPv4 address"
+:shortdesc: "Address of the gateway for the IPv4 subnet"
+:type: "string"
+
+```
+
+```{config:option} ipv4.dhcp.ranges network-bridge-network-conf
+:condition: "IPv4 DHCP"
+:defaultdesc: "all addresses"
+:shortdesc: "IPv4 ranges to use for DHCP"
+:type: "string"
+Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
+```
+
+```{config:option} ipv4.firewall network-bridge-network-conf
+:condition: "IPv4 address"
+:defaultdesc: "`true`"
+:shortdesc: "Whether to generate filtering firewall rules for this network"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat network-bridge-network-conf
+:condition: "IPv4 address"
+:defaultdesc: "`false` (initial value on creation if `ipv4.address` is set to `auto`: `true`)"
+:shortdesc: "Whether to use NAT for IPv4"
+:type: "bool"
+
+```
+
+```{config:option} ipv4.nat.address network-bridge-network-conf
+:condition: "IPv4 address"
+:shortdesc: "Source address used for outbound traffic from the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv4.nat.order network-bridge-network-conf
+:condition: "IPv4 address"
+:defaultdesc: "`before`"
+:shortdesc: "Where to add the required NAT rules"
+:type: "string"
+Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
+```
+
+```{config:option} ipv4.ovn.ranges network-bridge-network-conf
+:shortdesc: "IPv4 ranges to use for child OVN network routers"
+:type: "string"
+Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
+```
+
+```{config:option} ipv4.routes network-bridge-network-conf
+:condition: "IPv4 address"
+:shortdesc: "Additional IPv4 CIDR subnets to route to the bridge"
+:type: "string"
+Specify a comma-separated list of IPv4 CIDR subnets.
+```
+
+```{config:option} ipv4.routing network-bridge-network-conf
+:condition: "IPv4 address"
+:defaultdesc: "`true`"
+:shortdesc: "Whether to route IPv4 traffic in and out of the bridge"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.address network-bridge-network-conf
+:condition: "standard mode"
+:defaultdesc: "initial value on creation: `auto`"
+:shortdesc: "IPv6 address for the bridge"
+:type: "string"
+Use CIDR notation.
+
+You can set the option to `none` to turn off IPv6, or to `auto` to generate a new random unused subnet.
+```
+
+```{config:option} ipv6.dhcp network-bridge-network-conf
+:condition: "IPv6 address"
+:defaultdesc: "`true`"
+:shortdesc: "Whether to provide additional network configuration over DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.dhcp.expiry network-bridge-network-conf
+:condition: "IPv6 DHCP"
+:defaultdesc: "`1h`"
+:shortdesc: "When to expire DHCP leases"
+:type: "string"
+
+```
+
+```{config:option} ipv6.dhcp.ranges network-bridge-network-conf
+:condition: "IPv6 stateful DHCP"
+:defaultdesc: "all addresses"
+:shortdesc: "IPv6 ranges to use for DHCP"
+:type: "string"
+Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
+```
+
+```{config:option} ipv6.dhcp.stateful network-bridge-network-conf
+:condition: "IPv6 DHCP"
+:defaultdesc: "`false`"
+:shortdesc: "Whether to allocate IPv6 addresses using DHCP"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.firewall network-bridge-network-conf
+:condition: "IPv6 DHCP"
+:defaultdesc: "`true`"
+:shortdesc: "Whether to generate filtering firewall rules for this network"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat network-bridge-network-conf
+:condition: "IPv6 address"
+:defaultdesc: "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)"
+:shortdesc: "Whether to use NAT for IPv6"
+:type: "bool"
+
+```
+
+```{config:option} ipv6.nat.address network-bridge-network-conf
+:condition: "IPv6 address"
+:shortdesc: "Source address used for outbound traffic from the bridge"
+:type: "string"
+
+```
+
+```{config:option} ipv6.nat.order network-bridge-network-conf
+:condition: "IPv6 address"
+:defaultdesc: "`before`"
+:shortdesc: "Where to add the required NAT rules"
+:type: "string"
+Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
+```
+
+```{config:option} ipv6.ovn.ranges network-bridge-network-conf
+:shortdesc: "IPv6 ranges to use for child OVN network routers"
+:type: "string"
+Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
+```
+
+```{config:option} ipv6.routes network-bridge-network-conf
+:condition: "IPv6 address"
+:shortdesc: "Additional IPv6 CIDR subnets to route to the bridge"
+:type: "string"
+Specify a comma-separated list of IPv6 CIDR subnets.
+```
+
+```{config:option} ipv6.routing network-bridge-network-conf
+:condition: "IPv6 address"
+:shortdesc: "Whether to route IPv6 traffic in and out of the bridge"
+:type: "bool"
+
+```
+
+```{config:option} maas.subnet.ipv4 network-bridge-network-conf
+:condition: "IPv4 address; using the `network` property on the NIC"
+:shortdesc: "MAAS IPv4 subnet to register instances in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 network-bridge-network-conf
+:condition: "IPv6 address; using the `network` property on the NIC"
+:shortdesc: "MAAS IPv6 subnet to register instances in"
+:type: "string"
+
+```
+
+```{config:option} raw.dnsmasq network-bridge-network-conf
+:shortdesc: "Additional `dnsmasq` configuration to append to the configuration file"
+:type: "string"
+
+```
+
+```{config:option} security.acls network-bridge-network-conf
+:shortdesc: "Network ACLs to apply to NICs connected to this network"
+:type: "string"
+Specify a comma-separated list of network ACLs.
+
+Also see {ref}`network-acls-bridge-limitations`.
+```
+
+```{config:option} security.acls.default.egress.action network-bridge-network-conf
+:condition: "`security.acls`"
+:shortdesc: "Default action to use for egress traffic"
+:type: "string"
+The specified action is used for all egress traffic that doesn’t match any ACL rule.
+```
+
+```{config:option} security.acls.default.egress.logged network-bridge-network-conf
+:condition: "`security.acls`"
+:shortdesc: "Whether to log egress traffic that doesn’t match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} security.acls.default.ingress.action network-bridge-network-conf
+:condition: "`security.acls`"
+:shortdesc: "Default action to use for ingress traffic"
+:type: "string"
+The specified action is used for all ingress traffic that doesn’t match any ACL rule.
+```
+
+```{config:option} security.acls.default.ingress.logged network-bridge-network-conf
+:condition: "`security.acls`"
+:shortdesc: "Whether to log ingress traffic that doesn’t match any ACL rule"
+:type: "bool"
+
+```
+
+```{config:option} tunnel.NAME.group network-bridge-network-conf
+:condition: "`vxlan`"
+:shortdesc: "Multicast address for `vxlan`"
+:type: "string"
+This address is used if {config:option}`network-bridge-network-conf:tunnel.NAME.local` and {config:option}`network-bridge-network-conf:tunnel.NAME.remote` aren’t set.
+```
+
+```{config:option} tunnel.NAME.id network-bridge-network-conf
+:condition: "`vxlan`"
+:shortdesc: "Specific tunnel ID to use for the `vxlan` tunnel"
+:type: "integer"
+
+```
+
+```{config:option} tunnel.NAME.interface network-bridge-network-conf
+:condition: "`vxlan`"
+:shortdesc: "Specific host interface to use for the tunnel"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.local network-bridge-network-conf
+:condition: "`gre` or `vxlan`"
+:required: "not required for multicast `vxlan`"
+:shortdesc: "Local address for the tunnel"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.port network-bridge-network-conf
+:condition: "`vxlan`"
+:defaultdesc: "`0`"
+:shortdesc: "Specific port to use for the `vxlan` tunnel"
+:type: "integer"
+
+```
+
+```{config:option} tunnel.NAME.protocol network-bridge-network-conf
+:condition: "standard mode"
+:shortdesc: "Tunneling protocol"
+:type: "string"
+Possible values are `vxlan` and `gre`.
+```
+
+```{config:option} tunnel.NAME.remote network-bridge-network-conf
+:condition: "`gre` or `vxlan`"
+:required: "not required for multicast `vxlan`"
+:shortdesc: "Remote address for the tunnel"
+:type: "string"
+
+```
+
+```{config:option} tunnel.NAME.ttl network-bridge-network-conf
+:condition: "`vxlan`"
+:defaultdesc: "`1`"
+:shortdesc: "Specific TTL to use for multicast routing topologies"
+:type: "string"
+
+```
+
+```{config:option} user.* network-bridge-network-conf
+:shortdesc: "User-provided free-form key/value pairs"
+:type: "string"
+
+```
+
+<!-- config group network-bridge-network-conf end -->
 <!-- config group network-macvlan-network-conf start -->
 ```{config:option} gvrp network-macvlan-network-conf
 :defaultdesc: "`false`"

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -58,69 +58,11 @@ The following configuration key namespaces are currently supported for the `brid
 
 The following configuration options are available for the `bridge` network type:
 
-Key                                  | Type      | Condition             | Default                   | Description
-:--                                  | :--       | :--                   | :--                       | :--
-`bgp.peers.NAME.address`             | string    | BGP server            | -                         | Peer address (IPv4 or IPv6)
-`bgp.peers.NAME.asn`                 | integer   | BGP server            | -                         | Peer AS number
-`bgp.peers.NAME.password`            | string    | BGP server            | - (no password)           | Peer session password (optional)
-`bgp.peers.NAME.holdtime`            | integer   | BGP server            | `180`                     | Peer session hold time (in seconds; optional)
-`bgp.ipv4.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
-`bgp.ipv6.nexthop`                   | string    | BGP server            | local address             | Override the next-hop for advertised prefixes
-`bridge.driver`                      | string    | -                     | `native`                  | Bridge driver: `native` or `openvswitch`
-`bridge.external_interfaces`         | string    | -                     | -                         | Comma-separated list of unconfigured network interfaces to include in the bridge
-`bridge.hwaddr`                      | string    | -                     | -                         | MAC address for the bridge
-`bridge.mode`                        | string    | -                     | `standard`                | Bridge operation mode: `standard` or `fan`
-`bridge.mtu`                         | integer   | -                     | `1500`                    | Bridge MTU (default varies if tunnel or fan setup)
-`dns.domain`                         | string    | -                     | `lxd`                     | Domain to advertise to DHCP clients and use for DNS resolution
-`dns.mode`                           | string    | -                     | `managed`                 | DNS registration mode: `none` for no DNS record, `managed` for LXD-generated static records or `dynamic` for client-generated records
-`dns.search`                         | string    | -                     | -                         | Full comma-separated domain search list, defaulting to `dns.domain` value
-`dns.zone.forward`                   | string    | -                     | `managed`                 | Comma-separated list of DNS zone names for forward DNS records
-`dns.zone.reverse.ipv4`              | string    | -                     | `managed`                 | DNS zone name for IPv4 reverse DNS records
-`dns.zone.reverse.ipv6`              | string    | -                     | `managed`                 | DNS zone name for IPv6 reverse DNS records
-`fan.overlay_subnet`                 | string    | fan mode              | `240.0.0.0/8`             | Subnet to use as the overlay for the FAN (CIDR)
-`fan.type`                           | string    | fan mode              | `vxlan`                   | Tunneling type for the FAN: `vxlan` or `ipip`
-`fan.underlay_subnet`                | string    | fan mode              | `auto` (on create only)   | Subnet to use as the underlay for the FAN (use `auto` to use default gateway subnet) (CIDR)
-`ipv4.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv4 address for the bridge (use `none` to turn off IPv4 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv4.dhcp`                          | bool      | IPv4 address          | `true`                    | Whether to allocate addresses using DHCP
-`ipv4.dhcp.expiry`                   | string    | IPv4 DHCP             | `1h`                      | When to expire DHCP leases
-`ipv4.dhcp.gateway`                  | string    | IPv4 DHCP             | IPv4 address              | Address of the gateway for the subnet
-`ipv4.dhcp.ranges`                   | string    | IPv4 DHCP             | all addresses             | Comma-separated list of IP ranges to use for DHCP (FIRST-LAST format)
-`ipv4.firewall`                      | bool      | IPv4 address          | `true`                    | Whether to generate filtering firewall rules for this network
-`ipv4.nat`                           | bool      | IPv4 address          | `false` (initial value on creation if `ipv4.address` is set to `auto`: `true`) | Whether to NAT
-`ipv4.nat.address`                   | string    | IPv4 address          | -                         | The source address used for outbound traffic from the bridge
-`ipv4.nat.order`                     | string    | IPv4 address          | `before`                  | Whether to add the required NAT rules before or after any pre-existing rules
-`ipv4.ovn.ranges`                    | string    | -                     | -                         | Comma-separated list of IPv4 ranges to use for child OVN network routers (FIRST-LAST format)
-`ipv4.routes`                        | string    | IPv4 address          | -                         | Comma-separated list of additional IPv4 CIDR subnets to route to the bridge
-`ipv4.routing`                       | bool      | IPv4 address          | `true`                    | Whether to route traffic in and out of the bridge
-`ipv6.address`                       | string    | standard mode         | - (initial value on creation: `auto`) | IPv6 address for the bridge (use `none` to turn off IPv6 or `auto` to generate a new random unused subnet) (CIDR)
-`ipv6.dhcp`                          | bool      | IPv6 address          | `true`                    | Whether to provide additional network configuration over DHCP
-`ipv6.dhcp.expiry`                   | string    | IPv6 DHCP             | `1h`                      | When to expire DHCP leases
-`ipv6.dhcp.ranges`                   | string    | IPv6 stateful DHCP    | all addresses             | Comma-separated list of IPv6 ranges to use for DHCP (FIRST-LAST format)
-`ipv6.dhcp.stateful`                 | bool      | IPv6 DHCP             | `false`                   | Whether to allocate addresses using DHCP
-`ipv6.firewall`                      | bool      | IPv6 address          | `true`                    | Whether to generate filtering firewall rules for this network
-`ipv6.nat`                           | bool      | IPv6 address          | `false` (initial value on creation if `ipv6.address` is set to `auto`: `true`) | Whether to NAT
-`ipv6.nat.address`                   | string    | IPv6 address          | -                         | The source address used for outbound traffic from the bridge
-`ipv6.nat.order`                     | string    | IPv6 address          | `before`                  | Whether to add the required NAT rules before or after any pre-existing rules
-`ipv6.ovn.ranges`                    | string    | -                     | -                         | Comma-separated list of IPv6 ranges to use for child OVN network routers (FIRST-LAST format)
-`ipv6.routes`                        | string    | IPv6 address          | -                         | Comma-separated list of additional IPv6 CIDR subnets to route to the bridge
-`ipv6.routing`                       | bool      | IPv6 address          | `true`                    | Whether to route traffic in and out of the bridge
-`maas.subnet.ipv4`                   | string    | IPv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on NIC)
-`maas.subnet.ipv6`                   | string    | IPv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on NIC)
-`raw.dnsmasq`                        | string    | -                     | -                         | Additional `dnsmasq` configuration to append to the configuration file
-`security.acls`                      | string    | -                     | -                         | Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)
-`security.acls.default.egress.action`| string    | `security.acls`       | `reject`                  | Action to use for egress traffic that doesn't match any ACL rule
-`security.acls.default.egress.logged`| bool      | `security.acls`       | `false`                   | Whether to log egress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.action`| string    | `security.acls`      | `reject`                  | Action to use for ingress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.logged`| bool      | `security.acls`      | `false`                   | Whether to log ingress traffic that doesn't match any ACL rule
-`tunnel.NAME.group`                  | string    | `vxlan`               | `239.0.0.1`               | Multicast address for `vxlan` (used if local and remote aren't set)
-`tunnel.NAME.id`                     | integer   | `vxlan`               | `0`                       | Specific tunnel ID to use for the `vxlan` tunnel
-`tunnel.NAME.interface`              | string    | `vxlan`               | -                         | Specific host interface to use for the tunnel
-`tunnel.NAME.local`                  | string    | `gre` or `vxlan`      | -                         | Local address for the tunnel (not necessary for multicast `vxlan`)
-`tunnel.NAME.port`                   | integer   | `vxlan`               | `0`                       | Specific port to use for the `vxlan` tunnel
-`tunnel.NAME.protocol`               | string    | standard mode         | -                         | Tunneling protocol: `vxlan` or `gre`
-`tunnel.NAME.remote`                 | string    | `gre` or `vxlan`      | -                         | Remote address for the tunnel (not necessary for multicast `vxlan`)
-`tunnel.NAME.ttl`                    | integer   | `vxlan`               | `1`                       | Specific TTL to use for multicast routing topologies
-`user.*`                             | string    | -                     | -                         | User-provided free-form key/value pairs
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group network-bridge-network-conf start -->
+    :end-before: <!-- config group network-bridge-network-conf end -->
+```
 
 (network-bridge-features)=
 ## Supported features

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2850,6 +2850,520 @@
 				]
 			}
 		},
+		"network-bridge": {
+			"network-conf": {
+				"keys": [
+					{
+						"bgp.ipv4.nexthop": {
+							"condition": "BGP server",
+							"defaultdesc": "local address",
+							"longdesc": "",
+							"shortdesc": "Override the IPv4 next-hop for advertised prefixes",
+							"type": "string"
+						}
+					},
+					{
+						"bgp.ipv6.nexthop": {
+							"condition": "BGP server",
+							"defaultdesc": "local address",
+							"longdesc": "",
+							"shortdesc": "Override the IPv6 next-hop for advertised prefixes",
+							"type": "string"
+						}
+					},
+					{
+						"bgp.peers.NAME.address": {
+							"condition": "BGP server",
+							"longdesc": "",
+							"shortdesc": "Peer address (IPv4 or IPv6)",
+							"type": "string"
+						}
+					},
+					{
+						"bgp.peers.NAME.asn": {
+							"condition": "BGP server",
+							"longdesc": "",
+							"shortdesc": "Peer AS number",
+							"type": "integer"
+						}
+					},
+					{
+						"bgp.peers.NAME.holdtime": {
+							"condition": "BGP server",
+							"defaultdesc": "`180`",
+							"longdesc": "Specify the hold time in seconds.",
+							"required": "no",
+							"shortdesc": "Peer session hold time",
+							"type": "integer"
+						}
+					},
+					{
+						"bgp.peers.NAME.password": {
+							"condition": "BGP server",
+							"defaultdesc": "(no password)",
+							"longdesc": "",
+							"required": "no",
+							"shortdesc": "Peer session password",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.driver": {
+							"defaultdesc": "`native`",
+							"longdesc": "Possible values are `native` and `openvswitch`.",
+							"shortdesc": "Bridge driver",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.external_interfaces": {
+							"longdesc": "Specify a comma-separated list of unconfigured network interfaces to include in the bridge.",
+							"shortdesc": "Unconfigured network interfaces to include in the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.hwaddr": {
+							"longdesc": "",
+							"shortdesc": "MAC address for the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.mode": {
+							"defaultdesc": "`standard`",
+							"longdesc": "Possible values are `standard` and `fan`.",
+							"shortdesc": "Bridge operation mode",
+							"type": "string"
+						}
+					},
+					{
+						"bridge.mtu": {
+							"defaultdesc": "`1500` if `bridge.mode=standard`, `1480` if `bridge.mode=fan` and `fan.type=ipip`, or `1450` if `bridge.mode=fan` and `fan.type=vxlan`",
+							"longdesc": "The default value varies depending on whether the bridge uses a tunnel or a fan setup.",
+							"shortdesc": "Bridge MTU",
+							"type": "integer"
+						}
+					},
+					{
+						"dns.domain": {
+							"defaultdesc": "`lxd`",
+							"longdesc": "",
+							"shortdesc": "Domain to advertise to DHCP clients and use for DNS resolution",
+							"type": "string"
+						}
+					},
+					{
+						"dns.mode": {
+							"defaultdesc": "`managed`",
+							"longdesc": "Possible values are `none` for no DNS record, `managed` for LXD-generated static records, and `dynamic` for client-generated records.",
+							"shortdesc": "DNS registration mode",
+							"type": "string"
+						}
+					},
+					{
+						"dns.search": {
+							"defaultdesc": "`dns.domain` value",
+							"longdesc": "Specify a comma-separated list of domains.",
+							"shortdesc": "Full domain search list",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.forward": {
+							"longdesc": "Specify a comma-separated list of DNS zone names.",
+							"shortdesc": "DNS zone names for forward DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv4": {
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv4 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"dns.zone.reverse.ipv6": {
+							"longdesc": "",
+							"shortdesc": "DNS zone name for IPv6 reverse DNS records",
+							"type": "string"
+						}
+					},
+					{
+						"fan.overlay_subnet": {
+							"condition": "fan mode",
+							"defaultdesc": "`240.0.0.0/8`",
+							"longdesc": "Use CIDR notation.",
+							"shortdesc": "Subnet to use as the overlay for the FAN",
+							"type": "string"
+						}
+					},
+					{
+						"fan.type": {
+							"condition": "fan mode",
+							"defaultdesc": "`vxlan`",
+							"longdesc": "Possible values are `vxlan` and `ipip`.",
+							"shortdesc": "Tunneling type for the FAN",
+							"type": "string"
+						}
+					},
+					{
+						"fan.underlay_subnet": {
+							"condition": "fan mode",
+							"defaultdesc": "initial value on creation: `auto`",
+							"longdesc": "Use CIDR notation.\n\nYou can set the option to `auto` to use the default gateway subnet.",
+							"shortdesc": "Subnet to use as the underlay for the FAN",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.address": {
+							"condition": "standard mode",
+							"defaultdesc": "initial value on creation: `auto`",
+							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv4, or to `auto` to generate a new random unused subnet.",
+							"shortdesc": "IPv4 address for the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp": {
+							"condition": "IPv4 address",
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate IPv4 addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.dhcp.expiry": {
+							"condition": "IPv4 DHCP",
+							"defaultdesc": "`1h`",
+							"longdesc": "",
+							"shortdesc": "When to expire DHCP leases",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.gateway": {
+							"condition": "IPv4 DHCP",
+							"defaultdesc": "IPv4 address",
+							"longdesc": "",
+							"shortdesc": "Address of the gateway for the IPv4 subnet",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.dhcp.ranges": {
+							"condition": "IPv4 DHCP",
+							"defaultdesc": "all addresses",
+							"longdesc": "Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.",
+							"shortdesc": "IPv4 ranges to use for DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.firewall": {
+							"condition": "IPv4 address",
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to generate filtering firewall rules for this network",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat": {
+							"condition": "IPv4 address",
+							"defaultdesc": "`false` (initial value on creation if `ipv4.address` is set to `auto`: `true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to use NAT for IPv4",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv4.nat.address": {
+							"condition": "IPv4 address",
+							"longdesc": "",
+							"shortdesc": "Source address used for outbound traffic from the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.nat.order": {
+							"condition": "IPv4 address",
+							"defaultdesc": "`before`",
+							"longdesc": "Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.",
+							"shortdesc": "Where to add the required NAT rules",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.ovn.ranges": {
+							"longdesc": "Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.",
+							"shortdesc": "IPv4 ranges to use for child OVN network routers",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routes": {
+							"condition": "IPv4 address",
+							"longdesc": "Specify a comma-separated list of IPv4 CIDR subnets.",
+							"shortdesc": "Additional IPv4 CIDR subnets to route to the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv4.routing": {
+							"condition": "IPv4 address",
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to route IPv4 traffic in and out of the bridge",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.address": {
+							"condition": "standard mode",
+							"defaultdesc": "initial value on creation: `auto`",
+							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv6, or to `auto` to generate a new random unused subnet.",
+							"shortdesc": "IPv6 address for the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp": {
+							"condition": "IPv6 address",
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to provide additional network configuration over DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.dhcp.expiry": {
+							"condition": "IPv6 DHCP",
+							"defaultdesc": "`1h`",
+							"longdesc": "",
+							"shortdesc": "When to expire DHCP leases",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp.ranges": {
+							"condition": "IPv6 stateful DHCP",
+							"defaultdesc": "all addresses",
+							"longdesc": "Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.",
+							"shortdesc": "IPv6 ranges to use for DHCP",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.dhcp.stateful": {
+							"condition": "IPv6 DHCP",
+							"defaultdesc": "`false`",
+							"longdesc": "",
+							"shortdesc": "Whether to allocate IPv6 addresses using DHCP",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.firewall": {
+							"condition": "IPv6 DHCP",
+							"defaultdesc": "`true`",
+							"longdesc": "",
+							"shortdesc": "Whether to generate filtering firewall rules for this network",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat": {
+							"condition": "IPv6 address",
+							"defaultdesc": "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)",
+							"longdesc": "",
+							"shortdesc": "Whether to use NAT for IPv6",
+							"type": "bool"
+						}
+					},
+					{
+						"ipv6.nat.address": {
+							"condition": "IPv6 address",
+							"longdesc": "",
+							"shortdesc": "Source address used for outbound traffic from the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.nat.order": {
+							"condition": "IPv6 address",
+							"defaultdesc": "`before`",
+							"longdesc": "Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.",
+							"shortdesc": "Where to add the required NAT rules",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.ovn.ranges": {
+							"longdesc": "Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.",
+							"shortdesc": "IPv6 ranges to use for child OVN network routers",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routes": {
+							"condition": "IPv6 address",
+							"longdesc": "Specify a comma-separated list of IPv6 CIDR subnets.",
+							"shortdesc": "Additional IPv6 CIDR subnets to route to the bridge",
+							"type": "string"
+						}
+					},
+					{
+						"ipv6.routing": {
+							"condition": "IPv6 address",
+							"longdesc": "",
+							"shortdesc": "Whether to route IPv6 traffic in and out of the bridge",
+							"type": "bool"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"condition": "IPv4 address; using the `network` property on the NIC",
+							"longdesc": "",
+							"shortdesc": "MAAS IPv4 subnet to register instances in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"condition": "IPv6 address; using the `network` property on the NIC",
+							"longdesc": "",
+							"shortdesc": "MAAS IPv6 subnet to register instances in",
+							"type": "string"
+						}
+					},
+					{
+						"raw.dnsmasq": {
+							"longdesc": "",
+							"shortdesc": "Additional `dnsmasq` configuration to append to the configuration file",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls": {
+							"longdesc": "Specify a comma-separated list of network ACLs.\n\nAlso see {ref}`network-acls-bridge-limitations`.",
+							"shortdesc": "Network ACLs to apply to NICs connected to this network",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.action": {
+							"condition": "`security.acls`",
+							"longdesc": "The specified action is used for all egress traffic that doesn’t match any ACL rule.",
+							"shortdesc": "Default action to use for egress traffic",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.egress.logged": {
+							"condition": "`security.acls`",
+							"longdesc": "",
+							"shortdesc": "Whether to log egress traffic that doesn’t match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"security.acls.default.ingress.action": {
+							"condition": "`security.acls`",
+							"longdesc": "The specified action is used for all ingress traffic that doesn’t match any ACL rule.",
+							"shortdesc": "Default action to use for ingress traffic",
+							"type": "string"
+						}
+					},
+					{
+						"security.acls.default.ingress.logged": {
+							"condition": "`security.acls`",
+							"longdesc": "",
+							"shortdesc": "Whether to log ingress traffic that doesn’t match any ACL rule",
+							"type": "bool"
+						}
+					},
+					{
+						"tunnel.NAME.group": {
+							"condition": "`vxlan`",
+							"longdesc": "This address is used if {config:option}`network-bridge-network-conf:tunnel.NAME.local` and {config:option}`network-bridge-network-conf:tunnel.NAME.remote` aren’t set.",
+							"shortdesc": "Multicast address for `vxlan`",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.id": {
+							"condition": "`vxlan`",
+							"longdesc": "",
+							"shortdesc": "Specific tunnel ID to use for the `vxlan` tunnel",
+							"type": "integer"
+						}
+					},
+					{
+						"tunnel.NAME.interface": {
+							"condition": "`vxlan`",
+							"longdesc": "",
+							"shortdesc": "Specific host interface to use for the tunnel",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.local": {
+							"condition": "`gre` or `vxlan`",
+							"longdesc": "",
+							"required": "not required for multicast `vxlan`",
+							"shortdesc": "Local address for the tunnel",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.port": {
+							"condition": "`vxlan`",
+							"defaultdesc": "`0`",
+							"longdesc": "",
+							"shortdesc": "Specific port to use for the `vxlan` tunnel",
+							"type": "integer"
+						}
+					},
+					{
+						"tunnel.NAME.protocol": {
+							"condition": "standard mode",
+							"longdesc": "Possible values are `vxlan` and `gre`.",
+							"shortdesc": "Tunneling protocol",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.remote": {
+							"condition": "`gre` or `vxlan`",
+							"longdesc": "",
+							"required": "not required for multicast `vxlan`",
+							"shortdesc": "Remote address for the tunnel",
+							"type": "string"
+						}
+					},
+					{
+						"tunnel.NAME.ttl": {
+							"condition": "`vxlan`",
+							"defaultdesc": "`1`",
+							"longdesc": "",
+							"shortdesc": "Specific TTL to use for multicast routing topologies",
+							"type": "string"
+						}
+					},
+					{
+						"user.*": {
+							"longdesc": "",
+							"shortdesc": "User-provided free-form key/value pairs",
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"network-macvlan": {
 			"network-conf": {
 				"keys": [


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/jira/software/c/projects/LXD/boards/54?assignee=63d9eb6128cddcc70770aff1&selectedIssue=LXD-442

* [x] Annotate `bridge` network (this PR)
* [x] Annotate `ovn` network (see https://github.com/canonical/lxd/pull/13028)
* [x] Annotate `macvlan` network (see https://github.com/canonical/lxd/pull/13029)
* [x] Annotate `physical` network (see https://github.com/canonical/lxd/pull/13031)
* [x] Annotate `sriov` network (see https://github.com/canonical/lxd/pull/13032)

____

Searching for references in `/doc` (more precisely in `doc/*.md,doc/explanation/*.md,doc/howto/*.md,doc/reference/*.md,doc/tutorial/*.md`) of the form `[<key_name>](<section_name>)` to replace:

* [x] `bridge` network
* [x] `ovn` network
* [x] `macvlan` network
* [x] `physical` network
* [x] `sriov` network