### PR TITLE
Migration: Accept offered rsync features for BLOCK_AND_RSYNC

### DIFF
--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -193,14 +193,8 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				offeredFeatures = offer.GetZfsFeaturesSlice()
 			} else if offerFSType == MigrationFSType_BTRFS {
 				offeredFeatures = offer.GetBtrfsFeaturesSlice()
-			} else if offerFSType == MigrationFSType_RSYNC {
+			} else if shared.ValueInSlice(offerFSType, []MigrationFSType{MigrationFSType_RSYNC, MigrationFSType_BLOCK_AND_RSYNC}) {
 				offeredFeatures = offer.GetRsyncFeaturesSlice()
-				if !shared.ValueInSlice("bidirectional", offeredFeatures) {
-					// If no bi-directional support, this means we are getting a response from
-					// an old LXD server that doesn't support bidirectional negotiation, so
-					// assume LXD 3.7 level. NOTE: Do NOT extend this list of arguments.
-					offeredFeatures = []string{"xattrs", "delete", "compress"}
-				}
 			}
 
 			// Find common features in both our type and offered type.


### PR DESCRIPTION
The core of this change (checking for other rsync related migration types) was proposed in https://github.com/canonical/lxd/pull/13030 but reverted https://github.com/canonical/lxd/pull/13037 as it was breaking the sync with older LXDs that don't yet have this fix applied.

By removing the check for LXD 3.7 (EOL) no more rsync features are assumed which will allow LXDs that don't yet have the fix proposed in this PR to perform migrations.
See https://github.com/canonical/lxd/pull/13037#issuecomment-1978253612 for more detailed information.