### PR TITLE
Indicate LTS version in LXD agent and useragent

### DIFF
--- a/lxd-agent/main.go
+++ b/lxd-agent/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,6 +38,9 @@ func main() {
 	// Version handling
 	app.SetVersionTemplate("{{.Version}}\n")
 	app.Version = version.Version
+	if version.IsLTSVersion {
+		app.Version = fmt.Sprintf("%s LTS", version.Version)
+	}
 
 	// Run the main command and handle errors
 	err := app.Execute()

--- a/shared/version/useragent.go
+++ b/shared/version/useragent.go
@@ -32,6 +32,9 @@ func getUserAgent() string {
 
 	// Initial version string
 	agent := fmt.Sprintf("LXD %s", Version)
+	if IsLTSVersion {
+		agent = fmt.Sprintf("%s LTS", agent)
+	}
 
 	// OS information
 	agent = fmt.Sprintf("%s (%s)", agent, strings.Join(osTokens, "; "))


### PR DESCRIPTION
Indicate LTS version in LXD agent. 
In addition, indicate LTS version in useragent, which simplifies scraping LXD version from various logs, such as Nginx log.