### PR TITLE
lxc/file: Get owner mode only if `--gid` or `--uid` is unset - from Incus

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -617,8 +617,9 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
-			_, dUID, dGID := shared.GetOwnerMode(finfo)
 			if c.file.flagUID == -1 || c.file.flagGID == -1 {
+				_, dUID, dGID := shared.GetOwnerMode(finfo)
+
 				if c.file.flagUID == -1 {
 					uid = dUID
 				}


### PR DESCRIPTION
If both `--gid` and `--uid` are set there's no need to get a file's GID or UID as they will be overridden by the provided values.