### PR TITLE
Network: Change protocol field for OVN ACL logs

### DIFF
--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -1078,12 +1078,12 @@ func ovnParseLogEntry(input string, prefix string) string {
 	}
 
 	// Get the protocol.
-	severityFields := strings.Split(aclEntry["severity"], " ")
-	if len(severityFields) != 2 {
+	directionFields := strings.Split(aclEntry["direction"], " ")
+	if len(directionFields) != 2 {
 		return ""
 	}
 
-	protocol := severityFields[1]
+	protocol := directionFields[1]
 
 	// Get the source and destination addresses.
 	srcAddr, ok := aclEntry["nw_src"]


### PR DESCRIPTION
Closes #12933

ovn-controller.log no longer reports the protocol on the `severity` field, instead including it with the `direction` field.

Previously, the log line would include:
 `severity=info: tcp`

Whereas now, it simply reports the log level:
 `severity=info`

The protocol is now reported with the direction:
 `direction=to-lport: icmp`