### PR TITLE
Instance: Add container `finit_module()` syscall interception support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2402,3 +2402,7 @@ Adds the ability for `POST /1.0/instances/{name}/files` to modify the permission
 ## `image_restriction_nesting`
 
 This extension adds a new image restriction, `requirements.nesting` which when `true` indicates that an image cannot be run without nesting.
+## `container_syscall_intercept_finit_module`
+
+Adds the `linux.kernel_modules.load` container configuration option. If the option is set to `ondemand`, the `finit_modules()` syscall is intercepted and a privileged user in the container's user namespace can load the Linux kernel modules specified in the
+allow list `linux.kernel_modules`.

--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1791,9 +1791,21 @@ See {ref}`cluster-evacuate` for more information.
 ```{config:option} linux.kernel_modules instance-miscellaneous
 :condition: "container"
 :liveupdate: "yes"
-:shortdesc: "Kernel modules to load before starting the instance"
+:shortdesc: "Kernel modules to load or allow loading"
 :type: "string"
 Specify the kernel modules as a comma-separated list.
+
+The modules are loaded before the instance starts, or they can be loaded by a privileged user if {config:option}`instance-miscellaneous:linux.kernel_modules.load` is set to `ondemand`.
+```
+
+```{config:option} linux.kernel_modules.load instance-miscellaneous
+:condition: "container"
+:defaultdesc: "`boot`"
+:liveupdate: "no"
+:shortdesc: "How to load kernel modules"
+:type: "string"
+This option specifies how to load the kernel modules that are specified in {config:option}`instance-miscellaneous:linux.kernel_modules`.
+Possible values are `boot` (load the modules when booting the container) and `ondemand` (intercept the `finit_modules()` syscall and allow a privileged user in the container's user namespace to load the modules).
 ```
 
 ```{config:option} linux.sysctl.* instance-miscellaneous

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1934,7 +1934,8 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 
 	// Load any required kernel modules
 	kernelModules := d.expandedConfig["linux.kernel_modules"]
-	if kernelModules != "" {
+	kernelModulesLoadPolicy := d.expandedConfig["linux.kernel_modules.load"]
+	if kernelModulesLoadPolicy != "ondemand" && kernelModules != "" {
 		for _, module := range strings.Split(kernelModules, ",") {
 			module = strings.TrimPrefix(module, " ")
 			err := util.LoadModule(module)
@@ -4465,6 +4466,10 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 					}
 				}
 			} else if key == "linux.kernel_modules" && value != "" {
+				if d.expandedConfig["linux.kernel_modules.load"] == "ondemand" {
+					continue
+				}
+
 				for _, module := range strings.Split(value, ",") {
 					module = strings.TrimPrefix(module, " ")
 					err := util.LoadModule(module)

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -559,12 +559,25 @@ var InstanceConfigKeysContainer = map[string]func(value string) error{
 
 	// lxdmeta:generate(entities=instance; group=miscellaneous; key=linux.kernel_modules)
 	// Specify the kernel modules as a comma-separated list.
+	//
+	// The modules are loaded before the instance starts, or they can be loaded by a privileged user if {config:option}`instance-miscellaneous:linux.kernel_modules.load` is set to `ondemand`.
 	// ---
 	//  type: string
 	//  liveupdate: yes
 	//  condition: container
-	//  shortdesc: Kernel modules to load before starting the instance
+	//  shortdesc: Kernel modules to load or allow loading
 	"linux.kernel_modules": validate.IsAny,
+
+	// lxdmeta:generate(entities=instance; group=miscellaneous; key=linux.kernel_modules.load)
+	// This option specifies how to load the kernel modules that are specified in {config:option}`instance-miscellaneous:linux.kernel_modules`.
+	// Possible values are `boot` (load the modules when booting the container) and `ondemand` (intercept the `finit_modules()` syscall and allow a privileged user in the container's user namespace to load the modules).
+	// ---
+	//  type: string
+	//  defaultdesc: `boot`
+	//  liveupdate: no
+	//  condition: container
+	//  shortdesc: How to load kernel modules
+	"linux.kernel_modules.load": validate.Optional(validate.IsOneOf("boot", "ondemand")),
 
 	// lxdmeta:generate(entities=instance; group=migration; key=migration.incremental.memory)
 	// Using incremental memory transfer of the instance's memory can reduce downtime.

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -145,6 +145,10 @@ func main() {
 	forksyscallCmd := cmdForksyscall{global: &globalCmd}
 	app.AddCommand(forksyscallCmd.Command())
 
+	// forksyscallgo sub-command
+	forksyscallgoCmd := cmdForksyscallgo{global: &globalCmd}
+	app.AddCommand(forksyscallgoCmd.Command())
+
 	// forkcoresched sub-command
 	forkcoreschedCmd := cmdForkcoresched{global: &globalCmd}
 	app.AddCommand(forkcoreschedCmd.Command())

--- a/lxd/main_forksyscallgo.go
+++ b/lxd/main_forksyscallgo.go
@@ -1,0 +1,112 @@
+// Analogous to main_forksyscall.go but for cases, when
+// you want to implement stuff in Golang.
+package main
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+type cmdForksyscallgo struct {
+	global *cmdGlobal
+}
+
+// Command returns a cobra.Command object representing the "forksyscallgo" command.
+func (c *cmdForksyscallgo) Command() *cobra.Command {
+	// Main subcommand
+	cmd := &cobra.Command{}
+	cmd.Use = "forksyscallgo <syscall_operation> <PID> <PidFd> [...]"
+	cmd.Short = "Perform syscall operations (golang)"
+	cmd.Long = `Description:
+  Perform syscall operations (golang)
+
+  This set of internal commands is used for all seccomp-based container syscall
+  operations (golang).
+`
+	cmd.Hidden = true
+
+	// finit_module_parse
+	finitModuleParseCmd := cmdFinitModuleParse{global: c.global, syscallgo: c}
+	cmd.AddCommand(finitModuleParseCmd.Command())
+
+	// Workaround for subcommand usage errors. See: https://github.com/spf13/cobra/issues/706
+	cmd.Args = cobra.NoArgs
+	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
+	return cmd
+}
+
+// finit_module_parse.
+type cmdFinitModuleParse struct {
+	global    *cmdGlobal
+	syscallgo *cmdForksyscallgo
+}
+
+// Command returns a cobra.Command object representing the "finit_module_parse" subcommand.
+func (c *cmdFinitModuleParse) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "finit_module_parse <module_fd>"
+
+	cmd.RunE = c.Run
+
+	return cmd
+}
+
+// Run executes the "finit_module_parse" subcommand.
+func (c *cmdFinitModuleParse) Run(cmd *cobra.Command, args []string) error {
+	moduleFD, err := strconv.Atoi(args[2])
+	if err != nil {
+		return fmt.Errorf("Unable to extract module_fd: %w", err)
+	}
+
+	f := os.NewFile(uintptr(moduleFD), "/proc/self/fd/<module_fd>")
+	if f == nil {
+		return fmt.Errorf("Can't open module file: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	elfFile, err := elf.NewFile(f)
+	if err != nil {
+		return fmt.Errorf("elf.NewFile failed: %w", err)
+	}
+
+	sec := elfFile.Section(".modinfo")
+	if sec == nil {
+		return fmt.Errorf("module's ELF file has no .modinfo section")
+	}
+
+	secData, err := sec.Data()
+	if err != nil {
+		return fmt.Errorf("Can't read .modinfo section: %w", err)
+	}
+
+	secNameDataIdx := bytes.Index(secData, []byte("name="))
+	if secNameDataIdx == -1 {
+		return fmt.Errorf(`.modinfo section data looks wrong: can't find "name="`)
+	}
+
+	secNameStart := secData[secNameDataIdx+5:]
+	if len(secNameStart) == 0 {
+		return fmt.Errorf(`.modinfo section data looks wrong: no data after "name="`)
+	}
+
+	secNameIdxEnd := bytes.Index(secNameStart, []byte("\x00"))
+	if secNameIdxEnd == -1 {
+		return fmt.Errorf(".modinfo section data looks wrong: can't find terminating NULL-byte")
+	}
+
+	secName := secNameStart[:secNameIdxEnd]
+	if len(secName) == 0 {
+		return fmt.Errorf(".modinfo section data looks wrong: module name is empty")
+	}
+
+	// print extracted module name so we can use it in the seccomp.go
+	fmt.Printf("%s", string(secName))
+
+	return nil
+}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2060,8 +2060,18 @@
 						"linux.kernel_modules": {
 							"condition": "container",
 							"liveupdate": "yes",
-							"longdesc": "Specify the kernel modules as a comma-separated list.",
-							"shortdesc": "Kernel modules to load before starting the instance",
+							"longdesc": "Specify the kernel modules as a comma-separated list.\n\nThe modules are loaded before the instance starts, or they can be loaded by a privileged user if {config:option}`instance-miscellaneous:linux.kernel_modules.load` is set to `ondemand`.",
+							"shortdesc": "Kernel modules to load or allow loading",
+							"type": "string"
+						}
+					},
+					{
+						"linux.kernel_modules.load": {
+							"condition": "container",
+							"defaultdesc": "`boot`",
+							"liveupdate": "no",
+							"longdesc": "This option specifies how to load the kernel modules that are specified in {config:option}`instance-miscellaneous:linux.kernel_modules`.\nPossible values are `boot` (load the modules when booting the container) and `ondemand` (intercept the `finit_modules()` syscall and allow a privileged user in the container's user namespace to load the modules).",
+							"shortdesc": "How to load kernel modules",
 							"type": "string"
 						}
 					},

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -854,6 +854,7 @@ func isContainerLowLevelOptionForbidden(key string) bool {
 	if shared.ValueInSlice(key, []string{
 		"boot.host_shutdown_timeout",
 		"linux.kernel_modules",
+		"linux.kernel_modules.load",
 		"raw.apparmor",
 		"raw.idmap",
 		"raw.lxc",

--- a/lxd/seccomp/cgo.go
+++ b/lxd/seccomp/cgo.go
@@ -8,4 +8,5 @@ package seccomp
 // #cgo CFLAGS: -Werror=implicit-function-declaration
 // #cgo CFLAGS: -Werror=return-type -Wendif-labels -Werror=overflow
 // #cgo CFLAGS: -Wnested-externs -fexceptions
+// #cgo pkg-config: libcap
 import "C"

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -100,6 +100,7 @@ struct lxd_seccomp_data_arch {
 	int nr_bpf;
 	int nr_sched_setscheduler;
 	int nr_sysinfo;
+	int nr_finit_module;
 };
 
 #define LXD_SECCOMP_NOTIFY_MKNOD    0
@@ -109,66 +110,67 @@ struct lxd_seccomp_data_arch {
 #define LXD_SECCOMP_NOTIFY_BPF 4
 #define LXD_SECCOMP_NOTIFY_SCHED_SETSCHEDULER 5
 #define LXD_SECCOMP_NOTIFY_SYSINFO 6
+#define LXD_SECCOMP_NOTIFY_FINIT_MODULE 7
 
 // ordered by likelihood of usage...
 static const struct lxd_seccomp_data_arch seccomp_notify_syscall_table[] = {
-	{ -1, LXD_SECCOMP_NOTIFY_MKNOD, LXD_SECCOMP_NOTIFY_MKNODAT, LXD_SECCOMP_NOTIFY_SETXATTR, LXD_SECCOMP_NOTIFY_MOUNT, LXD_SECCOMP_NOTIFY_BPF, LXD_SECCOMP_NOTIFY_SCHED_SETSCHEDULER, LXD_SECCOMP_NOTIFY_SYSINFO},
+	{ -1, LXD_SECCOMP_NOTIFY_MKNOD, LXD_SECCOMP_NOTIFY_MKNODAT, LXD_SECCOMP_NOTIFY_SETXATTR, LXD_SECCOMP_NOTIFY_MOUNT, LXD_SECCOMP_NOTIFY_BPF, LXD_SECCOMP_NOTIFY_SCHED_SETSCHEDULER, LXD_SECCOMP_NOTIFY_SYSINFO, LXD_SECCOMP_NOTIFY_FINIT_MODULE },
 #ifdef AUDIT_ARCH_X86_64
-	{ AUDIT_ARCH_X86_64,      133, 259, 188, 165, 321, 144, 99 },
+	{ AUDIT_ARCH_X86_64,       133, 259, 188, 165, 321, 144, 99, 313 },
 #endif
 #ifdef AUDIT_ARCH_I386
-	{ AUDIT_ARCH_I386,         14, 297, 226,  21, 357, 156, 116 },
+	{ AUDIT_ARCH_I386,         14, 297, 226,  21, 357, 156, 116, 350 },
 #endif
 #ifdef AUDIT_ARCH_AARCH64
-	{ AUDIT_ARCH_AARCH64,      -1,  33,   5,  21, 386, 156, 179 },
+	{ AUDIT_ARCH_AARCH64,      -1,  33,   5,  21, 386, 156, 179, 273 },
 #endif
 #ifdef AUDIT_ARCH_ARM
-	{ AUDIT_ARCH_ARM,          14, 324, 226,  21, 386, 156, 116 },
+	{ AUDIT_ARCH_ARM,          14, 324, 226,  21, 386, 156, 116, 379 },
 #endif
 #ifdef AUDIT_ARCH_ARMEB
-	{ AUDIT_ARCH_ARMEB,        14, 324, 226,  21, 386, 156, 116 },
+	{ AUDIT_ARCH_ARMEB,        14, 324, 226,  21, 386, 156, 116, 379 },
 #endif
 #ifdef AUDIT_ARCH_S390
-	{ AUDIT_ARCH_S390,         14, 290, 224,  21, 386, 156, 116 },
+	{ AUDIT_ARCH_S390,         14, 290, 224,  21, 386, 156, 116, 344 },
 #endif
 #ifdef AUDIT_ARCH_S390X
-	{ AUDIT_ARCH_S390X,        14, 290, 224,  21, 351, 156, 116 },
+	{ AUDIT_ARCH_S390X,        14, 290, 224,  21, 351, 156, 116, 344 },
 #endif
 #ifdef AUDIT_ARCH_PPC
-	{ AUDIT_ARCH_PPC,          14, 288, 209,  21, 361, 156, 116 },
+	{ AUDIT_ARCH_PPC,          14, 288, 209,  21, 361, 156, 116, 353 },
 #endif
 #ifdef AUDIT_ARCH_PPC64
-	{ AUDIT_ARCH_PPC64,        14, 288, 209,  21, 361, 156, 116 },
+	{ AUDIT_ARCH_PPC64,        14, 288, 209,  21, 361, 156, 116, 353 },
 #endif
 #ifdef AUDIT_ARCH_PPC64LE
-	{ AUDIT_ARCH_PPC64LE,      14, 288, 209,  21, 361, 156, 116 },
+	{ AUDIT_ARCH_PPC64LE,      14, 288, 209,  21, 361, 156, 116, 353 },
 #endif
 #ifdef AUDIT_ARCH_RISCV64
-	{ AUDIT_ARCH_RISCV64,      -1,  33,   5,  40, 280, -1, 179 },
+	{ AUDIT_ARCH_RISCV64,      -1,  33,   5,  40, 280, -1, 179, 273 },
 #endif
 #ifdef AUDIT_ARCH_SPARC
-	{ AUDIT_ARCH_SPARC,        14, 286, 169, 167, 349, 243, 214 },
+	{ AUDIT_ARCH_SPARC,        14, 286, 169, 167, 349, 243, 214, 342 },
 #endif
 #ifdef AUDIT_ARCH_SPARC64
-	{ AUDIT_ARCH_SPARC64,      14, 286, 169, 167, 349, 243, 214 },
+	{ AUDIT_ARCH_SPARC64,      14, 286, 169, 167, 349, 243, 214, 342 },
 #endif
 #ifdef AUDIT_ARCH_MIPS
-	{ AUDIT_ARCH_MIPS,         14, 290, 224,  21,  -1, 141, 4116 },
+	{ AUDIT_ARCH_MIPS,         14, 290, 224,  21,  -1, 141, 4116, 4348 },
 #endif
 #ifdef AUDIT_ARCH_MIPSEL
-	{ AUDIT_ARCH_MIPSEL,       14, 290, 224,  21,  -1, 141, 4116 },
+	{ AUDIT_ARCH_MIPSEL,       14, 290, 224,  21,  -1, 141, 4116, 4348 },
 #endif
 #ifdef AUDIT_ARCH_MIPS64
-	{ AUDIT_ARCH_MIPS64,      131, 249, 180, 160,  -1, 141, 5097 },
+	{ AUDIT_ARCH_MIPS64,      131, 249, 180, 160,  -1, 141, 5097, 5307 },
 #endif
 #ifdef AUDIT_ARCH_MIPS64N32
-	{ AUDIT_ARCH_MIPS64N32,   131, 253, 180, 160,  -1, 141, 4116 },
+	{ AUDIT_ARCH_MIPS64N32,   131, 253, 180, 160,  -1, 141, 4116, 6312 },
 #endif
 #ifdef AUDIT_ARCH_MIPSEL64
-	{ AUDIT_ARCH_MIPSEL64,    131, 249, 180, 160,  -1, 141, 5097 },
+	{ AUDIT_ARCH_MIPSEL64,    131, 249, 180, 160,  -1, 141, 5097, 5307 },
 #endif
 #ifdef AUDIT_ARCH_MIPSEL64N32
-	{ AUDIT_ARCH_MIPSEL64N32, 131, 253, 180, 160,  -1, 141, 4116 },
+	{ AUDIT_ARCH_MIPSEL64N32, 131, 253, 180, 160,  -1, 141, 4116, 6312 },
 #endif
 };
 
@@ -208,6 +210,9 @@ static int seccomp_notify_get_syscall(struct seccomp_notif *req,
 
 		if (entry->nr_sysinfo == req->data.nr)
 			return LXD_SECCOMP_NOTIFY_SYSINFO;
+
+		if (entry->nr_finit_module == req->data.nr)
+			return LXD_SECCOMP_NOTIFY_FINIT_MODULE;
 
 		break;
 	}
@@ -463,6 +468,7 @@ static bool lxd_pid_cap_is_set(pid_t pid, cap_value_t cap, cap_flag_t flag)
 import "C"
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -486,6 +492,7 @@ import (
 	"github.com/canonical/lxd/lxd/linux"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/lxd/subprocess"
 	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
@@ -502,6 +509,7 @@ const lxdSeccompNotifyMount = C.LXD_SECCOMP_NOTIFY_MOUNT
 const lxdSeccompNotifyBpf = C.LXD_SECCOMP_NOTIFY_BPF
 const lxdSeccompNotifySchedSetscheduler = C.LXD_SECCOMP_NOTIFY_SCHED_SETSCHEDULER
 const lxdSeccompNotifySysinfo = C.LXD_SECCOMP_NOTIFY_SYSINFO
+const lxdSeccompNotifyFinitModule = C.LXD_SECCOMP_NOTIFY_FINIT_MODULE
 
 const seccompHeader = `2
 `
@@ -511,7 +519,6 @@ const defaultSeccompPolicy = `reject_force_umount  # comment this to allow umoun
 kexec_load errno 38
 open_by_handle_at errno 38
 init_module errno 38
-finit_module errno 38
 delete_module errno 38
 `
 
@@ -534,6 +541,9 @@ const seccompNotifySchedSetscheduler = `sched_setscheduler notify
 `
 
 const seccompNotifySysinfo = `sysinfo notify
+`
+
+const seccompNotifyModule = `finit_module notify
 `
 
 const seccompBlockNewMountAPI = `fsopen errno 38
@@ -1875,6 +1885,197 @@ func (s *Server) HandleSysinfoSyscall(c Instance, siov *Iovec) int {
 	return 0
 }
 
+type nullWriteCloser struct {
+	*bytes.Buffer
+}
+
+// Close is a no-op closer implementation
+func (nwc *nullWriteCloser) Close() error {
+	return nil
+}
+
+// HandleFinitModuleSyscall handles finit_module syscalls.
+func (s *Server) HandleFinitModuleSyscall(c Instance, siov *Iovec) int {
+	ctx := logger.Ctx{"container": c.Name(),
+		"project":               c.Project().Name,
+		"syscall_number":        siov.req.data.nr,
+		"audit_architecture":    siov.req.data.arch,
+		"seccomp_notify_id":     siov.req.id,
+		"seccomp_notify_flags":  siov.req.flags,
+		"seccomp_notify_pid":    siov.req.pid,
+		"seccomp_notify_fd":     siov.notifyFd,
+		"seccomp_notify_mem_fd": siov.memFd,
+	}
+
+	defer logger.Debug("Handling finit_module syscall", ctx)
+
+	// int fd
+	fd := C.int(siov.req.data.args[0])
+
+	// const char *param_values
+	cBuf := [4096]C.char{}
+	_, err := C.pread(C.int(siov.memFd), unsafe.Pointer(&cBuf[0]), C.size_t(4096), C.off_t(siov.req.data.args[1]))
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Failed to read memory for finit_module syscall: %s", err)
+		if s.s.OS.SeccompListenerContinue {
+			ctx["syscall_continue"] = "true"
+			C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
+			return 0
+		}
+
+		return int(-C.EFAULT)
+	}
+
+	paramValues := C.GoString(&cBuf[0])
+
+	// disallow specifying module parameters, because
+	// for some modules parameters can be dangerous.
+	// Some modules have parameters like "debug" which can
+	// turn on dangerous debugging features or create performance issues.
+	if string(paramValues) != "" {
+		ctx["err"] = "Forbid setting module parameters"
+		if s.s.OS.SeccompListenerContinue {
+			ctx["syscall_continue"] = "true"
+			C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
+			return 0
+		}
+
+		return int(-C.EPERM)
+	}
+
+	// int flags
+	flags := C.int(siov.req.data.args[2])
+
+	// disallow specifying flags, because it's not safe:
+	// - MODULE_INIT_IGNORE_MODVERSIONS
+	// - MODULE_INIT_IGNORE_VERMAGIC
+	// this can allow to load a kernel module which is incompatible
+	// with the running kernel and trigger host system crash.
+	if flags != 0 {
+		ctx["err"] = "Forbid setting flags in finit_module()"
+		if s.s.OS.SeccompListenerContinue {
+			ctx["syscall_continue"] = "true"
+			C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))
+			return 0
+		}
+
+		return int(-C.EPERM)
+	}
+
+	containerInitPID := int(siov.msg.init_pid)
+	targetPID := int(siov.req.pid)
+
+	ctInitUserNS, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/user", containerInitPID))
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Can't get userns for ct init process: %v", err)
+		return int(-C.EPERM)
+	}
+
+	reqUserNS, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/user", targetPID))
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Can't get userns for requestor process: %v", err)
+		return int(-C.EPERM)
+	}
+
+	ctx["param_values"] = string(paramValues)
+
+	// nested container?
+	if ctInitUserNS != reqUserNS {
+		ctx["err"] = "finit_module() from nested container is forbidden"
+		return int(-C.EPERM)
+	}
+
+	// has CAP_SYS_MODULE capability?
+	if !C.lxd_pid_cap_is_set(C.int(targetPID), C.CAP_SYS_MODULE, C.CAP_EFFECTIVE) {
+		ctx["err"] = "requestor process creds lacks CAP_SYS_MODULE"
+		return int(-C.EPERM)
+	}
+
+	moduleFileFD, err := unix.Openat(siov.procFd, fmt.Sprintf("fd/%d", fd), unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Can't open module file (unix.Openat): %v", err)
+		return int(-C.EPERM)
+	}
+
+	moduleFile := os.NewFile(uintptr(moduleFileFD), "/proc/<pid>/fd/<fd>")
+	if moduleFile == nil {
+		ctx["err"] = fmt.Sprintf("Can't open module file (os.NewFile): %v", err)
+		return int(-C.EPERM)
+	}
+
+	defer func() { _ = moduleFile.Close() }()
+
+	forksyscallgoargs := []string{
+		"forksyscallgo",
+		"finit_module_parse",         // <syscall_operation>
+		fmt.Sprintf("%d", targetPID), // <PID>
+		fmt.Sprintf("%d", 0),         // <PidFd>
+		fmt.Sprintf("%d", 3),         // <module_fd>
+	}
+
+	var buffer bytes.Buffer
+	var output bytes.Buffer
+	p := subprocess.NewProcessWithFds(util.GetExecPath(), forksyscallgoargs, nil,
+		&nullWriteCloser{&output}, &nullWriteCloser{&buffer})
+
+	// We want to drop privileges, as we use "debug/elf" Golang
+	// package which is considered as not safe for production use.
+	// By spawning an unprivileged process we can safely use this package.
+	p.SetCreds(s.s.OS.UnprivUID, s.s.OS.UnprivGID)
+
+	// Let's set timeout for the helper process.
+	// It's just a precautionary measure to prevent blocakge of a syscall interception
+	// daemon if anything goes wrong inside the debug/elf Golang package internals.
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	err = p.StartWithFiles(timeoutCtx, []*os.File{moduleFile})
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Can't open module file: %v", err)
+		return int(-C.EPERM)
+	}
+
+	exitCode, err := p.Wait(context.TODO())
+	if err != nil || exitCode != 0 {
+		ctx["err"] = fmt.Sprintf("forksyscallgo finit_module_parse helper failed. Err: %v exitCode: %d stdout: %s stderr: %s",
+			err, exitCode, output.String(), buffer.String())
+		return int(-C.EPERM)
+	}
+
+	moduleName := output.String()
+	ctx["module_name"] = moduleName
+
+	// Check that this module is in the allowlist
+	inAllowList := false
+	kernelModules := c.ExpandedConfig()["linux.kernel_modules"]
+	if kernelModules != "" {
+		for _, module := range strings.Split(kernelModules, ",") {
+			module = strings.TrimPrefix(module, " ")
+
+			if module == moduleName {
+				inAllowList = true
+			}
+		}
+	}
+
+	if !inAllowList {
+		ctx["err"] = fmt.Sprintf("Module %q is not in allowlist (linux.kernel_modules)", moduleName)
+		return int(-C.EPERM)
+	}
+
+	if shared.PathExists(fmt.Sprintf("/sys/module/%s", moduleName)) {
+		return int(-C.EEXIST)
+	}
+
+	err = util.LoadModule(moduleName)
+	if err != nil {
+		ctx["err"] = fmt.Sprintf("Failed to load module %q: %v", moduleName, err)
+		return int(-C.EPERM)
+	}
+
+	return 0
+}
+
 // MountArgs arguments for mount.
 type MountArgs struct {
 	source    string
@@ -2313,6 +2514,8 @@ func (s *Server) handleSyscall(c Instance, siov *Iovec) int {
 		return s.HandleSchedSetschedulerSyscall(c, siov)
 	case lxdSeccompNotifySysinfo:
 		return s.HandleSysinfoSyscall(c, siov)
+	case lxdSeccompNotifyFinitModule:
+		return s.HandleFinitModuleSyscall(c, siov)
 	}
 
 	return int(-C.EINVAL)

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -737,6 +737,15 @@ func InstanceNeedsIntercept(s *state.State, c Instance) (bool, error) {
 		needed = true
 	}
 
+	if config["linux.kernel_modules.load"] == "ondemand" {
+		err := lxcSupportSeccompNotifyContinue(s)
+		if err != nil {
+			return needed, err
+		}
+
+		needed = true
+	}
+
 	return needed, nil
 }
 
@@ -812,6 +821,10 @@ func seccompGetPolicyContent(s *state.State, c Instance) (string, error) {
 
 		if shared.IsTrue(config["security.syscalls.intercept.sysinfo"]) {
 			policy += seccompNotifySysinfo
+		}
+
+		if config["linux.kernel_modules.load"] == "ondemand" {
+			policy += seccompNotifyModule
 		}
 
 		if shared.IsTrue(config["security.syscalls.intercept.mount"]) {

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -17,6 +17,7 @@ package seccomp
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/capability.h>
 #include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -440,6 +441,24 @@ static int handle_bpf_syscall(pid_t pid_target, int notify_fd, int mem_fd,
 #ifndef MS_LAZYTIME
 #define MS_LAZYTIME (1<<25)
 #endif
+
+static bool lxd_pid_cap_is_set(pid_t pid, cap_value_t cap, cap_flag_t flag)
+{
+	int ret;
+	cap_t caps;
+	cap_flag_value_t flagval;
+
+	caps = cap_get_pid(pid);
+	if (!caps)
+		return false;
+
+	ret = cap_get_flag(caps, cap, flag, &flagval);
+	if (ret < 0)
+		return false;
+
+	return flagval == CAP_SET;
+}
+
 */
 import "C"
 

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -129,6 +129,7 @@ _have lxc && {
       limits.processes \
       limits.kernel. \
       linux.kernel_modules \
+      linux.kernel_modules.load \
       linux.sysctl. \
       migration.incremental.memory migration.incremental.memory.goal migration.incremental.memory.iterations migration.stateful \
       nvidia.driver.capabilities nvidia.require.cuda nvidia.require.driver nvidia.runtime \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -404,6 +404,7 @@ var APIExtensions = []string{
 	"storage_volumes_all",
 	"instances_files_modify_permissions",
 	"image_restriction_nesting",
+	"container_syscall_intercept_finit_module",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR introduces support for `finit_module` syscall interception that allows to lazily load Linux kernel modules from inside unprivileged container if module is in the allow list `linux.kernel_modules`

Specification:
https://discourse.ubuntu.com/t/lxd-container-instance-lazy-modules-loading/42837