### PR TITLE
Auth: Improve error handling

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -387,13 +387,13 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	fullSrv.AuthUserMethod = requestor.Protocol
 
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanViewConfiguration)
-	if err == nil {
+	if err != nil && !auth.IsDeniedError(err) {
+		return response.SmartError(err)
+	} else if err == nil {
 		fullSrv.Config, err = daemonConfigRender(s)
 		if err != nil {
 			return response.InternalError(err)
 		}
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
-		return response.SmartError(err)
 	}
 
 	return response.SyncResponseETag(true, fullSrv, fullSrv.Config)

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -329,7 +329,7 @@ func getFilteredMetrics(s *state.State, r *http.Request, compress bool, metricSe
 
 	// Get instances the user is allowed to view.
 	userHasPermission, err := s.Authorizer.GetPermissionChecker(r.Context(), r, auth.EntitlementCanView, entity.TypeInstance)
-	if err != nil && !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
 	} else if err != nil {
 		// This is counterintuitive. We are unauthorized to get a permission checker for viewing instances because a metric type certificate

--- a/lxd/auth/util.go
+++ b/lxd/auth/util.go
@@ -9,6 +9,13 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 )
 
+// IsDeniedError returns true if the error is not found or forbidden. This is because the CheckPermission method on
+// Authorizer will return a not found error if the requestor does not have access to view the resource. If a requestor
+// has view access, but not edit access a forbidden error is returned.
+func IsDeniedError(err error) bool {
+	return api.StatusErrorCheck(err, http.StatusNotFound, http.StatusForbidden)
+}
+
 // ValidateAuthenticationMethod returns an api.StatusError with http.StatusBadRequest if the given authentication
 // method is not recognised.
 func ValidateAuthenticationMethod(authenticationMethod string) error {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -423,10 +423,10 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	// Handle requests by non-admin users.
 	var userCanCreateCertificates bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanCreateIdentities)
-	if err == nil {
-		userCanCreateCertificates = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanCreateCertificates = true
 	}
 
 	if !trusted || !userCanCreateCertificates {
@@ -871,10 +871,10 @@ func doCertificateUpdate(d *Daemon, dbInfo api.Certificate, req api.CertificateP
 
 	var userCanEditCertificate bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.CertificateURL(dbInfo.Fingerprint), auth.EntitlementCanEdit)
-	if err == nil {
-		userCanEditCertificate = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanEditCertificate = true
 	}
 
 	// Non-admins are able to change their own certificate but no other fields.
@@ -1026,10 +1026,10 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 
 	var userCanEditCertificate bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.CertificateURL(certInfo.Fingerprint), auth.EntitlementCanDelete)
-	if err == nil {
-		userCanEditCertificate = true
-	} else if api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanEditCertificate = true
 	}
 
 	// Non-admins are able to delete only their own certificate.

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -973,10 +973,10 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 	var userCanCreateImages bool
 	err := s.Authorizer.CheckPermission(r.Context(), r, entity.ProjectURL(projectName), auth.EntitlementCanCreateImages)
-	if err == nil {
-		userCanCreateImages = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanCreateImages = true
 	}
 
 	trusted := d.checkTrustedClient(r) == nil && userCanCreateImages
@@ -3013,10 +3013,10 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 
 	var userCanViewImage bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageURL(projectName, info.Fingerprint), auth.EntitlementCanView)
-	if err == nil {
-		userCanViewImage = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanViewImage = true
 	}
 
 	public := d.checkTrustedClient(r) != nil || !userCanViewImage
@@ -3609,10 +3609,10 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 
 	var userCanViewImageAlias bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageAliasURL(projectName, name), auth.EntitlementCanView)
-	if err == nil {
-		userCanViewImageAlias = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanViewImageAlias = true
 	}
 
 	public := d.checkTrustedClient(r) != nil || !userCanViewImageAlias
@@ -4049,10 +4049,10 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 	// Access control.
 	var userCanViewImage bool
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.ImageURL(projectName, imgInfo.Fingerprint), auth.EntitlementCanView)
-	if err == nil {
-		userCanViewImage = true
-	} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err == nil {
+		userCanViewImage = true
 	}
 
 	public := d.checkTrustedClient(r) != nil || !userCanViewImage

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -870,11 +870,11 @@ func doNetworkGet(s *state.State, r *http.Request, allNodes bool, projectName st
 		apiNet.Type = n.Type()
 
 		err = s.Authorizer.CheckPermission(r.Context(), r, entity.NetworkURL(projectName, networkName), auth.EntitlementCanEdit)
-		if err == nil {
-			// Only allow admins to see network config as sensitive info can be stored there.
-			apiNet.Config = n.Config()
-		} else if !api.StatusErrorCheck(err, http.StatusForbidden) {
+		if err != nil && !auth.IsDeniedError(err) {
 			return api.Network{}, err
+		} else if err == nil {
+			// Only allow users that can edit network config to view it as sensitive info can be stored there.
+			apiNet.Config = n.Config()
 		}
 
 		// If no member is specified, we omit the node-specific fields.

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1509,7 +1509,7 @@ func CheckClusterTargetRestriction(authorizer auth.Authorizer, r *http.Request, 
 	if projectHasRestriction(project, "restricted.cluster.target", "block") && targetFlag != "" {
 		// Allow server administrators to move instances around even when restricted (node evacuation, ...)
 		err := authorizer.CheckPermission(r.Context(), r, entity.ServerURL(), auth.EntitlementCanOverrideClusterTargetRestriction)
-		if err != nil && api.StatusErrorCheck(err, http.StatusForbidden) {
+		if err != nil && auth.IsDeniedError(err) {
 			return api.StatusErrorf(http.StatusForbidden, "This project doesn't allow cluster member targeting")
 		} else if err != nil {
 			return err

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -638,11 +638,11 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	poolAPI.UsedBy = project.FilterUsedBy(s.Authorizer, r, poolUsedBy)
 
 	err = s.Authorizer.CheckPermission(r.Context(), r, entity.StoragePoolURL(poolName), auth.EntitlementCanEdit)
-	if err != nil && api.StatusErrorCheck(err, http.StatusForbidden) {
-		// Don't allow non-admins to see pool config as sensitive info can be stored there.
-		poolAPI.Config = nil
-	} else if err != nil {
+	if err != nil && !auth.IsDeniedError(err) {
 		return response.SmartError(err)
+	} else if err != nil {
+		// Only allow users that can edit storage pool config to view it as sensitive info can be stored there.
+		poolAPI.Config = nil
 	}
 
 	// If no member is specified and the daemon is clustered, we omit the node-specific fields.


### PR DESCRIPTION
The OpenFGA driver will return a 404 if the user does not have permission to view a resource, otherwise it will return a 403. This PR adds a util to check for auth errors being one of those codes and improves how error codes are being checked in the handlers.

Blocks #12976 