### PR TITLE
Migration: Accept offered rsync features for `BLOCK_AND_RSYNC`

### DIFF
--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -193,7 +193,7 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				offeredFeatures = offer.GetZfsFeaturesSlice()
 			} else if offerFSType == MigrationFSType_BTRFS {
 				offeredFeatures = offer.GetBtrfsFeaturesSlice()
-			} else if offerFSType == MigrationFSType_RSYNC {
+			} else if shared.ValueInSlice(offerFSType, []MigrationFSType{MigrationFSType_RSYNC, MigrationFSType_BLOCK_AND_RSYNC}) {
 				offeredFeatures = offer.GetRsyncFeaturesSlice()
 				if !shared.ValueInSlice("bidirectional", offeredFeatures) {
 					// If no bi-directional support, this means we are getting a response from


### PR DESCRIPTION
For both `MigrationFSType_RSYNC` and `MigrationFSType_BLOCK_AND_RSYNC` the target can agree on `rsync` features. Don't skip the features offered by the target if the mode is `MigrationFSType_BLOCK_AND_RSYNC`. Otherwise the list of features returned in the migration response is empty which leads to not using any `rsync` features for the migration in case of `MigrationFSType_BLOCK_AND_RSYNC`.

I found this whilst adding a new type for the Ceph RBD refresh that also requires using `rsync` for VMs filesystem volumes.

This can be tested easily by printing the list of features from the storage driver:

```go
func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs *migration.VolumeSourceArgs, op *operations.Operation) error {
	fmt.Println("--> type:", volSrcArgs.MigrationType)
...
}
```

Before this change this will print `--> type: {BLOCK_AND_RSYNC []}`.
With the fix the features get passed accordingly `--> type: {BLOCK_AND_RSYNC [xattrs delete compress bidirectional]}`.