### PR TITLE
Auth: Filter out identities, groups and, IdP groups that the requestor cannot view

### DIFF
--- a/lxd/auth/authorization_types.go
+++ b/lxd/auth/authorization_types.go
@@ -58,6 +58,18 @@ const (
 	// EntitlementCanDeleteGroups is the `can_delete_groups` Entitlement. It applies to entity.TypeServer.
 	EntitlementCanDeleteGroups Entitlement = "can_delete_groups"
 
+	// EntitlementCanCreateIdentityProviderGroups is the `can_create_identity_provider_groups` Entitlement. It applies to entity.TypeServer.
+	EntitlementCanCreateIdentityProviderGroups Entitlement = "can_create_identity_provider_groups"
+
+	// EntitlementCanViewIdentityProviderGroups is the `can_view_identity_provider_groups` Entitlement. It applies to entity.TypeServer.
+	EntitlementCanViewIdentityProviderGroups Entitlement = "can_view_identity_provider_groups"
+
+	// EntitlementCanEditIdentityProviderGroups is the `can_edit_identity_provider_groups` Entitlement. It applies to entity.TypeServer.
+	EntitlementCanEditIdentityProviderGroups Entitlement = "can_edit_identity_provider_groups"
+
+	// EntitlementCanDeleteIdentityProviderGroups is the `can_delete_identity_provider_groups` Entitlement. It applies to entity.TypeServer.
+	EntitlementCanDeleteIdentityProviderGroups Entitlement = "can_delete_identity_provider_groups"
+
 	// EntitlementStoragePoolManager is the `storage_pool_manager` Entitlement. It applies to entity.TypeServer.
 	EntitlementStoragePoolManager Entitlement = "storage_pool_manager"
 

--- a/lxd/db/cluster/identity_provider_groups.go
+++ b/lxd/db/cluster/identity_provider_groups.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
 )
 
 // Code generation directives.
@@ -44,7 +47,7 @@ type IdentityProviderGroupFilter struct {
 }
 
 // ToAPI converts the IdentityProviderGroup to an api.IdentityProviderGroup, making more database calls as necessary.
