### PR TITLE
github: fix branch target name/version extraction logic

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -17,7 +17,7 @@ jobs:
       if: ${{ github.actor != 'dependabot[bot]' }}
       run: |
         set -eux
-        TARGET_FROM_PR_TITLE="$(echo "${TITLE}" | sed -n 's/.*(\(stable-[0-9]\.[0-9]\))$/\1/p')"
+        TARGET_FROM_PR_TITLE="$(echo "${TITLE}" | sed -n 's/.*(\(stable-[0-9]\+\.[0-9]\+\))$/\1/p')"
         if [ -z "${TARGET_FROM_PR_TITLE}" ]; then
           TARGET_FROM_PR_TITLE="main"
         else


### PR DESCRIPTION
This should handle stable-NM.XYZ instead of only stable-X.Y