### PR TITLE
Auth: Add `GET /1.0/auth/identities/current`.

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -437,9 +437,8 @@ type InstanceServer interface {
 	GetIdentityIdentifiersByAuthenticationMethod(authenticationMethod string) (identifiers []string, err error)
 	GetIdentities() (identities []api.Identity, err error)
 	GetIdentitiesByAuthenticationMethod(authenticationMethod string) (identities []api.Identity, err error)
-	GetIdentitiesInfo() (identityInfos []api.IdentityInfo, err error)
-	GetIdentitiesInfoByAuthenticationMethod(authenticationMethod string) (identityInfos []api.IdentityInfo, err error)
-	GetIdentity(authenticationMethod string, nameOrIdentifier string) (identityInfo *api.IdentityInfo, ETag string, err error)
+	GetIdentity(authenticationMethod string, nameOrIdentifier string) (identity *api.Identity, ETag string, err error)
+	GetCurrentIdentityInfo() (identityInfo *api.IdentityInfo, ETag string, err error)
 	UpdateIdentity(authenticationMethod string, nameOrIdentifier string, identityPut api.IdentityPut, ETag string) error
 	GetIdentityProviderGroupNames() (identityProviderGroupNames []string, err error)
 	GetIdentityProviderGroups() (identityProviderGroups []api.IdentityProviderGroup, err error)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -7,10 +7,12 @@ definitions:
                 type: string
                 x-go-name: Description
             identities:
-                description: Identities are the identities that are members of the group.
-                items:
-                    $ref: '#/definitions/Identity'
-                type: array
+                additionalProperties:
+                    items:
+                        type: string
+                    type: array
+                description: Identities is a map of authentication method to slice of identity identifiers.
+                type: object
                 x-go-name: Identities
             identity_provider_groups:
                 description: |-
@@ -710,35 +712,6 @@ definitions:
                 example: tls
                 type: string
                 x-go-name: AuthenticationMethod
-            id:
-                description: Identifier is a unique identifier for the identity (e.g. certificate fingerprint or email for OIDC).
-                example: jane.doe@example.com
-                type: string
-                x-go-name: Identifier
-            name:
-                description: |-
-                    Name is the Name claim of the identity if authenticated via OIDC, or the name
-                    of the certificate if authenticated with TLS.
-                example: Jane Doe
-                type: string
-                x-go-name: Name
-            type:
-                description: Type is the type of identity.
-                example: oidc-service-account
-                type: string
-                x-go-name: Type
-        title: Identity is the type for an authenticated party that can make requests to the HTTPS API.
-        type: object
-        x-go-package: github.com/canonical/lxd/shared/api
-    IdentityInfo:
-        properties:
-            authentication_method:
-                description: |-
-                    AuthenticationMethod is the authentication method that the identity
-                    authenticates to LXD with.
-                example: tls
-                type: string
-                x-go-name: AuthenticationMethod
             groups:
                 description: Groups is the list of groups for which the identity is a member.
                 example:
@@ -765,7 +738,65 @@ definitions:
                 example: oidc-service-account
                 type: string
                 x-go-name: Type
-        title: IdentityInfo expands an Identity to include group membership.
+        title: Identity is the type for an authenticated party that can make requests to the HTTPS API.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    IdentityInfo:
+        description: These fields can only be evaluated for the currently authenticated identity.
+        properties:
+            authentication_method:
+                description: |-
+                    AuthenticationMethod is the authentication method that the identity
+                    authenticates to LXD with.
+                example: tls
+                type: string
+                x-go-name: AuthenticationMethod
+            effective_groups:
+                description: |-
+                    Effective groups is the combined and deduplicated list of LXD groups that the identity is a direct member of, and
+                    the LXD groups that the identity is an effective member of via identity provider group mappings.
+                example:
+                    - foo
+                    - bar
+                items:
+                    type: string
+                type: array
+                x-go-name: EffectiveGroups
+            effective_permissions:
+                description: |-
+                    Effective permissions is the combined and deduplicated list of permissions that the identity has by virtue of
+                    direct membership to a LXD group, or effective membership of a LXD group via identity provider group mappings.
+                items:
+                    $ref: '#/definitions/Permission'
+                type: array
+                x-go-name: EffectivePermissions
+            groups:
+                description: Groups is the list of groups for which the identity is a member.
+                example:
+                    - foo
+                    - bar
+                items:
+                    type: string
+                type: array
+                x-go-name: Groups
+            id:
+                description: Identifier is a unique identifier for the identity (e.g. certificate fingerprint or email for OIDC).
+                example: jane.doe@example.com
+                type: string
+                x-go-name: Identifier
+            name:
+                description: |-
+                    Name is the Name claim of the identity if authenticated via OIDC, or the name
+                    of the certificate if authenticated with TLS.
+                example: Jane Doe
+                type: string
+                x-go-name: Name
+            type:
+                description: Type is the type of identity.
+                example: oidc-service-account
+                type: string
+                x-go-name: Type
+        title: IdentityInfo expands an Identity to include effective group membership and effective permissions.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     IdentityProviderGroup:
@@ -7073,7 +7104,7 @@ paths:
                         description: Sync response
                         properties:
                             metadata:
-                                $ref: '#/definitions/IdentityInfo'
+                                $ref: '#/definitions/Identity'
                             status:
                                 description: Status description
                                 example: Success
@@ -7181,10 +7212,10 @@ paths:
             summary: Get the identities
             tags:
                 - identities
-    /1.0/auth/identities/{authenticationMethod}?recursion=2:
+    /1.0/auth/identities/current:
         get:
-            description: Returns a list of identities including group membership.
-            operationId: identities_get_by_auth_method_recursion2
+            description: Gets the identity of the requestor, including contextual authorization information.
+            operationId: identity_get_current
             produces:
                 - application/json
             responses:
@@ -7194,10 +7225,7 @@ paths:
                         description: Sync response
                         properties:
                             metadata:
-                                description: List of identities
-                                items:
-                                    $ref: '#/definitions/IdentityInfo'
-                                type: array
+                                $ref: '#/definitions/IdentityInfo'
                             status:
                                 description: Status description
                                 example: Success
@@ -7215,7 +7243,7 @@ paths:
                     $ref: '#/responses/Forbidden'
                 "500":
                     $ref: '#/responses/InternalServerError'
-            summary: Get the identities
+            summary: Get the current identity
             tags:
                 - identities
     /1.0/auth/identities?recursion=1:
@@ -7234,43 +7262,6 @@ paths:
                                 description: List of identities
                                 items:
                                     $ref: '#/definitions/Identity'
-                                type: array
-                            status:
-                                description: Status description
-                                example: Success
-                                type: string
-                            status_code:
-                                description: Status code
-                                example: 200
-                                type: integer
-                            type:
-                                description: Response type
-                                example: sync
-                                type: string
-                        type: object
-                "403":
-                    $ref: '#/responses/Forbidden'
-                "500":
-                    $ref: '#/responses/InternalServerError'
-            summary: Get the identities
-            tags:
-                - identities
-    /1.0/auth/identities?recursion=2:
-        get:
-            description: Returns a list of identities including group membership.
-            operationId: identities_get_recursion2
-            produces:
-                - application/json
-            responses:
-                "200":
-                    description: API endpoints
-                    schema:
-                        description: Sync response
-                        properties:
-                            metadata:
-                                description: List of identities
-                                items:
-                                    $ref: '#/definitions/IdentityInfo'
                                 type: array
                             status:
                                 description: Status description

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -733,10 +733,16 @@ func (c *cmdIdentity) command() *cobra.Command {
 
 	identityListCmd := cmdIdentityList{global: c.global}
 	cmd.AddCommand(identityListCmd.command())
+
 	identityShowCmd := cmdIdentityShow{global: c.global}
 	cmd.AddCommand(identityShowCmd.command())
+
+	identityInfoCmd := cmdIdentityInfo{global: c.global}
+	cmd.AddCommand(identityInfoCmd.command())
+
 	identityEditCmd := cmdIdentityEdit{global: c.global}
 	cmd.AddCommand(identityEditCmd.command())
+
 	identityGroupCmd := cmdIdentityGroup{global: c.global}
 	cmd.AddCommand(identityGroupCmd.command())
 
@@ -863,6 +869,67 @@ func (c *cmdIdentityShow) run(cmd *cobra.Command, args []string) error {
 
 	// Show the identity
 	identity, _, err := resource.server.GetIdentity(authenticationMethod, nameOrID)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(&identity)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", data)
+
+	return nil
+}
+
+// Show current.
+type cmdIdentityInfo struct {
+	global *cmdGlobal
+}
+
+func (c *cmdIdentityInfo) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("info", i18n.G("[<remote>:]"))
+	cmd.Short = i18n.G("View the current identity")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Show the current identity
+
+This command will display permissions for the current user.
+This includes contextual information, such as effective groups and permissions
+that are granted via identity provider group mappings. 
+`))
+
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+func (c *cmdIdentityInfo) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
+	if exit {
+		return err
+	}
+
+	// Connect to LXD
+	var server lxd.InstanceServer
+	if len(args) == 0 {
+		server, err = c.global.conf.GetInstanceServer(c.global.conf.DefaultRemote)
+		if err != nil {
+			return err
+		}
+	} else {
+		resources, err := c.global.ParseServers(args[0])
+		if err != nil {
+			return err
+		}
+
+		server = resources[0].server
+	}
+
+	// Show the identity
+	identity, _, err := server.GetCurrentIdentityInfo()
 	if err != nil {
 		return err
 	}

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -786,7 +786,7 @@ func (c *cmdIdentityList) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	// List identities
-	identities, err := resource.server.GetIdentitiesInfo()
+	identities, err := resource.server.GetIdentities()
 	if err != nil {
 		return err
 	}

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -260,14 +260,9 @@ func getAuthGroups(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			apiIdentities := make([]api.Identity, 0, len(groupsIdentities[group.ID]))
+			apiIdentities := make(map[string][]string)
 			for _, identity := range groupsIdentities[group.ID] {
-				apiIdentities = append(apiIdentities, api.Identity{
-					AuthenticationMethod: string(identity.AuthMethod),
-					Type:                 string(identity.Type),
-					Identifier:           identity.Identifier,
-					Name:                 identity.Name,
-				})
+				apiIdentities[string(identity.AuthMethod)] = append(apiIdentities[string(identity.AuthMethod)], identity.Identifier)
 			}
 
 			idpGroups := make([]string, 0, len(groupsIdentityProviderGroups[group.ID]))

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -24,7 +24,6 @@ import (
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
-	"github.com/canonical/lxd/shared/logger"
 )
 
 var authGroupsCmd = APIEndpoint{
@@ -210,24 +209,10 @@ func getAuthGroups(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			// Get the EntityURLs for the permissions. Ignore any dangling permissions.
-			var danglingPermissions []dbCluster.Permission
-			authGroupPermissions, danglingPermissions, entityURLs, err = dbCluster.GetPermissionEntityURLs(ctx, tx.Tx(), authGroupPermissions)
+			// Get the EntityURLs for the permissions.
+			authGroupPermissions, entityURLs, err = dbCluster.GetPermissionEntityURLs(ctx, tx.Tx(), authGroupPermissions)
 			if err != nil {
 				return err
-			}
-
-			if len(danglingPermissions) > 0 {
-				permissionIDs := make([]int, 0, len(danglingPermissions))
-				entityTypes := make([]dbCluster.EntityType, 0, len(danglingPermissions))
-				for _, perm := range danglingPermissions {
-					permissionIDs = append(permissionIDs, perm.ID)
-					if !shared.ValueInSlice(perm.EntityType, entityTypes) {
-						entityTypes = append(entityTypes, perm.EntityType)
-					}
-				}
-
-				logger.Warn("Encountered dangling permissions", logger.Ctx{"permission_ids": permissionIDs, "entity_types": entityTypes})
 			}
 		}
 

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -289,8 +289,8 @@ func (i Identity) Subject() (string, error) {
 	return metadata.Subject, nil
 }
 
-// ToAPIInfo converts an Identity to an api.IdentityInfo, executing database queries as necessary.
-func (i *Identity) ToAPIInfo(ctx context.Context, tx *sql.Tx) (*api.IdentityInfo, error) {
+// ToAPI converts an Identity to an api.Identity, executing database queries as necessary.
+func (i *Identity) ToAPI(ctx context.Context, tx *sql.Tx) (*api.Identity, error) {
 	groups, err := GetAuthGroupsByIdentityID(ctx, tx, i.ID)
 	if err != nil {
 		return nil, err
@@ -301,13 +301,11 @@ func (i *Identity) ToAPIInfo(ctx context.Context, tx *sql.Tx) (*api.IdentityInfo
 		groupNames = append(groupNames, group.Name)
 	}
 
-	return &api.IdentityInfo{
-		Identity: api.Identity{
-			AuthenticationMethod: string(i.AuthMethod),
-			Type:                 string(i.Type),
-			Identifier:           i.Identifier,
-			Name:                 i.Name,
-		},
+	return &api.Identity{
+		AuthenticationMethod: string(i.AuthMethod),
+		Type:                 string(i.Type),
+		Identifier:           i.Identifier,
+		Name:                 i.Name,
 		IdentityPut: api.IdentityPut{
 			Groups: groupNames,
 		},

--- a/lxd/db/cluster/permissions.go
+++ b/lxd/db/cluster/permissions.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/logger"
 )
 
 // Permission is the database representation of an api.Permission.
@@ -22,10 +24,11 @@ type Permission struct {
 // GetPermissionEntityURLs accepts a slice of Permission as input. The input Permission slice may include permissions
 // that are no longer valid because the entity against which they are defined no longer exists. This method determines
 // which permissions are valid and which are not valid by attempting to retrieve their entity URL. It uses as few
-// queries as possible to do this. It returns a slice of valid permissions, a slice of invalid permissions and a map of
-// entity.Type, to entity ID, to api.URL. The returned map contains the URL of the entity of each returned valid
-// permission. It is used for populating api.Permission. The invalid permissions can be ignored or deleted.
-func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Permission) (validPermissions []Permission, danglingPermissions []Permission, entityURLs map[entity.Type]map[int]*api.URL, err error) {
+// queries as possible to do this. It returns a slice of valid permissions and a map of entity.Type, to entity ID, to
+// api.URL. The returned map contains the URL of the entity of each returned valid permission. It is used for populating
+// api.Permission. A warning is logged if any invalid permissions are found. And error is returned if any query returns
+// unexpected error.
+func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Permission) ([]Permission, map[entity.Type]map[int]*api.URL, error) {
 	// To make as few calls as possible, categorize the permissions by entity type.
 	permissionsByEntityType := map[EntityType][]Permission{}
 	for _, permission := range permissions {
@@ -34,7 +37,7 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 
 	// For each entity type, if there is only on permission for the entity type, we'll get the URL by its entity type and ID.
 	// If there are multiple permissions for the entity type, append the entity type to a list for later use.
-	entityURLs = make(map[entity.Type]map[int]*api.URL)
+	entityURLs := make(map[entity.Type]map[int]*api.URL)
 	var entityTypes []entity.Type
 	for entityType, permissions := range permissionsByEntityType {
 		if len(permissions) > 1 {
@@ -51,7 +54,7 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 
 		u, err := GetEntityURL(ctx, tx, entity.Type(entityType), permissions[0].EntityID)
 		if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
-			return nil, nil, nil, err
+			return nil, nil, err
 		} else if err != nil {
 			continue
 		}
@@ -64,7 +67,7 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 	if len(entityTypes) > 0 {
 		entityURLsAll, err := GetEntityURLs(ctx, tx, "", entityTypes...)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
 		for k, v := range entityURLsAll {
@@ -74,6 +77,8 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 
 	// Iterate over the input permissions and check which ones are present in the entityURLs map.
 	// If they are not present, the entity against which they are defined is no longer present in the DB.
+	validPermissions := make([]Permission, 0, len(permissions))
+	danglingPermissions := make([]Permission, 0, len(permissions))
 	for _, permission := range permissions {
 		entityIDToURL, ok := entityURLs[entity.Type(permission.EntityType)]
 		if !ok {
@@ -90,5 +95,19 @@ func GetPermissionEntityURLs(ctx context.Context, tx *sql.Tx, permissions []Perm
 		validPermissions = append(validPermissions, permission)
 	}
 
-	return validPermissions, danglingPermissions, entityURLs, nil
+	// If there are any dangling permissions, log an appropriate warning message.
+	if len(danglingPermissions) > 0 {
+		permissionIDs := make([]int, 0, len(danglingPermissions))
+		entityTypes := make([]EntityType, 0, len(danglingPermissions))
+		for _, perm := range danglingPermissions {
+			permissionIDs = append(permissionIDs, perm.ID)
+			if !shared.ValueInSlice(perm.EntityType, entityTypes) {
+				entityTypes = append(entityTypes, perm.EntityType)
+			}
+		}
+
+		logger.Warn("Encountered dangling permissions", logger.Ctx{"permission_ids": permissionIDs, "entity_types": entityTypes})
+	}
+
+	return validPermissions, entityURLs, nil
 }

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -276,7 +276,9 @@ func getIdentities(d *Daemon, r *http.Request) response.Response {
 		return response.InternalError(fmt.Errorf("Failed to unescape path argument: %w", err))
 	}
 
-	if authenticationMethod != "" {
+	if authenticationMethod == "current" {
+		return getCurrentIdentityInfo(d, r)
+	} else if authenticationMethod != "" {
 		err = auth.ValidateAuthenticationMethod(authenticationMethod)
 		if err != nil {
 			return response.SmartError(err)

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -405,7 +405,7 @@ func getIdentities(d *Daemon, r *http.Request) response.Response {
 //	          description: Status code
 //	          example: 200
 //	        metadata:
-//	          $ref: "#/definitions/IdentityInfo"
+//	          $ref: "#/definitions/Identity"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
@@ -416,10 +416,10 @@ func getIdentity(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	var apiIdentityInfo *api.IdentityInfo
+	var apiIdentity *api.Identity
 	err = d.State().DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
-		apiIdentityInfo, err = id.ToAPIInfo(ctx, tx.Tx())
+		apiIdentity, err = id.ToAPI(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
@@ -430,7 +430,7 @@ func getIdentity(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return response.SyncResponseETag(true, apiIdentityInfo, apiIdentityInfo)
+	return response.SyncResponseETag(true, apiIdentity, apiIdentity)
 }
 
 // swagger:operation PUT /1.0/auth/identities/{authenticationMethod}/{nameOrIdentifier} identities identity_put
@@ -477,12 +477,12 @@ func updateIdentity(d *Daemon, r *http.Request) response.Response {
 
 	s := d.State()
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		apiIdentityInfo, err := id.ToAPIInfo(ctx, tx.Tx())
+		apiIdentity, err := id.ToAPI(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
 
-		err = util.EtagCheck(r, apiIdentityInfo)
+		err = util.EtagCheck(r, apiIdentity)
 		if err != nil {
 			return err
 		}
@@ -565,21 +565,21 @@ func patchIdentity(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
-	var apiIdentityInfo *api.IdentityInfo
+	var apiIdentity *api.Identity
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		apiIdentityInfo, err = id.ToAPIInfo(ctx, tx.Tx())
+		apiIdentity, err = id.ToAPI(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
 
-		err = util.EtagCheck(r, apiIdentityInfo)
+		err = util.EtagCheck(r, apiIdentity)
 		if err != nil {
 			return err
 		}
 
 		for _, groupName := range identityPut.Groups {
-			if !shared.ValueInSlice(groupName, apiIdentityInfo.Groups) {
-				apiIdentityInfo.Groups = append(apiIdentityInfo.Groups, groupName)
+			if !shared.ValueInSlice(groupName, apiIdentity.Groups) {
+				apiIdentity.Groups = append(apiIdentity.Groups, groupName)
 			}
 		}
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2672,7 +2672,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2704,12 +2704,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3129,11 +3129,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3481,11 +3481,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,19 +3734,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3968,7 +3968,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5347,7 +5347,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5450,6 +5450,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5676,7 +5686,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6316,8 +6326,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6387,12 +6401,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6420,7 +6434,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6481,11 +6495,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6498,7 +6512,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6517,15 +6531,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7065,14 +7079,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -225,7 +225,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -246,7 +246,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -824,7 +824,7 @@ msgstr "ARCHITEKTUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -866,11 +866,11 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1659,12 +1659,12 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1898,7 +1898,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1988,23 +1988,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2268,7 +2268,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2287,7 +2287,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2789,7 +2789,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2847,7 +2847,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -3027,7 +3027,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3087,7 +3087,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3121,12 +3121,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3256,7 +3256,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3566,12 +3566,12 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3742,7 +3742,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliasse:\n"
@@ -3955,12 +3955,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3969,7 +3969,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4242,22 +4242,22 @@ msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4499,7 +4499,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4898,7 +4898,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5262,7 +5262,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5304,7 +5304,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5374,7 +5374,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5921,7 +5921,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5957,7 +5957,7 @@ msgstr "Geräte zu Containern oder Profilen hinzufügen"
 msgid "Show group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6077,6 +6077,16 @@ msgstr "Profil %s erstellt\n"
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
+msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
@@ -6314,7 +6324,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6998,8 +7008,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -7086,12 +7100,12 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7150,7 +7164,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7270,11 +7284,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7297,7 +7311,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7332,7 +7346,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7340,7 +7354,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7349,7 +7363,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8377,14 +8391,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1354,12 +1354,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1659,23 +1659,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2421,7 +2421,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2479,7 +2479,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2651,7 +2651,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2710,7 +2710,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2742,12 +2742,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3169,11 +3169,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3522,12 +3522,12 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3535,7 +3535,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3792,22 +3792,22 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -4033,7 +4033,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4816,7 +4816,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4879,7 +4879,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5436,7 +5436,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5547,6 +5547,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5774,7 +5784,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6431,8 +6441,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6502,12 +6516,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6535,7 +6549,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6596,11 +6610,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6613,7 +6627,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6632,15 +6646,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7180,14 +7194,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -229,7 +229,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -803,7 +803,7 @@ msgstr "ARQUITECTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -842,11 +842,11 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1609,12 +1609,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1920,23 +1920,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2189,7 +2189,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2205,7 +2205,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2687,7 +2687,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2745,7 +2745,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2918,7 +2918,7 @@ msgstr "Perfil %s creado"
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3012,12 +3012,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3450,12 +3450,12 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3610,7 +3610,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliases:"
@@ -3810,12 +3810,12 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3823,7 +3823,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4081,22 +4081,22 @@ msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4331,7 +4331,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5080,7 +5080,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5182,7 +5182,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5712,7 +5712,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5746,7 +5746,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5858,6 +5858,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -6086,7 +6096,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6750,8 +6760,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6823,12 +6837,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6863,7 +6877,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6938,11 +6952,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6957,7 +6971,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -6980,17 +6994,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7643,14 +7657,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -227,7 +227,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -248,7 +248,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -822,7 +822,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +862,11 @@ msgstr "Action (GET par défaut)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1662,12 +1662,12 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1728,7 +1728,7 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1919,7 +1919,7 @@ msgstr "Création du conteneur"
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2012,23 +2012,23 @@ msgstr "Récupération de l'image : %s"
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2306,7 +2306,7 @@ msgstr "Création du conteneur"
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2822,7 +2822,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -3061,7 +3061,7 @@ msgstr "Profil %s créé"
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3123,7 +3123,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3157,12 +3157,12 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3298,7 +3298,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3607,12 +3607,12 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3829,7 +3829,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias :"
@@ -4036,12 +4036,12 @@ msgstr "Création du conteneur"
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -4050,7 +4050,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4325,22 +4325,22 @@ msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4998,7 +4998,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5365,7 +5365,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
@@ -5407,7 +5407,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5478,7 +5478,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6082,7 +6082,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6207,6 +6207,16 @@ msgstr "Afficher la configuration étendue"
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
+msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
 #, fuzzy
@@ -6448,7 +6458,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -7138,9 +7148,14 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
 msgstr ""
+
+#: lxc/auth.go:894
+#, fuzzy
+msgid "View the current identity"
+msgstr "impossible de supprimer le serveur distant par défaut"
 
 #: lxc/storage_volume.go:1374
 msgid "Volume Only"
@@ -7226,12 +7241,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
@@ -7296,7 +7311,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7422,11 +7437,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7455,7 +7470,7 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7490,7 +7505,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7498,7 +7513,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7510,7 +7525,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8632,14 +8647,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1648,23 +1648,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2708,12 +2708,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3133,11 +3133,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3485,11 +3485,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,19 +3738,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4810,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5454,6 +5454,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5680,7 +5690,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6320,8 +6330,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6391,12 +6405,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6424,7 +6438,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6485,11 +6499,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6502,7 +6516,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6521,15 +6535,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7069,14 +7083,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -236,7 +236,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -257,7 +257,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -805,7 +805,7 @@ msgstr "ARCHITETTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -844,11 +844,11 @@ msgstr "Azione (default a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1603,12 +1603,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1915,23 +1915,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2186,7 +2186,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgstr "Creazione del container in corso"
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2684,7 +2684,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2742,7 +2742,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2972,7 +2972,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3004,12 +3004,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3137,7 +3137,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3443,12 +3443,12 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3604,7 +3604,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias:"
@@ -3807,12 +3807,12 @@ msgstr "Creazione del container in corso"
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4080,22 +4080,22 @@ msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4329,7 +4329,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5079,7 +5079,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5118,7 +5118,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5182,7 +5182,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5708,7 +5708,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5742,7 +5742,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5854,6 +5854,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -6084,7 +6094,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6744,8 +6754,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6820,12 +6834,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -6860,7 +6874,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6935,11 +6949,11 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6954,7 +6968,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -6977,17 +6991,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
@@ -7640,14 +7654,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -215,7 +215,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -796,7 +796,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -835,11 +835,11 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1640,12 +1640,12 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, fuzzy, c-format
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1703,7 +1703,7 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1863,7 +1863,7 @@ msgstr "インスタンス内のファイルを削除します"
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1945,23 +1945,23 @@ msgstr "警告を削除します"
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2218,7 +2218,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
@@ -2236,7 +2236,7 @@ msgstr "インスタンス内のファイルを編集します"
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2751,7 +2751,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2809,7 +2809,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr "プロファイル %s を作成しました"
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3038,7 +3038,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3070,12 +3070,12 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3213,7 +3213,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3519,12 +3519,12 @@ msgstr "バックグラウンド操作を一覧表示します"
 msgid "List groups"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3784,7 +3784,7 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
@@ -4012,12 +4012,12 @@ msgstr "デバイスを管理します"
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 #, fuzzy
 msgid "Manage groups for the identity"
 msgstr "信頼済みのクライアントを管理します"
@@ -4027,7 +4027,7 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4288,22 +4288,22 @@ msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4544,7 +4544,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4937,7 +4937,7 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5295,7 +5295,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
@@ -5332,7 +5332,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5396,7 +5396,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5983,7 +5983,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6016,7 +6016,7 @@ msgstr "デバイスの設定をすべて表示します"
 msgid "Show group configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6121,6 +6121,16 @@ msgstr "ストレージボリュームの設定を表示する"
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
+msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
@@ -6346,7 +6356,7 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -7029,9 +7039,14 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
 msgstr ""
+
+#: lxc/auth.go:894
+#, fuzzy
+msgid "View the current identity"
+msgstr "現在のプロジェクトを切り替えます"
 
 #: lxc/storage_volume.go:1374
 msgid "Volume Only"
@@ -7105,12 +7120,12 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -7138,7 +7153,7 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7199,11 +7214,11 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7216,7 +7231,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
@@ -7237,17 +7252,17 @@ msgstr "[<remote>:]<group> <new-name>"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
@@ -7820,7 +7835,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 #, fuzzy
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
@@ -7830,7 +7845,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2672,7 +2672,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2704,12 +2704,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3129,11 +3129,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3481,11 +3481,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,19 +3734,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3968,7 +3968,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5347,7 +5347,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5450,6 +5450,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5676,7 +5686,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6316,8 +6326,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6387,12 +6401,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6420,7 +6434,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6481,11 +6495,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6498,7 +6512,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6517,15 +6531,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7065,14 +7079,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-03-05 17:17+0000\n"
+        "POT-Creation-Date: 2024-03-06 09:51+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,7 +147,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all group information is shown but only the description and permissions can be modified"
 msgstr  ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -166,7 +166,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all identity information is shown but only the projects and groups can be modified"
 msgstr  ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -526,7 +526,7 @@ msgstr  ""
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
@@ -564,11 +564,11 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -1260,12 +1260,12 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid   "Could not parse identity: %s"
 msgstr  ""
@@ -1322,7 +1322,7 @@ msgstr  ""
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1468,7 +1468,7 @@ msgstr  ""
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1544,7 +1544,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889 lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167 lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455 lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732 lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470 lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750 lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1700,7 +1700,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
@@ -1716,7 +1716,7 @@ msgstr  ""
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
@@ -2161,7 +2161,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2209,7 +2209,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2368,7 +2368,7 @@ msgstr  ""
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2427,7 +2427,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid   "IDENTIFIER"
 msgstr  ""
 
@@ -2459,12 +2459,12 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
@@ -2587,7 +2587,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid   "Inspect permissions"
 msgstr  ""
 
@@ -2875,11 +2875,11 @@ msgstr  ""
 msgid   "List groups"
 msgstr  ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -3022,7 +3022,7 @@ msgstr  ""
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid   "List permissions"
 msgstr  ""
 
@@ -3215,11 +3215,11 @@ msgstr  ""
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid   "Manage groups"
 msgstr  ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid   "Manage groups for the identity"
 msgstr  ""
 
@@ -3227,7 +3227,7 @@ msgstr  ""
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3455,19 +3455,19 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416 lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416 lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid   "Missing group name"
 msgstr  ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
@@ -3628,7 +3628,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
 msgid   "NAME"
 msgstr  ""
 
@@ -4008,7 +4008,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4333,7 +4333,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid   "Remove a group from an identity"
 msgstr  ""
 
@@ -4369,7 +4369,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4429,7 +4429,7 @@ msgstr  ""
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -4907,7 +4907,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -4939,7 +4939,7 @@ msgstr  ""
 msgid   "Show group configurations"
 msgstr  ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid   "Show identity configurations\n"
         "\n"
         "The argument must be a concatenation of the authentication method and either the \n"
@@ -5038,6 +5038,14 @@ msgstr  ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid   "Show storage volume state information"
+msgstr  ""
+
+#: lxc/auth.go:895
+msgid   "Show the current identity\n"
+        "\n"
+        "This command will display permissions for the current user.\n"
+        "This includes contextual information, such as effective groups and permissions\n"
+        "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5264,7 +5272,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1509 lxc/warning.go:215
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1509 lxc/warning.go:215
 msgid   "TYPE"
 msgstr  ""
 
@@ -5881,8 +5889,12 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid   "View an identity"
+msgstr  ""
+
+#: lxc/auth.go:894
+msgid   "View the current identity"
 msgstr  ""
 
 #: lxc/storage_volume.go:1374
@@ -5946,7 +5958,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687 lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -5974,7 +5986,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
@@ -6034,11 +6046,11 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6050,7 +6062,7 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439 lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155 lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
+#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439 lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155 lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
@@ -6066,15 +6078,15 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
@@ -6583,12 +6595,12 @@ msgid   "lxc auth group edit <group> < group.yaml\n"
         "   Update a group using the content of group.yaml"
 msgstr  ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < identity.yaml\n"
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -228,7 +228,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -249,7 +249,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -784,7 +784,7 @@ msgstr "ARCHITECTUUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -822,11 +822,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1574,12 +1574,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1871,23 +1871,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2152,7 +2152,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2623,7 +2623,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2681,7 +2681,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2899,7 +2899,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2931,12 +2931,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3062,7 +3062,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3356,11 +3356,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3513,7 +3513,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3708,11 +3708,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3720,7 +3720,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3961,19 +3961,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4195,7 +4195,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4585,7 +4585,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4936,7 +4936,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4972,7 +4972,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5033,7 +5033,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5542,7 +5542,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5677,6 +5677,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5903,7 +5913,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6543,8 +6553,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6614,12 +6628,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6647,7 +6661,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6708,11 +6722,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6725,7 +6739,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6744,15 +6758,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7292,14 +7306,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -822,7 +822,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -860,11 +860,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1612,12 +1612,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1909,23 +1909,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2174,7 +2174,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2661,7 +2661,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2719,7 +2719,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2937,7 +2937,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2969,12 +2969,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3394,11 +3394,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3551,7 +3551,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3746,11 +3746,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3758,7 +3758,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3999,19 +3999,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4233,7 +4233,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4623,7 +4623,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4974,7 +4974,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5010,7 +5010,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5071,7 +5071,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5580,7 +5580,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5612,7 +5612,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5715,6 +5715,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5941,7 +5951,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6581,8 +6591,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6652,12 +6666,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6685,7 +6699,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6746,11 +6760,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6763,7 +6777,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6782,15 +6796,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7330,14 +7344,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2672,7 +2672,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2704,12 +2704,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3129,11 +3129,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3481,11 +3481,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,19 +3734,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3968,7 +3968,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5347,7 +5347,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5450,6 +5450,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5676,7 +5686,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6316,8 +6326,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6387,12 +6401,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6420,7 +6434,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6481,11 +6495,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6498,7 +6512,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6517,15 +6531,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7065,14 +7079,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -231,7 +231,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -819,7 +819,7 @@ msgstr "ARQUITETURA"
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -859,11 +859,11 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1640,12 +1640,12 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1877,7 +1877,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1967,23 +1967,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2259,7 +2259,7 @@ msgstr "Editar arquivos no container"
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2746,7 +2746,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2983,7 +2983,7 @@ msgstr "Clustering ativado"
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3042,7 +3042,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3074,12 +3074,12 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3508,11 +3508,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3668,7 +3668,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3868,12 +3868,12 @@ msgstr "Editar arquivos no container"
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3882,7 +3882,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4148,22 +4148,22 @@ msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4395,7 +4395,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4786,7 +4786,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5146,7 +5146,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
@@ -5187,7 +5187,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5256,7 +5256,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5796,7 +5796,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5832,7 +5832,7 @@ msgstr "Adicionar dispositivos aos containers ou perfis"
 msgid "Show group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5951,6 +5951,16 @@ msgstr ""
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
+msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
@@ -6179,7 +6189,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6852,8 +6862,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6924,12 +6938,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6960,7 +6974,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7031,11 +7045,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7049,7 +7063,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7072,17 +7086,17 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
@@ -7674,14 +7688,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -235,7 +235,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +256,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -823,7 +823,7 @@ msgstr "АРХИТЕКТУРА"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +862,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1628,12 +1628,12 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1864,7 +1864,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1953,23 +1953,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2240,7 +2240,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2730,7 +2730,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2963,7 +2963,7 @@ msgstr " Использование сети:"
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3023,7 +3023,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3055,12 +3055,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3496,12 +3496,12 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 #, fuzzy
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3658,7 +3658,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 #, fuzzy
 msgid "List permissions"
 msgstr "Псевдонимы:"
@@ -3863,12 +3863,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3877,7 +3877,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4145,22 +4145,22 @@ msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4396,7 +4396,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4791,7 +4791,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -5147,7 +5147,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5186,7 +5186,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5251,7 +5251,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5787,7 +5787,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5822,7 +5822,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5938,6 +5938,16 @@ msgstr ""
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
+msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
 msgid "Show the default remote"
@@ -6170,7 +6180,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6833,8 +6843,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6912,12 +6926,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -6973,7 +6987,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7090,11 +7104,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7115,7 +7129,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7150,7 +7164,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7158,7 +7172,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7166,7 +7180,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8162,14 +8176,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1648,23 +1648,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2708,12 +2708,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3133,11 +3133,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3485,11 +3485,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,19 +3738,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4810,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5454,6 +5454,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5680,7 +5690,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6320,8 +6330,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6391,12 +6405,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6424,7 +6438,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6485,11 +6499,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6502,7 +6516,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6521,15 +6535,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7069,14 +7083,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1648,23 +1648,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2708,12 +2708,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3133,11 +3133,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3485,11 +3485,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,19 +3738,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4810,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5454,6 +5454,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5680,7 +5690,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6320,8 +6330,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6391,12 +6405,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6424,7 +6438,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6485,11 +6499,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6502,7 +6516,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6521,15 +6535,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7069,14 +7083,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1644,23 +1644,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2454,7 +2454,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2613,7 +2613,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2672,7 +2672,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2704,12 +2704,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2835,7 +2835,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3129,11 +3129,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3481,11 +3481,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3493,7 +3493,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,19 +3734,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3968,7 +3968,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4358,7 +4358,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5315,7 +5315,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5347,7 +5347,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5450,6 +5450,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5676,7 +5686,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6316,8 +6326,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6387,12 +6401,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6420,7 +6434,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6481,11 +6495,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6498,7 +6512,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6517,15 +6531,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7065,14 +7079,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1648,23 +1648,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1913,7 +1913,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2708,12 +2708,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3133,11 +3133,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3485,11 +3485,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3497,7 +3497,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,19 +3738,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3972,7 +3972,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4810,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5351,7 +5351,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5454,6 +5454,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5680,7 +5690,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6320,8 +6330,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6391,12 +6405,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6424,7 +6438,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6485,11 +6499,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6502,7 +6516,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6521,15 +6535,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7069,14 +7083,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -721,7 +721,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -759,11 +759,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1511,12 +1511,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1808,23 +1808,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -2073,7 +2073,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2560,7 +2560,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2618,7 +2618,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2777,7 +2777,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2868,12 +2868,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3293,11 +3293,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3450,7 +3450,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3645,11 +3645,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3898,19 +3898,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4132,7 +4132,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4873,7 +4873,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4909,7 +4909,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5511,7 +5511,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5614,6 +5614,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5840,7 +5850,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6480,8 +6490,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6551,12 +6565,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6584,7 +6598,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6645,11 +6659,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6662,7 +6676,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6681,15 +6695,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7229,14 +7243,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-05 17:17+0000\n"
+"POT-Creation-Date: 2024-03-06 09:51+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:901
+#: lxc/auth.go:968
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1516
+#: lxc/auth.go:1583
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:807
+#: lxc/auth.go:813
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1039 lxc/auth.go:1040
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1805 lxc/auth.go:1806
+#: lxc/auth.go:1872 lxc/auth.go:1873
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1350,12 +1350,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1591
+#: lxc/auth.go:300 lxc/auth.go:1658
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:987
+#: lxc/auth.go:1054
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1402 lxc/auth.go:1403
+#: lxc/auth.go:1469 lxc/auth.go:1470
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1454 lxc/auth.go:1455
+#: lxc/auth.go:1521 lxc/auth.go:1522
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,23 +1647,23 @@ msgstr ""
 #: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
 #: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:759 lxc/auth.go:826 lxc/auth.go:889
-#: lxc/auth.go:1017 lxc/auth.go:1040 lxc/auth.go:1098 lxc/auth.go:1167
-#: lxc/auth.go:1189 lxc/auth.go:1365 lxc/auth.go:1403 lxc/auth.go:1455
-#: lxc/auth.go:1504 lxc/auth.go:1623 lxc/auth.go:1683 lxc/auth.go:1732
-#: lxc/auth.go:1783 lxc/auth.go:1806 lxc/auth.go:1859 lxc/cluster.go:29
-#: lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306
-#: lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521
-#: lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880
-#: lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168
-#: lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84
-#: lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266
-#: lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529
-#: lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23
-#: lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32
-#: lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734
-#: lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988
-#: lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
+#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
+#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
+#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
+#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
+#: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
+#: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
+#: lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061
+#: lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214
+#: lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456
+#: lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631
+#: lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106
+#: lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517
+#: lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933
+#: lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164
 #: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208
 #: lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450
 #: lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668
@@ -1912,7 +1912,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:888 lxc/auth.go:889
+#: lxc/auth.go:955 lxc/auth.go:956
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,7 +1928,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1503 lxc/auth.go:1504
+#: lxc/auth.go:1570 lxc/auth.go:1571
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2399,7 +2399,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:763 lxc/auth.go:1627
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:811 lxc/auth.go:1667
+#: lxc/auth.go:817 lxc/auth.go:1734
 msgid "GROUPS"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1717
+#: lxc/auth.go:426 lxc/auth.go:1784
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:810
+#: lxc/auth.go:816
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2707,12 +2707,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1439
+#: lxc/auth.go:1506
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1489
+#: lxc/auth.go:1556
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1166 lxc/auth.go:1167
+#: lxc/auth.go:1233 lxc/auth.go:1234
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3132,11 +3132,11 @@ msgstr ""
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:758 lxc/auth.go:759
+#: lxc/auth.go:764 lxc/auth.go:765
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1622 lxc/auth.go:1623
+#: lxc/auth.go:1689 lxc/auth.go:1690
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3289,7 +3289,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1188 lxc/auth.go:1189
+#: lxc/auth.go:1255 lxc/auth.go:1256
 msgid "List permissions"
 msgstr ""
 
@@ -3484,11 +3484,11 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1364 lxc/auth.go:1365
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1016 lxc/auth.go:1017
+#: lxc/auth.go:1083 lxc/auth.go:1084
 msgid "Manage groups for the identity"
 msgstr ""
 
@@ -3496,7 +3496,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1782 lxc/auth.go:1783
+#: lxc/auth.go:1849 lxc/auth.go:1850
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,19 +3737,19 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1756
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:856 lxc/auth.go:936 lxc/auth.go:1064 lxc/auth.go:1122
+#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1426 lxc/auth.go:1479 lxc/auth.go:1545 lxc/auth.go:1707
+#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1830 lxc/auth.go:1883
+#: lxc/auth.go:1897 lxc/auth.go:1950
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3971,7 +3971,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:809 lxc/auth.go:1666 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:988 lxc/auth.go:1592 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
 #: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
@@ -4712,7 +4712,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1097 lxc/auth.go:1098
+#: lxc/auth.go:1164 lxc/auth.go:1165
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1858 lxc/auth.go:1859
+#: lxc/auth.go:1925 lxc/auth.go:1926
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4809,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1682 lxc/auth.go:1683
+#: lxc/auth.go:1749 lxc/auth.go:1750
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5318,7 +5318,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1798 lxc/auth.go:1799
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:826
+#: lxc/auth.go:832
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5453,6 +5453,16 @@ msgstr ""
 
 #: lxc/storage_volume.go:1174 lxc/storage_volume.go:1175
 msgid "Show storage volume state information"
+msgstr ""
+
+#: lxc/auth.go:895
+msgid ""
+"Show the current identity\n"
+"\n"
+"This command will display permissions for the current user.\n"
+"This includes contextual information, such as effective groups and "
+"permissions\n"
+"that are granted via identity provider group mappings. \n"
 msgstr ""
 
 #: lxc/remote.go:623 lxc/remote.go:624
@@ -5679,7 +5689,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:808 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6319,8 +6329,12 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:831
 msgid "View an identity"
+msgstr ""
+
+#: lxc/auth.go:894
+msgid "View the current identity"
 msgstr ""
 
 #: lxc/storage_volume.go:1374
@@ -6390,12 +6404,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:756 lxc/auth.go:1620 lxc/cluster.go:119
-#: lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347
-#: lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909
-#: lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103
-#: lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20
-#: lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
+#: lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407
+#: lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6423,7 +6437,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1187
+#: lxc/auth.go:1254
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6484,11 +6498,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:824
+#: lxc/auth.go:830
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1038 lxc/auth.go:1096 lxc/auth.go:1857
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6501,7 +6515,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:887 lxc/auth.go:1401 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6520,15 +6534,15 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1452 lxc/auth.go:1502 lxc/auth.go:1730
+#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1804
+#: lxc/auth.go:1871
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1680
+#: lxc/auth.go:1747
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7068,14 +7082,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:891
+#: lxc/auth.go:958
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1573
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -31,6 +31,8 @@ const (
 //
 // API extension: access_management.
 type Identity struct {
+	IdentityPut `yaml:",inline"`
+
 	// AuthenticationMethod is the authentication method that the identity
 	// authenticates to LXD with.
 	// Example: tls

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -79,8 +79,8 @@ type IdentityPut struct {
 type AuthGroup struct {
 	AuthGroupsPost `yaml:",inline"`
 
-	// Identities are the identities that are members of the group.
-	Identities []Identity `json:"identities" yaml:"identities"`
+	// Identities is a map of authentication method to slice of identity identifiers.
+	Identities map[string][]string `json:"identities" yaml:"identities"`
 
 	// IdentityProviderGroups are a list of groups from the IdP whose mapping
 	// includes this group.

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -52,14 +52,23 @@ type Identity struct {
 	Name string `json:"name" yaml:"name"`
 }
 
-// IdentityInfo expands an Identity to include group membership.
+// IdentityInfo expands an Identity to include effective group membership and effective permissions.
+// These fields can only be evaluated for the currently authenticated identity.
 //
 // swagger:model
 //
 // API extension: access_management.
 type IdentityInfo struct {
-	IdentityPut `yaml:",inline"`
-	Identity    `yaml:",inline"`
+	Identity `yaml:",inline"`
+
+	// Effective groups is the combined and deduplicated list of LXD groups that the identity is a direct member of, and
+	// the LXD groups that the identity is an effective member of via identity provider group mappings.
+	// Example: ["foo", "bar"]
+	EffectiveGroups []string `json:"effective_groups" yaml:"effective_groups"`
+
+	// Effective permissions is the combined and deduplicated list of permissions that the identity has by virtue of
+	// direct membership to a LXD group, or effective membership of a LXD group via identity provider group mappings.
+	EffectivePermissions []Permission `json:"effective_permissions" yaml:"effective_permissions"`
 }
 
 // IdentityPut contains the editable fields of an IdentityInfo.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -82,6 +82,21 @@ test_authorization() {
   # Check user has been added to the group.
   lxc auth identity list --format csv | grep -Fq 'oidc,OIDC client," ",test-user@example.com,test-group'
 
+  # Test `lxc auth identity info`
+  expected=$(cat << EOF
+groups:
+- test-group
+authentication_method: oidc
+type: OIDC client
+id: test-user@example.com
+name: ' '
+effective_groups:
+- test-group
+effective_permissions: []
+EOF
+)
+  lxc auth identity info oidc: | grep -Fz "${expected}"
+
   ### IDENTITY PROVIDER GROUP MANAGEMENT ###
   lxc auth identity-provider-group create test-idp-group
   ! lxc auth identity-provider-group group add test-idp-group not-found || false # Group not found


### PR DESCRIPTION
This PR:
* Changes the `Identities` field of the `Group` API type to a `map[string][]string` (authentication method to list of identifiers).
* Changes the `Identity` type to include `IdentityPut` (the list of group names).
* Removes `recursion=2` from `GET /1.0/identities` and always returns the groups for each identity.
* Changes `IdentityInfo` to include `Identity` and two new fields: `EffectiveGroups` and `EffectivePermissions`.
* Implements a new endpoint `GET /1.0/auth/identities/current` that resolves all of the requestors groups and permissions in the context of any group mappings that may have been set by the IdP.
* Updates the client for the above API changes.
* Adds a new command `lxc auth identity info [remote:]` to show permissions for the current user.

See https://github.com/canonical/lxd/pull/12976#issuecomment-1978897909 for more details.
#13042 should be merged first.