### PR TITLE
Release LXD 5.21.0 (stable-5.21)

### DIFF
--- a/shared/version/flex.go
+++ b/shared/version/flex.go
@@ -1,7 +1,7 @@
 package version
 
 // Version contains the LXD version number.
-var Version = "5.21"
+var Version = "5.21.0"
 
 // IsLTSVersion indicates this is an LTS version of LXD.
 var IsLTSVersion = true


### PR DESCRIPTION
Adds missing `.0` to internal version.