### PR TITLE
Migration: Revert adding rsync features for BLOCK_AND_RSYNC

### DIFF
--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -193,7 +193,13 @@ func MatchTypes(offer *MigrationHeader, fallbackType MigrationFSType, ourTypes [
 				offeredFeatures = offer.GetZfsFeaturesSlice()
 			} else if offerFSType == MigrationFSType_BTRFS {
 				offeredFeatures = offer.GetBtrfsFeaturesSlice()
-			} else if shared.ValueInSlice(offerFSType, []MigrationFSType{MigrationFSType_RSYNC, MigrationFSType_BLOCK_AND_RSYNC}) {
+			} else if offerFSType == MigrationFSType_RSYNC {
+				// There are other migration types using rsync like MigrationFSType_BLOCK_AND_RSYNC
+				// for which we cannot set the offered features as an older LXD might ignore those
+				// if the migration type is not MigrationFSType_RSYNC.
+				// When both the source and target agree on MigrationFSType_BLOCK_AND_RSYNC
+				// the rsync portion of the migration type isn't using any features.
+				// This allows staying backwards compatible with older versions of LXD.
 				offeredFeatures = offer.GetRsyncFeaturesSlice()
 			}
 


### PR DESCRIPTION
This allows staying backwards compatible with older versions of LXD.

The removal of legacy LXD 3.7 rsync feature assumptions from https://github.com/canonical/lxd/pull/13040 and https://github.com/canonical/lxd/pull/13041 can stay as the check for rsync features in the `RSYNC` migration type is already part of the older LXD releases.