### PR TITLE
Auth: Don't build authorization drivers into the lxd-agent

### DIFF
--- a/lxd/auth/authorization.go
+++ b/lxd/auth/authorization.go
@@ -13,24 +13,10 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 )
 
-const (
-	// DriverTLS is used at start up to allow communication between cluster members and initialise the cluster database.
-	DriverTLS string = "tls"
-
-	// DriverEmbeddedOpenFGA is the default authorization driver. It currently falls back to DriverTLS for all TLS
-	// clients. It cannot be initialised until after the cluster database is operational.
-	DriverEmbeddedOpenFGA string = "embedded-openfga"
-)
+var authorizers = map[string]func() authorizer{}
 
 // ErrUnknownDriver is the "Unknown driver" error.
 var ErrUnknownDriver = fmt.Errorf("Unknown driver")
-
-var authorizers = map[string]func() authorizer{
-	DriverTLS: func() authorizer { return &tls{} },
-	DriverEmbeddedOpenFGA: func() authorizer {
-		return &embeddedOpenFGA{}
-	},
-}
 
 type authorizer interface {
 	Authorizer

--- a/lxd/auth/driver_common.go
+++ b/lxd/auth/driver_common.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo && !agent
+
 package auth
 
 import (

--- a/lxd/auth/driver_openfga.go
+++ b/lxd/auth/driver_openfga.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo && !agent
+
 package auth
 
 import (
@@ -21,6 +23,16 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 )
+
+const (
+	// DriverEmbeddedOpenFGA is the default authorization driver. It currently falls back to DriverTLS for all TLS
+	// clients. It cannot be initialised until after the cluster database is operational.
+	DriverEmbeddedOpenFGA string = "embedded-openfga"
+)
+
+func init() {
+	authorizers[DriverEmbeddedOpenFGA] = func() authorizer { return &embeddedOpenFGA{} }
+}
 
 //go:embed driver_openfga_model.openfga
 var model string

--- a/lxd/auth/driver_tls.go
+++ b/lxd/auth/driver_tls.go
@@ -1,3 +1,5 @@
+//go:build linux && cgo && !agent
+
 package auth
 
 import (
@@ -13,6 +15,15 @@ import (
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/logger"
 )
+
+const (
+	// DriverTLS is used at start up to allow communication between cluster members and initialise the cluster database.
+	DriverTLS string = "tls"
+)
+
+func init() {
+	authorizers[DriverTLS] = func() authorizer { return &tls{} }
+}
 
 type tls struct {
 	commonAuthorizer

--- a/lxd/db/openfga.go
+++ b/lxd/db/openfga.go
@@ -262,7 +262,7 @@ func (o *openfgaStore) ReadUsersetTuples(ctx context.Context, store string, filt
 
 		// Get all groups with the permission.
 		q := `
-SELECT auth_groups.name 
+SELECT auth_groups.name
 FROM auth_groups_permissions
 JOIN auth_groups ON auth_groups_permissions.auth_group_id = auth_groups.id
 WHERE auth_groups_permissions.entitlement = ? AND auth_groups_permissions.entity_type = ? AND auth_groups_permissions.entity_id = ?
@@ -460,8 +460,8 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 	// Construct a query to list permissions with the given entity type and entitlement for the given group.
 	q := `
 SELECT auth_groups_permissions.entity_type, auth_groups_permissions.entity_id, auth_groups_permissions.entitlement
-FROM auth_groups_permissions 
-JOIN auth_groups ON auth_groups_permissions.auth_group_id = auth_groups.id 
+FROM auth_groups_permissions
+JOIN auth_groups ON auth_groups_permissions.auth_group_id = auth_groups.id
 WHERE auth_groups_permissions.entitlement = ? AND auth_groups_permissions.entity_type = ? AND auth_groups.name = ?
 `
 	groupName := userURLPathArguments[0]


### PR DESCRIPTION
This only builds the parts of the auth package that are referenced by the state.State struct
used by the lxd-agent when building the lxd-agent.

This significantly reduces the size of the lxd-agent.