### PR TITLE
lxd-metadata: Annotate codebase for `macvlan` network config keys

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -2517,6 +2517,53 @@ It is globally unique across all servers and projects.
 ```
 
 <!-- config group instance-volatile end -->
+<!-- config group network-macvlan-network-conf start -->
+```{config:option} gvrp network-macvlan-network-conf
+:defaultdesc: "`false`"
+:shortdesc: "Whether to use GARP VLAN Registration Protocol"
+:type: "bool"
+This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+```
+
+```{config:option} maas.subnet.ipv4 network-macvlan-network-conf
+:condition: "IPv4 address; using the `network` property on the NIC"
+:shortdesc: "MAAS IPv4 subnet to register instances in"
+:type: "string"
+
+```
+
+```{config:option} maas.subnet.ipv6 network-macvlan-network-conf
+:condition: "IPv4 address; using the `network` property on the NIC"
+:shortdesc: "MAAS IPv6 subnet to register instances in"
+:type: "string"
+
+```
+
+```{config:option} mtu network-macvlan-network-conf
+:shortdesc: "MTU of the new interface"
+:type: "integer"
+
+```
+
+```{config:option} parent network-macvlan-network-conf
+:shortdesc: "Parent interface to create `macvlan` NICs on"
+:type: "string"
+
+```
+
+```{config:option} user.* network-macvlan-network-conf
+:shortdesc: "User-provided free-form key/value pairs"
+:type: "string"
+
+```
+
+```{config:option} vlan network-macvlan-network-conf
+:shortdesc: "VLAN ID to attach to"
+:type: "integer"
+
+```
+
+<!-- config group network-macvlan-network-conf end -->
 <!-- config group network-sriov-network-conf start -->
 ```{config:option} maas.subnet.ipv4 network-sriov-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"

--- a/doc/reference/network_macvlan.md
+++ b/doc/reference/network_macvlan.md
@@ -28,12 +28,8 @@ The following configuration key namespaces are currently supported for the `macv
 
 The following configuration options are available for the `macvlan` network type:
 
-Key                             | Type      | Condition             | Default                   | Description
-:--                             | :--       | :--                   | :--                       | :--
-`gvrp`                          | bool      | -                     | `false`                   | Register VLAN using GARP VLAN Registration Protocol
-`mtu`                           | integer   | -                     | -                         | The MTU of the new interface
-`parent`                        | string    | -                     | -                         | Parent interface to create `macvlan` NICs on
-`vlan`                          | integer   | -                     | -                         | The VLAN ID to attach to
-`maas.subnet.ipv4`              | string    | IPv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on NIC)
-`maas.subnet.ipv6`              | string    | IPv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on NIC)
-`user.*`                        | string    | -                     | -                         | User-provided free-form key/value pairs
+% Include content from [../config_options.txt](../config_options.txt)
+```{include} ../config_options.txt
+    :start-after: <!-- config group network-macvlan-network-conf start -->
+    :end-before: <!-- config group network-macvlan-network-conf end -->
+```

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2850,6 +2850,64 @@
 				]
 			}
 		},
+		"network-macvlan": {
+			"network-conf": {
+				"keys": [
+					{
+						"gvrp": {
+							"defaultdesc": "`false`",
+							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
+							"type": "bool"
+						}
+					},
+					{
+						"maas.subnet.ipv4": {
+							"condition": "IPv4 address; using the `network` property on the NIC",
+							"longdesc": "",
+							"shortdesc": "MAAS IPv4 subnet to register instances in",
+							"type": "string"
+						}
+					},
+					{
+						"maas.subnet.ipv6": {
+							"condition": "IPv4 address; using the `network` property on the NIC",
+							"longdesc": "",
+							"shortdesc": "MAAS IPv6 subnet to register instances in",
+							"type": "string"
+						}
+					},
+					{
+						"mtu": {
+							"longdesc": "",
+							"shortdesc": "MTU of the new interface",
+							"type": "integer"
+						}
+					},
+					{
+						"parent": {
+							"longdesc": "",
+							"shortdesc": "Parent interface to create `macvlan` NICs on",
+							"type": "string"
+						}
+					},
+					{
+						"user.*": {
+							"longdesc": "",
+							"shortdesc": "User-provided free-form key/value pairs",
+							"type": "string"
+						}
+					},
+					{
+						"vlan": {
+							"longdesc": "",
+							"shortdesc": "VLAN ID to attach to",
+							"type": "integer"
+						}
+					}
+				]
+			}
+		},
 		"network-sriov": {
 			"network-conf": {
 				"keys": [

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -24,12 +24,51 @@ func (n *macvlan) DBType() db.NetworkType {
 // Validate network config.
 func (n *macvlan) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
-		"parent":           validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
-		"mtu":              validate.Optional(validate.IsNetworkMTU),
-		"vlan":             validate.Optional(validate.IsNetworkVLAN),
-		"gvrp":             validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=parent)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: Parent interface to create `macvlan` NICs on
+		"parent": validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=mtu)
+		//
+		// ---
+		//  type: integer
+		//  shortdesc: MTU of the new interface
+		"mtu": validate.Optional(validate.IsNetworkMTU),
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=vlan)
+		//
+		// ---
+		//  type: integer
+		//  shortdesc: VLAN ID to attach to
+		"vlan": validate.Optional(validate.IsNetworkVLAN),
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=gvrp)
+		// This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
+		// ---
+		//  type: bool
+		//  defaultdesc: `false`
+		//  shortdesc: Whether to use GARP VLAN Registration Protocol
+		"gvrp": validate.Optional(validate.IsBool),
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=maas.subnet.ipv4)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 address; using the `network` property on the NIC
+		//  shortdesc: MAAS IPv4 subnet to register instances in
 		"maas.subnet.ipv4": validate.IsAny,
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=maas.subnet.ipv6)
+		//
+		// ---
+		//  type: string
+		//  condition: IPv4 address; using the `network` property on the NIC
+		//  shortdesc: MAAS IPv6 subnet to register instances in
 		"maas.subnet.ipv6": validate.IsAny,
+
+		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=user.*)
+		//
+		// ---
+		//  type: string
+		//  shortdesc: User-provided free-form key/value pairs
 	}
 
 	err := n.validate(config, rules)


### PR DESCRIPTION
See the root PR https://github.com/canonical/lxd/pull/13027 for a summary