### PR TITLE
Storage: Use volume name from VolumeDBGet in BackupCustomVolume

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7032,13 +7032,13 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 	l.Debug("BackupCustomVolume started")
 	defer l.Debug("BackupCustomVolume finished")
 
-	// Get the volume name on storage.
-	volStorageName := project.StorageVolume(projectName, volName)
-
 	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return err
 	}
+
+	// Get the volume name on storage.
+	volStorageName := project.StorageVolume(projectName, volume.Name)
 
 	contentDBType, err := VolumeContentTypeNameToContentType(volume.ContentType)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/security/code-scanning/142

Although not an actual security issue because the `VolumeDBGet` was already validating the input was a valid volume name.