### PR TITLE
Migration: Use volume name from DB in migrationSourceWs.DoStorage

### DIFF
--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -150,7 +150,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 
 	volSourceArgs := &migration.VolumeSourceArgs{
 		IndexHeaderVersion: respHeader.GetIndexHeaderVersion(), // Enable index header frame if supported.
-		Name:               volName,
+		Name:               srcConfig.Volume.Name,
 		MigrationType:      migrationTypes[0],
 		Snapshots:          offerHeader.SnapshotNames,
 		TrackProgress:      true,


### PR DESCRIPTION
This fixes https://github.com/canonical/lxd/security/code-scanning/147

Although wasn't an actual security problem because the DB check would fail the request if the volume specified didn't exist rather than passing unverified input to the storage layer.