### PR TITLE
Auth: Pre-check permissions when performing bulk state update.

### DIFF
--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -102,15 +102,21 @@ func instancesPut(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	var names []string
-	var instances []instance.Instance
 	for _, inst := range c {
 		if inst.Project().Name != projectName {
 			continue
 		}
 
-		// Only allow changing the state of instances the user has permission for.
+		// Check permission for all instances so that we apply the state change to all or none.
 		if !userHasPermission(entity.InstanceURL(inst.Project().Name, inst.Name())) {
+			return response.Forbidden(nil)
+		}
+	}
+
+	var names []string
+	var instances []instance.Instance
+	for _, inst := range c {
+		if inst.Project().Name != projectName {
 			continue
 		}
 


### PR DESCRIPTION
Previously, state updates invoked against all instances in a project were applied partially - depending on the permissions of the caller. The commit checks permissions for all instances in the project and enforces that the caller has permission to update all of them before continuing.

Partially addresses #12461 - see https://github.com/canonical/lxd/pull/12313#discussion_r1371526260