### PR TITLE
Auth: Identity cache improvements

### DIFF
--- a/lxd/identity/cache.go
+++ b/lxd/identity/cache.go
@@ -186,3 +186,21 @@ func (c *Cache) GetByOIDCSubject(subject string) (*CacheEntry, error) {
 
 	return nil, api.StatusErrorf(http.StatusNotFound, "Identity with OIDC subject %q not found", subject)
 }
+
+// GetIdentityProviderGroupMapping returns the auth groups that the given identity provider group maps to or an
+// api.StatusError with http.StatusNotFound.
+func (c *Cache) GetIdentityProviderGroupMapping(idpGroup string) ([]string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	lxdGroups, ok := c.identityProviderGroups[idpGroup]
+	if !ok {
+		return nil, api.StatusErrorf(http.StatusNotFound, "No mapping found for identity provider group %q", idpGroup)
+	}
+
+	if lxdGroups == nil {
+		return nil, api.StatusErrorf(http.StatusNotFound, "No mapping found for identity provider group %q", idpGroup)
+	}
+
+	return *lxdGroups, nil
+}

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -24,6 +24,8 @@ func AuthenticationMethodFromIdentityType(identityType string) (string, error) {
 	switch identityType {
 	case api.IdentityTypeCertificateClientRestricted, api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateServer, api.IdentityTypeCertificateMetrics:
 		return api.AuthenticationMethodTLS, nil
+	case api.IdentityTypeOIDCClient:
+		return api.AuthenticationMethodOIDC, nil
 	}
 
 	return "", fmt.Errorf("Identity type %q not recognized", identityType)


### PR DESCRIPTION
Adds OIDC identities to the `AuthenticationMethodFromIdentityType` method. This was causing errors in the OpenFGA driver (mroe details in commit message). Additionally adds a method `GetIdentityProviderGroupMapping` to the identity cache that will be used by the OpenFGA authorization driver.

Blocks #12976 