### PR TITLE
Storage: Ceph RBD followup

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -622,6 +622,8 @@ func (d *ceph) copyVolumeDiff(sourceVolumeName string, targetVolumeName string, 
 	rbdRecvCmd.Stdout = os.Stdout
 	rbdRecvCmd.Stderr = os.Stderr
 
+	d.logger.Debug("Copying RBD volume", logger.Ctx{"srcVolName": sourceVolumeName, "volName": targetVolumeName, "srcParentSnap": sourceParentSnapshot})
+
 	err := rbdRecvCmd.Start()
 	if err != nil {
 		return err
@@ -1169,6 +1171,8 @@ func (d *ceph) sendVolume(conn io.ReadWriteCloser, volumeName string, volumePare
 
 	cmd.Stdout = stdout
 
+	d.logger.Debug("Sending RBD volume", logger.Ctx{"volName": volumeName, "volParentName": volumeParentName})
+
 	err = cmd.Start()
 	if err != nil {
 		return err
@@ -1213,6 +1217,8 @@ func (d *ceph) receiveVolume(volumeName string, conn io.ReadWriteCloser, writeWr
 		_ = stdin.Close()
 		chCopyConn <- err
 	}()
+
+	d.logger.Debug("Receiving RBD volume", logger.Ctx{"volName": volumeName})
 
 	// Run the command.
 	err = cmd.Start()

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -549,7 +549,7 @@ func (d *ceph) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteCloser
 	// This will recursively call this function again and fall back to the generic way of refreshing.
 	if vol.IsVMBlock() {
 		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
-		var fsVolSnapshots []Volume
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
 		for _, snapshot := range vol.Snapshots {
 			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
 		}
@@ -709,12 +709,12 @@ func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 	// This will recursively call this function again and fall back to the generic way of refreshing.
 	if srcVol.IsVMBlock() {
 		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
-		var srcFsVolSnapshots []Volume
+		srcFsVolSnapshots := make([]Volume, 0, len(srcVol.Snapshots))
 		for _, snapshot := range srcVol.Snapshots {
 			srcFsVolSnapshots = append(srcFsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
 		}
 
-		var fsVolSnapshots []Volume
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
 		for _, snapshot := range vol.Snapshots {
 			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
 		}
@@ -1644,7 +1644,7 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 	// This will recursively call this function again and fall back to the generic way of refreshing.
 	if vol.IsVMBlock() {
 		// Ensure that the volume's snapshots are also replaced with their filesystem counterpart.
-		var fsVolSnapshots []Volume
+		fsVolSnapshots := make([]Volume, 0, len(vol.Snapshots))
 		for _, snapshot := range vol.Snapshots {
 			fsVolSnapshots = append(fsVolSnapshots, snapshot.NewVMBlockFilesystemVolume())
 		}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -805,7 +805,8 @@ func (d *ceph) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots
 	}
 
 	if srcVol.IsSnapshot() {
-		// The target volume was just deleted.
+		// The target volume was just deleted in the step before
+		// as there isn't any common snapshot when refreshing a volume from a snapshot.
 		// Simply copy the source volume again to the target.
 		return d.CreateVolumeFromCopy(vol, srcVol, allowInconsistent, op)
 	}


### PR DESCRIPTION
This PR adds a comment to clarify local volume refreshes from snapshots as requested in https://github.com/canonical/lxd/pull/12743#discussion_r1516255599. 

Some slices are now initialized using their final size to improve performance.
Furthermore new log messages for local copies and migrations now indicate when a RBD volumes gets copied or sent/received.