### PR TITLE
Auth: Filter UsedBy results outside of transactions

### DIFF
--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -190,6 +190,7 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 
 			netACLInfo := netACL.Info()
 			netACLInfo.UsedBy, _ = netACL.UsedBy() // Ignore errors in UsedBy, will return nil.
+			netACLInfo.UsedBy = project.FilterUsedBy(s.Authorizer, r, netACLInfo.UsedBy)
 
 			resultMap = append(resultMap, *netACLInfo)
 		}
@@ -397,6 +398,7 @@ func networkACLGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	info.UsedBy = project.FilterUsedBy(s.Authorizer, r, info.UsedBy)
 	return response.SyncResponseETag(true, info, netACL.Etag())
 }
 

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -174,6 +174,7 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 		peers := make([]*api.NetworkPeer, 0, len(records))
 		for _, record := range records {
 			record.UsedBy, _ = n.PeerUsedBy(record.Name)
+			record.UsedBy = project.FilterUsedBy(s.Authorizer, r, record.UsedBy)
 			peers = append(peers, record)
 		}
 
@@ -443,6 +444,7 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	peer.UsedBy, _ = n.PeerUsedBy(peer.Name)
+	peer.UsedBy = project.FilterUsedBy(s.Authorizer, r, peer.UsedBy)
 
 	return response.SyncResponseETag(true, peer, peer.Etag())
 }

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -179,6 +179,7 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 
 			netzoneInfo := netzone.Info()
 			netzoneInfo.UsedBy, _ = netzone.UsedBy() // Ignore errors in UsedBy, will return nil.
+			netzoneInfo.UsedBy = project.FilterUsedBy(s.Authorizer, r, netzoneInfo.UsedBy)
 
 			resultMap = append(resultMap, *netzoneInfo)
 		}
@@ -386,6 +387,8 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 	if err != nil {
 		return response.SmartError(err)
 	}
+
+	info.UsedBy = project.FilterUsedBy(s.Authorizer, r, info.UsedBy)
 
 	return response.SyncResponseETag(true, info, netzone.Etag())
 }


### PR DESCRIPTION
Additionally, ensure that all UsedBy fields are filtered by what the user can view.

Blocks #12976 