### PR TITLE
lxd/response: Use SmartError if SyncResponse success=false

### DIFF
--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -157,6 +157,13 @@ func (r *syncResponse) Render(w http.ResponseWriter) error {
 	status := api.Success
 	if !r.success {
 		status = api.Failure
+
+		// If the metadata is an error, consider the response a SmartError
+		// to propagate the data and preserve the status code.
+		err, ok := r.metadata.(error)
+		if ok {
+			return SmartError(err).Render(w)
+		}
 	}
 
 	if r.headers != nil {


### PR DESCRIPTION
SyncResponse's `success` field can hint that SyncResponse can potentially handle errors. However, when an error is passed in like so:
```
err = ceph.ServicePlacementHandler(interfaces.CephState{State: s}, payload)
    if err != nil {
        return response.SyncResponse(false, err)
    }
```

The syncResponse does not set the `error` field of the response, so the result has no metadata or error:
```
{
    "type": "sync",
    "status": "Failure",
    "status_code": 400,
    "operation": "",
    "error_code": 0,
    "error": "",
    "metadata": {}
}
```

It seems `SyncResponse(false, ...)` is never used in the LXD codebase for any reason, so I think it's safe to just handle this type of response like an error. So I've changed `Render` to just fallback to a SmartError, which will also try to maintain the http information from the underlying error.