### PR TITLE
Storage: Ceph RBD lock concurrent snapshot migrations

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1659,13 +1659,20 @@ func (d *ceph) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs
 	}
 
 	if vol.IsSnapshot() {
+		unlock, err := vol.MountLock()
+		if err != nil {
+			return err
+		}
+
+		defer unlock()
+
 		parentName, snapOnlyName, _ := api.GetParentAndSnapshotName(vol.name)
 		snapOnlyName = fmt.Sprintf("snapshot_%s", snapOnlyName)
 		parentVol := NewVolume(d, vol.pool, vol.volType, vol.contentType, parentName, nil, nil)
 		cloneVol := NewVolume(d, vol.pool, vol.volType, vol.contentType, fmt.Sprintf("%s_clone", parentName), nil, nil)
 
 		// Ensure the snapshot is protected so that it allows creating a clone from it.
-		err := d.rbdProtectVolumeSnapshot(parentVol, snapOnlyName)
+		err = d.rbdProtectVolumeSnapshot(parentVol, snapOnlyName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is sometimes causing an error in the pipeline when subsequent migrations are called right after another and the earlier migration isn't yet finished as the snapshot requires locking.

The generic volume migration (refresh) is triggering the Ceph RBD drivers `MountVolumeSnapshot()` which is calling `vol.MountLock()` for the respective volume. Before https://github.com/canonical/lxd/pull/13079 the drivers `MountVolumeSnapshot()` was also used for the initial migration using type `RBD`.
As a result we also have to use the lock here so that subsequent generic refreshes will wait until the lock is returned.

That was first observed in https://github.com/canonical/lxd/actions/runs/8206575452/job/22446018257?pr=13084 and caused by https://github.com/canonical/lxd/pull/13079. 