### PR TITLE
VM: Further fix linter fixes preventing copy to remote

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7306,7 +7306,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		// A zero length Snapshots slice indicates volume only migration in
 		// VolumeTargetArgs. So if VolumeOnly was requested, do not populate them.
-		snapOps := []operationlock.InstanceOperation{}
+		snapOps := []*operationlock.InstanceOperation{}
 		if args.Snapshots {
 			volTargetArgs.Snapshots = make([]string, 0, len(snapshots))
 			for _, snap := range snapshots {
@@ -7342,7 +7342,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 						snapInstOp.Done(err)
 					})
 
-					snapOps = append(snapOps, *snapInstOp)
+					snapOps = append(snapOps, snapInstOp)
 				}
 			}
 		}


### PR DESCRIPTION
A change that was made to satisfy the linter as part of https://github.com/canonical/lxd/pull/12754 (commit https://github.com/canonical/lxd/commit/3dec35308f1b504f8f4ce72a586afa9cff389267) is causing an error message on subsequent migrations:

```bash
julian@thinkpad:~$ lxc cp v1 localhost:v2
julian@thinkpad:~$ lxc rm v2
julian@thinkpad:~$ lxc cp v1 localhost:v2
Error: Failed instance creation: Error transferring instance data: Failed migration on target: Failed creating instance snapshot record "v2/snap0": Instance is busy running a "create" operation
```

This PR ensures a pointer is used to track the VMs operations so that the actual operation is then marked as done.