### PR TITLE
Auth: Fix query when setting the IdP group mapping

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1486,7 +1486,7 @@ func (c *cmdIdentityProviderGroupDelete) run(cmd *cobra.Command, args []string) 
 	}
 
 	if !c.global.flagQuiet {
-		fmt.Printf(i18n.G("Group %s deleted")+"\n", resource.name)
+		fmt.Printf(i18n.G("Identity provider group %s deleted")+"\n", resource.name)
 	}
 
 	return nil

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -435,16 +435,16 @@ WHERE auth_groups.name IN (
 
 	res, err := tx.ExecContext(ctx, builder.String(), args...)
 	if err != nil {
-		return fmt.Errorf("Failed to write identity provider group mappings: %w", err)
+		return fmt.Errorf("Failed to write identity auth group associations: %w", err)
 	}
 
 	rowsAffected, err := res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("Failed to check validity of identity provider group mapping creation: %w", err)
+		return fmt.Errorf("Failed to check validity of identity auth group associations: %w", err)
 	}
 
 	if int(rowsAffected) != len(groupNames) {
-		return fmt.Errorf("Failed to write expected number of rows to identity provider group association table (expected %d, got %d)", len(groupNames), rowsAffected)
+		return fmt.Errorf("Failed to write expected number of rows to identity auth group association table (expected %d, got %d)", len(groupNames), rowsAffected)
 	}
 
 	return nil

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2707,6 +2707,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -3124,6 +3124,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "Profil %s erstellt\n"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
 
 #: lxc/rebuild.go:32

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -2646,7 +2646,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2745,6 +2745,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "  Χρήση δικτύου:"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
 #: lxc/rebuild.go:32

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
@@ -3015,6 +3015,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "Perfil %s creado"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
 
 #: lxc/rebuild.go:32

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
@@ -3160,6 +3160,11 @@ msgstr "DATE D'ÉMISSION"
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "Profil %s créé"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
 
 #: lxc/rebuild.go:32

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2711,6 +2711,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -3008,6 +3008,11 @@ msgstr ""
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
+msgstr "Il nome del container è: %s"
 
 #: lxc/rebuild.go:32
 msgid "If an instance is running, stop it and then rebuild it"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -2973,7 +2973,7 @@ msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %
 msgid "Group %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
@@ -3073,6 +3073,11 @@ msgstr "ISSUE DATE"
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "クラスターグループ %s を作成しました"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
 
 #: lxc/rebuild.go:32

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2707,6 +2707,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-02-20 21:09+0000\n"
+        "POT-Creation-Date: 2024-03-05 17:17+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2363,7 +2363,7 @@ msgstr  ""
 msgid   "Group %s created"
 msgstr  ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid   "Group %s deleted"
 msgstr  ""
@@ -2462,6 +2462,11 @@ msgstr  ""
 #: lxc/auth.go:1439
 #, c-format
 msgid   "Identity provider group %s created"
+msgstr  ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid   "Identity provider group %s deleted"
 msgstr  ""
 
 #: lxc/rebuild.go:32

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2934,6 +2934,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2972,6 +2972,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2707,6 +2707,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
@@ -3077,6 +3077,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr "Clustering ativado"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
 
 #: lxc/rebuild.go:32

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr " Использование сети:"
@@ -3058,6 +3058,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
+msgstr " Использование сети:"
+
+#: lxc/auth.go:1489
+#, fuzzy, c-format
+msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
 
 #: lxc/rebuild.go:32

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2711,6 +2711,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2711,6 +2711,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2707,6 +2707,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -2612,7 +2612,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2711,6 +2711,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -2772,7 +2772,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2871,6 +2871,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-02-20 21:09+0000\n"
+"POT-Creation-Date: 2024-03-05 17:17+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186 lxc/auth.go:1489
+#: lxc/auth.go:186
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
@@ -2710,6 +2710,11 @@ msgstr ""
 #: lxc/auth.go:1439
 #, c-format
 msgid "Identity provider group %s created"
+msgstr ""
+
+#: lxc/auth.go:1489
+#, c-format
+msgid "Identity provider group %s deleted"
 msgstr ""
 
 #: lxc/rebuild.go:32


### PR DESCRIPTION
The query is an `INSERT INTO SELECT` but the selected values and columns were inserting were reversed. This fixes https://github.com/canonical/lxd/pull/12976#issuecomment-1973376771.

Additional small fixes in subsequent commits.