### PR TITLE
Use latest minio in test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,7 +274,7 @@ jobs:
           sudo apt-get clean
 
           mkdir -p "$(go env GOPATH)/bin"
-          curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2024-02-24T17-11-14Z --output "$(go env GOPATH)/bin/minio"
+          curl -sSfL https://dl.min.io/server/minio/release/linux-amd64/minio --output "$(go env GOPATH)/bin/minio"
           chmod +x "$(go env GOPATH)/bin/minio"
 
           # Also grab the latest minio client to maintain compatibility with the server.


### PR DESCRIPTION
The btrfs issues fixed by commit 8543c93a8 have been addressed upstream in MinIO in the latest release, so we can go back to pulling that.