### PR TITLE
Revert Migration: Accept offered rsync features for BLOCK_AND_RSYNC

### DIFF
--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -193,7 +193,7 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				offeredFeatures = offer.GetZfsFeaturesSlice()
 			} else if offerFSType == MigrationFSType_BTRFS {
 				offeredFeatures = offer.GetBtrfsFeaturesSlice()
-			} else if shared.ValueInSlice(offerFSType, []MigrationFSType{MigrationFSType_RSYNC, MigrationFSType_BLOCK_AND_RSYNC}) {
+			} else if offerFSType == MigrationFSType_RSYNC {
 				offeredFeatures = offer.GetRsyncFeaturesSlice()
 				if !shared.ValueInSlice("bidirectional", offeredFeatures) {
 					// If no bi-directional support, this means we are getting a response from


### PR DESCRIPTION
This reverts https://github.com/canonical/lxd/pull/13030.

Unfortunately it's breaking the migration to and from older LXD servers that don't append those settings to the `rsync` command:

```bash
julian@thinkpad:~$ lxc cp v1 r:v1 -s remote2 --refresh
Error: Failed instance creation: Error transferring instance data: Failed migration on target: Failed creating instance on target: Rsync receive failed: /var/snap/lxd/common/lxd/storage-pools/remote2/virtual-machines/v1/: [exit status 22 read |0: file already closed] (overflow: xflags=0x6c6d l1=0 l2=10529 lastname= [Receiver]
[Receiver] buffer overflow: recv_file_entry (file=flist.c, line=728)
rsync error: error allocating core memory buffers (code 22) at util2.c(129) [Receiver=3.2.7]
)
```
I am wondering how we could still fix this but stay backwards compatible.