### PR TITLE
Auth: Project parameter to URLs in authorizer.

### DIFF
--- a/lxd/auth/driver_tls.go
+++ b/lxd/auth/driver_tls.go
@@ -80,13 +80,9 @@ func (t *tls) CheckPermission(ctx context.Context, r *http.Request, entityURL *a
 		return api.StatusErrorf(http.StatusForbidden, "Certificate is restricted")
 	}
 
-	entityType, projectName, _, pathArgs, err := entity.ParseURL(entityURL.URL)
+	entityType, projectName, _, _, err := entity.ParseURL(entityURL.URL)
 	if err != nil {
 		return fmt.Errorf("Failed to parse entity URL: %w", err)
-	}
-
-	if entityType == entity.TypeProject {
-		projectName = pathArgs[0]
 	}
 
 	// Check server level object types
@@ -190,7 +186,7 @@ func (t *tls) GetPermissionChecker(ctx context.Context, r *http.Request, entitle
 
 	// Filter objects by project.
 	return func(entityURL *api.URL) bool {
-		eType, project, _, pathArgs, err := entity.ParseURL(entityURL.URL)
+		eType, project, _, _, err := entity.ParseURL(entityURL.URL)
 		if err != nil {
 			logger.Warn("Permission checker failed to parse entity URL", logger.Ctx{"entity_url": entityURL, "error": err})
 			return false
@@ -200,11 +196,6 @@ func (t *tls) GetPermissionChecker(ctx context.Context, r *http.Request, entitle
 		if eType != entityType {
 			logger.Warn("Permission checker received URL with unexpected entity type", logger.Ctx{"expected": entityType, "actual": eType, "entity_url": entityURL})
 			return false
-		}
-
-		// If it's a project URL, the project name is in the path, not the query parameter.
-		if eType == entity.TypeProject {
-			project = pathArgs[0]
 		}
 
 		// If an effective project has been set in the request context. We expect all entities to be in that project.

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -233,7 +233,7 @@ var profileEntityByID = fmt.Sprintf(`%s WHERE profiles.id = ?`, profileEntities)
 var profileEntitiesByProjectName = fmt.Sprintf(`%s WHERE projects.name = ?`, profileEntities)
 
 // projectEntities returns all entities of type entity.TypeProject.
-var projectEntities = fmt.Sprintf(`SELECT %d, projects.id, '', '', json_array(projects.name) FROM projects`, entityTypeProject)
+var projectEntities = fmt.Sprintf(`SELECT %d, projects.id, projects.name, '', json_array(projects.name) FROM projects`, entityTypeProject)
 
 // projectEntities gets the entity of type entity.TypeProject with a particular ID.
 var projectEntityByID = fmt.Sprintf(`%s WHERE id = ?`, projectEntities)
@@ -779,7 +779,7 @@ WHERE projects.name = ?
 var projectIDFromURL = `
 SELECT ?, projects.id 
 FROM projects 
-WHERE '' = ? 
+WHERE projects.name = ? 
 	AND '' = ? 
 	AND projects.name = ?`
 

--- a/lxd/db/openfga.go
+++ b/lxd/db/openfga.go
@@ -386,7 +386,7 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 		return nil, fmt.Errorf("ReadStartingWithUser: Failed to parse user entity URL %q: %w", userURL, err)
 	}
 
-	_, _, _, userURLPathArguments, err := entity.ParseURL(*u)
+	_, projectName, _, userURLPathArguments, err := entity.ParseURL(*u)
 	if err != nil {
 		return nil, fmt.Errorf("ReadStartingWithUser: Unexpected user entity URL %q: %w", userURL, err)
 	}
@@ -398,13 +398,6 @@ func (o *openfgaStore) ReadStartingWithUser(ctx context.Context, store string, f
 			return nil, fmt.Errorf("ReadStartingWithUser: Cannot list project relations for non-project entities")
 		} else if filter.Relation == "server" && userEntityType != entity.TypeServer {
 			return nil, fmt.Errorf("ReadStartingWithUser: Cannot list server relations for non-server entities")
-		}
-
-		// If the filter is by project, we want to filter entity URLs by the project name.
-		var projectName string
-		if filter.Relation == "project" {
-			// The project name is the first path argument of a project URL.
-			projectName = userURLPathArguments[0]
 		}
 
 		// Get the entity URLs with the given type and project (if set).

--- a/lxd/project/permissions.go
+++ b/lxd/project/permissions.go
@@ -1477,34 +1477,17 @@ func FilterUsedBy(authorizer auth.Authorizer, r *http.Request, entries []string)
 			continue
 		}
 
-		entityType, projectName, location, pathArguments, err := entity.ParseURL(*u)
+		entityType, _, _, _, err := entity.ParseURL(*u)
 		if err != nil {
 			logger.Warn("Failed to parse project used-by entity URL", logger.Ctx{"url": entry, "error": err})
 			continue
 		}
 
-		entityURL, err := entityType.URL(projectName, location, pathArguments...)
-		if err != nil {
-			logger.Warn("Failed to create canonical entity URL for project used-by filtering", logger.Ctx{"url": entry, "error": err})
-			continue
-		}
-
-		urlsByEntityType[entityType] = append(urlsByEntityType[entityType], entityURL)
+		urlsByEntityType[entityType] = append(urlsByEntityType[entityType], &api.URL{URL: *u})
 	}
 
 	// Filter the entries.
 	usedBy := make([]string, 0, len(entries))
-
-	// Used-by lists do not include the project query parameter if it is the default project.
-	appendUsedBy := func(u *api.URL) {
-		if u.Query().Get("project") == api.ProjectDefaultName {
-			q := u.Query()
-			q.Del("project")
-			u.RawQuery = q.Encode()
-		}
-
-		usedBy = append(usedBy, u.String())
-	}
 
 	for entityType, urls := range urlsByEntityType {
 		// If only one entry of this type, check directly.
@@ -1514,7 +1497,7 @@ func FilterUsedBy(authorizer auth.Authorizer, r *http.Request, entries []string)
 				continue
 			}
 
-			appendUsedBy(urls[0])
+			usedBy = append(usedBy, urls[0].String())
 			continue
 		}
 