-func (i *IdentityProviderGroup) ToAPI(ctx context.Context, tx *sql.Tx) (*api.IdentityProviderGroup, error) {
+func (i *IdentityProviderGroup) ToAPI(ctx context.Context, tx *sql.Tx, canViewGroup auth.PermissionChecker) (*api.IdentityProviderGroup, error) {
 	idpGroup := &api.IdentityProviderGroup{
 		IdentityProviderGroupPost: api.IdentityProviderGroupPost{Name: i.Name},
 	}
@@ -56,7 +59,9 @@ func (i *IdentityProviderGroup) ToAPI(ctx context.Context, tx *sql.Tx) (*api.Ide
 
 	groupNames := make([]string, 0, len(groups))
 	for _, group := range groups {
-		groupNames = append(groupNames, group.Name)
+		if canViewGroup(entity.AuthGroupURL(group.Name)) {
+			groupNames = append(groupNames, group.Name)
+		}
 	}
 
 	idpGroup.Groups = groupNames

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -144,19 +144,36 @@ var identityProviderGroupCmd = APIEndpoint{
 func getIdentityProviderGroups(d *Daemon, r *http.Request) response.Response {
 	recursion := r.URL.Query().Get("recursion")
 	s := d.State()
+
+	canViewIDPGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeIdentityProviderGroup)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	var apiIDPGroups []*api.IdentityProviderGroup
 	var idpGroups []dbCluster.IdentityProviderGroup
-	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
-		idpGroups, err = dbCluster.GetIdentityProviderGroups(ctx, tx.Tx())
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+		allIDPGroups, err := dbCluster.GetIdentityProviderGroups(ctx, tx.Tx())
 		if err != nil {
 			return err
+		}
+
+		idpGroups = make([]dbCluster.IdentityProviderGroup, 0, len(allIDPGroups))
+		for _, idpGroup := range allIDPGroups {
+			if canViewIDPGroup(entity.IdentityProviderGroupURL(idpGroup.Name)) {
+				idpGroups = append(idpGroups, idpGroup)
+			}
 		}
 
 		if recursion == "1" {
 			apiIDPGroups = make([]*api.IdentityProviderGroup, 0, len(idpGroups))
 			for _, idpGroup := range idpGroups {
-				apiIDPGroup, err := idpGroup.ToAPI(ctx, tx.Tx())
+				apiIDPGroup, err := idpGroup.ToAPI(ctx, tx.Tx(), canViewGroup)
 				if err != nil {
 					return err
 				}
@@ -223,6 +240,11 @@ func getIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	var apiIDPGroup *api.IdentityProviderGroup
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		idpGroup, err := dbCluster.GetIdentityProviderGroup(ctx, tx.Tx(), idpGroupName)
@@ -230,7 +252,7 @@ func getIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		apiIDPGroup, err = idpGroup.ToAPI(ctx, tx.Tx())
+		apiIDPGroup, err = idpGroup.ToAPI(ctx, tx.Tx(), canViewGroup)
 		if err != nil {
 			return err
 		}
@@ -427,13 +449,18 @@ func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		idpGroup, err := dbCluster.GetIdentityProviderGroup(ctx, tx.Tx(), idpGroupName)
 		if err != nil {
 			return err
 		}
 
-		apiIDPGroup, err := idpGroup.ToAPI(ctx, tx.Tx())
+		apiIDPGroup, err := idpGroup.ToAPI(ctx, tx.Tx(), canViewGroup)
 		if err != nil {
 			return err
 		}
@@ -511,6 +538,11 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
+	canViewGroup, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeAuthGroup)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	var apiIDPGroup *api.IdentityProviderGroup
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		idpGroup, err := dbCluster.GetIdentityProviderGroup(ctx, tx.Tx(), idpGroupName)
@@ -518,7 +550,7 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
-		apiIDPGroup, err = idpGroup.ToAPI(ctx, tx.Tx())
+		apiIDPGroup, err = idpGroup.ToAPI(ctx, tx.Tx(), canViewGroup)
 		if err != nil {
 			return err
 		}

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -28,11 +28,11 @@ var identityProviderGroupsCmd = APIEndpoint{
 	Path: "auth/identity-provider-groups",
 	Get: APIEndpointAction{
 		Handler:       getIdentityProviderGroups,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanViewGroups),
+		AccessHandler: allowAuthenticated,
 	},
 	Post: APIEndpointAction{
 		Handler:       createIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEditGroups),
+		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanCreateIdentityProviderGroups),
 	},
 }
 
@@ -41,23 +41,23 @@ var identityProviderGroupCmd = APIEndpoint{
 	Path: "auth/identity-provider-groups/{idpGroupName}",
 	Get: APIEndpointAction{
 		Handler:       getIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanViewGroups),
+		AccessHandler: allowPermission(entity.TypeIdentityProviderGroup, auth.EntitlementCanView, "idpGroupName"),
 	},
 	Put: APIEndpointAction{
 		Handler:       updateIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEditGroups),
+		AccessHandler: allowPermission(entity.TypeIdentityProviderGroup, auth.EntitlementCanEdit, "idpGroupName"),
 	},
 	Post: APIEndpointAction{
 		Handler:       renameIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEditGroups),
+		AccessHandler: allowPermission(entity.TypeIdentityProviderGroup, auth.EntitlementCanEdit, "idpGroupName"),
 	},
 	Delete: APIEndpointAction{
 		Handler:       deleteIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEditGroups),
+		AccessHandler: allowPermission(entity.TypeIdentityProviderGroup, auth.EntitlementCanDelete, "idpGroupName"),
 	},
 	Patch: APIEndpointAction{
 		Handler:       patchIdentityProviderGroup,
-		AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEditGroups),
+		AccessHandler: allowPermission(entity.TypeIdentityProviderGroup, auth.EntitlementCanEdit, "idpGroupName"),
 	},
 }
 


### PR DESCRIPTION
This is an oversight from #12914. 

- [x] When listing identities, the groups that the identities are a member of should be filtered by what the requestor is able to view.
- [x]  When listing groups, the identities that are members and the identity provider groups that are mapped to the groups should be filtered by what the requestor is able to view. 
- [x] When listing identity provider groups, the groups that are mapped to it should be filtered by what the requestor is able to view.