### PR TITLE
client: Unset project when querying permissions.

### DIFF
--- a/client/lxd_auth.go
+++ b/client/lxd_auth.go
@@ -388,7 +388,7 @@ func (r *ProtocolLXD) GetPermissions(args GetPermissionsArgs) ([]api.Permission,
 	}
 
 	var permissions []api.Permission
-	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &permissions)
+	_, err = r.UseProject("").(*ProtocolLXD).queryStruct(http.MethodGet, u.String(), nil, "", &permissions)
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (r *ProtocolLXD) GetPermissionsInfo(args GetPermissionsArgs) ([]api.Permiss
 	}
 
 	var permissions []api.PermissionInfo
-	_, err = r.queryStruct(http.MethodGet, u.String(), nil, "", &permissions)
+	_, err = r.UseProject("").(*ProtocolLXD).queryStruct(http.MethodGet, u.String(), nil, "", &permissions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`lxc permission list` expects an explicit `project=<project_name>` argument. If the client has a project set (other than default) then all requests made by the client will add a `project=<project_name>` query parameter if it is not already set. This leads to confusing/inconsistent results for this command.