@@ -1527,7 +1510,7 @@ func FilterUsedBy(authorizer auth.Authorizer, r *http.Request, entries []string)
 		// Check each url and append.
 		for _, u := range urls {
 			if canViewEntity(u) {
-				appendUsedBy(u)
+				usedBy = append(usedBy, u.String())
 			}
 		}
 	}

--- a/shared/entity/type.go
+++ b/shared/entity/type.go
@@ -217,7 +217,7 @@ func (t Type) URL(projectName string, location string, pathArguments ...string) 
 	u := api.NewURL().Path(path...)
 
 	// Always set project parameter if provided (operations and warnings may be project specific but it is not a requirement).
-	if projectName != "" {
+	if projectName != "" && t != TypeProject {
 		u = u.WithQuery("project", projectName)
 	}
 
@@ -354,6 +354,8 @@ entityTypeLoop:
 		if projectName == "" {
 			projectName = api.ProjectDefaultName
 		}
+	} else if entityType == TypeProject {
+		projectName = pathArguments[0]
 	}
 
 	return entityType, projectName, u.Query().Get("target"), pathArguments, nil

--- a/shared/entity/type_test.go
+++ b/shared/entity/type_test.go
@@ -48,7 +48,7 @@ func TestURL(t *testing.T) {
 			name:               "projects",
 			rawURL:             "/1.0/projects/my-project",
 			expectedEntityType: TypeProject,
-			expectedProject:    "",
+			expectedProject:    "my-project",
 			expectedPathArgs:   []string{"my-project"},
 			expectedErr:        nil,
 		},


### PR DESCRIPTION
This allows the caller to pass in URLs such as `/1.0/instances/c1` where the project is implicitly `default`.

Closes #13072.