### PR TITLE
lxd/db/cluster: Actually swap argument order in SQL statement.

### DIFF
--- a/lxd/db/cluster/identity_provider_groups.go
+++ b/lxd/db/cluster/identity_provider_groups.go
@@ -113,7 +113,7 @@ func SetIdentityProviderGroupMapping(ctx context.Context, tx *sql.Tx, identityPr
 
 	q := fmt.Sprintf(`
 INSERT INTO auth_groups_identity_provider_groups (auth_group_id, identity_provider_group_id)
-SELECT ?, auth_groups.id
+SELECT auth_groups.id, ?
 FROM auth_groups
 WHERE auth_groups.name IN %s
 `, query.Params(len(groupNames)))


### PR DESCRIPTION
This was meant to be fixed in #13043 but it appears it hasn't been. I must have missed this while rebasing or something. Thanks to @mas-who for reporting.