### PR TITLE
github: Restore testing latest stable version of go rather than go tip

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,11 +143,13 @@ jobs:
         go: ["1.22.x"]
         suite: ["cluster", "standalone"]
         backend: ["dir", "btrfs", "lvm", "zfs", "ceph", "random"]
-        # Only test with go-tip when the event is not a push
-        include: >-
-          ${{
-            (github.event_name != 'push' && fromJSON('[{"go":"tip","suite":"cluster","backend":"dir"},{"go":"tip","suite":"standalone","backend":"dir"}]')) || null
-          }}
+        include:
+          - go: stable
+            suite: cluster
+            backend: dir
+          - go: stable
+            suite: standalone
+            backend: dir
 
     steps:
       - name: Performance tuning


### PR DESCRIPTION
Testing with go tip IMHO offers little benefit as we get the odd failure that later resolves itself
which causes distractions. And if a stable release introduces changes that cause our tests to fail
we will have time to fix them before we switch the snap to build with the later version as we now
pin the snap to build with a specific Go version for reproduciblity.

So instead lets do a basic standalone and cluster test with the latest stable version.
At the moment this will cause some duplication of tests as we are explicitly testing with go 1.22,
which is also the latest stable. But this will not be the case when go 1.23 comes out.

This also has the benefit of of not needing to have a conditional on push as we should take a
breakage on the latest stable release more seriously and stop the edge builds.

Fixes edge build introduced by https://github.com/canonical/lxd/pull/13042
