### PR TITLE
lxc: Check the image really exists on the remote before exporting it 

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -820,11 +820,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1244,15 +1244,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1300,16 +1300,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1646,9 +1646,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1673,10 +1673,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2187,12 +2187,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2207,12 +2207,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2232,7 +2232,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2247,7 +2257,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2257,12 +2267,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2301,12 +2311,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2316,7 +2326,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2335,7 +2345,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2396,10 +2406,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2454,7 +2464,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2613,7 +2623,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2638,22 +2648,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2704,12 +2714,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2748,11 +2758,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2760,25 +2770,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2798,14 +2808,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2843,11 +2853,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2865,7 +2875,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2917,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2990,7 +3000,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3034,12 +3044,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3133,7 +3143,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3148,11 +3158,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3445,7 +3455,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3481,7 +3491,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3493,7 +3503,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,7 +3744,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3742,11 +3752,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3906,7 +3916,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3960,7 +3970,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3968,7 +3978,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4153,7 +4163,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4233,7 +4243,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4300,7 +4310,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4354,14 +4364,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4432,7 +4442,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4449,11 +4459,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4476,11 +4486,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4574,7 +4584,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4592,7 +4602,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4601,7 +4611,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4610,7 +4620,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4647,16 +4657,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4816,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4944,7 +4954,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4960,12 +4970,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5041,7 +5051,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5067,7 +5077,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5303,7 +5313,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5315,7 +5325,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5360,7 +5370,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5494,7 +5504,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5506,7 +5516,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5538,7 +5548,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5686,7 +5696,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5697,11 +5707,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5908,7 +5918,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5954,7 +5964,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5970,12 +5980,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6003,7 +6013,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6018,7 +6028,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6059,12 +6069,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6075,7 +6085,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6106,7 +6116,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6253,7 +6263,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6401,7 +6411,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6426,7 +6436,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6499,7 +6509,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6512,7 +6522,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6531,31 +6541,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6567,11 +6577,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6655,7 +6665,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7034,7 +7044,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7042,7 +7052,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7086,7 +7096,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7159,7 +7169,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7178,7 +7188,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7382,7 +7392,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7398,16 +7408,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7427,7 +7437,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -246,7 +246,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -267,7 +267,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -672,7 +672,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -682,12 +682,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -795,7 +795,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -808,15 +808,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -870,7 +870,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1106,11 +1106,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
@@ -1165,7 +1165,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -1248,7 +1248,7 @@ msgstr "ERSTELLT AM"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1270,7 +1270,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1476,7 +1476,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Spalten"
@@ -1518,7 +1518,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1551,15 +1551,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1611,16 +1611,16 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1659,7 +1659,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1725,7 +1725,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1821,7 +1821,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1846,7 +1846,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1898,7 +1898,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1990,9 +1990,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -2017,10 +2017,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2179,7 +2179,7 @@ msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2187,7 +2187,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2287,12 +2287,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2509,20 +2509,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2554,7 +2554,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2567,7 +2567,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2576,12 +2576,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2596,12 +2596,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2621,7 +2621,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2636,7 +2646,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2646,12 +2656,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2690,12 +2700,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2705,7 +2715,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2727,7 +2737,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2789,10 +2799,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2847,7 +2857,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2869,7 +2879,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -3027,7 +3037,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3053,22 +3063,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3121,12 +3131,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3166,11 +3176,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3178,25 +3188,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3218,14 +3228,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3264,12 +3274,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3287,7 +3297,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3340,7 +3350,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3420,7 +3430,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3464,12 +3474,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3571,7 +3581,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3586,11 +3596,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3913,7 +3923,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
@@ -3955,7 +3965,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3969,7 +3979,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4242,7 +4252,7 @@ msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4252,12 +4262,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4432,7 +4442,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4490,7 +4500,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4499,7 +4509,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4686,7 +4696,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4770,7 +4780,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4837,7 +4847,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4894,14 +4904,14 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4972,7 +4982,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4992,12 +5002,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5021,12 +5031,12 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -5120,7 +5130,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5140,7 +5150,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5150,7 +5160,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5159,7 +5169,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5199,16 +5209,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5304,7 +5314,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5374,7 +5384,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5526,7 +5536,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5542,12 +5552,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5627,7 +5637,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5654,7 +5664,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5909,7 +5919,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5921,7 +5931,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5970,7 +5980,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -6123,7 +6133,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6135,7 +6145,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
@@ -6168,7 +6178,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -6324,7 +6334,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6335,12 +6345,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6555,7 +6565,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -6602,7 +6612,7 @@ msgstr "unbekannter entfernter Instanz Name: %q"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6618,12 +6628,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6652,7 +6662,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6667,7 +6677,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6709,12 +6719,12 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6725,7 +6735,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6760,7 +6770,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6930,7 +6940,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7100,7 +7110,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -7147,7 +7157,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7288,7 +7298,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7311,7 +7321,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7346,7 +7356,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7354,7 +7364,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7363,7 +7373,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7371,7 +7381,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7380,7 +7390,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7389,7 +7399,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7397,7 +7407,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7421,7 +7431,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7429,7 +7439,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7602,7 +7612,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8346,7 +8356,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -8354,7 +8364,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -8398,7 +8408,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8471,7 +8481,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8490,7 +8500,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8698,7 +8708,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -8714,16 +8724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8743,10 +8753,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Fingerprint %q not found"
+#~ msgstr "Fingerabdruck: %s\n"
 
 #, fuzzy
 #~ msgid "The --mode flag can't be used with --storage"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -603,7 +603,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -826,11 +826,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -965,7 +965,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -978,7 +978,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1218,7 +1218,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1251,15 +1251,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1307,16 +1307,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1354,7 +1354,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1523,7 +1523,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1661,9 +1661,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1688,10 +1688,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1944,12 +1944,12 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2030,7 +2030,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2149,20 +2149,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2190,7 +2190,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2203,7 +2203,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2212,12 +2212,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2232,12 +2232,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2257,7 +2257,17 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "  Χρήση δικτύου:"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "  Χρήση δικτύου:"
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2272,7 +2282,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2282,12 +2292,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2326,12 +2336,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2341,7 +2351,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2360,7 +2370,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2421,10 +2431,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2479,7 +2489,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2499,7 +2509,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2651,7 +2661,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2676,22 +2686,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2742,12 +2752,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2786,11 +2796,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2798,25 +2808,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,14 +2846,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2881,11 +2891,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2903,7 +2913,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2955,7 +2965,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3028,7 +3038,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3072,12 +3082,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3173,7 +3183,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3188,11 +3198,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3485,7 +3495,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3522,7 +3532,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
@@ -3535,7 +3545,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3792,7 +3802,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
@@ -3802,12 +3812,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4025,7 +4035,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4033,7 +4043,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4220,7 +4230,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4300,7 +4310,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4422,14 +4432,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4500,7 +4510,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4517,11 +4527,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4544,11 +4554,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4642,7 +4652,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4660,7 +4670,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4669,7 +4679,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4678,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4715,16 +4725,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4816,7 +4826,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4879,7 +4889,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5018,7 +5028,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5034,12 +5044,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5116,7 +5126,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5142,7 +5152,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5390,7 +5400,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5402,7 +5412,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5449,7 +5459,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5592,7 +5602,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5604,7 +5614,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5636,7 +5646,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5784,7 +5794,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5795,11 +5805,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6006,7 +6016,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6052,7 +6062,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6068,12 +6078,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6101,7 +6111,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6116,7 +6126,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6157,12 +6167,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6173,7 +6183,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6205,7 +6215,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6368,7 +6378,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6516,7 +6526,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6541,7 +6551,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6614,7 +6624,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6627,7 +6637,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6646,31 +6656,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6682,11 +6692,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6770,7 +6780,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7149,7 +7159,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7157,7 +7167,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7201,7 +7211,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7274,7 +7284,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7293,7 +7303,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7497,7 +7507,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7513,16 +7523,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7542,8 +7552,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -250,7 +250,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -269,7 +269,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -660,7 +660,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -670,12 +670,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -774,7 +774,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -787,15 +787,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -846,7 +846,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -981,7 +981,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1072,11 +1072,11 @@ msgstr "Tipo de autenticación %s no está soportada por el servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
@@ -1129,7 +1129,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
@@ -1211,7 +1211,7 @@ msgstr "CREADO EN"
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
@@ -1227,7 +1227,7 @@ msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
 "local"
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Columnas"
@@ -1471,7 +1471,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1504,15 +1504,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1560,17 +1560,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
@@ -1609,7 +1609,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1758,7 +1758,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1783,7 +1783,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
@@ -1922,9 +1922,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1949,10 +1949,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2103,7 +2103,7 @@ msgstr "Dispositivo: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -2111,7 +2111,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2205,12 +2205,12 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2291,7 +2291,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2412,20 +2412,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2455,7 +2455,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
@@ -2468,7 +2468,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2477,12 +2477,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2497,12 +2497,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2522,7 +2522,17 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "Nombre del Miembro del Cluster"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "Nombre del Miembro del Cluster"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2537,7 +2547,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2547,12 +2557,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2591,12 +2601,12 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2606,7 +2616,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2625,7 +2635,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -2687,10 +2697,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2745,7 +2755,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2766,7 +2776,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2918,7 +2928,7 @@ msgstr "Perfil %s creado"
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -2944,22 +2954,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3012,12 +3022,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3056,11 +3066,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3068,25 +3078,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3106,14 +3116,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3153,11 +3163,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3177,7 +3187,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3229,7 +3239,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3304,7 +3314,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3348,12 +3358,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3455,7 +3465,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3470,11 +3480,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3773,7 +3783,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3810,7 +3820,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
@@ -3823,7 +3833,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4081,7 +4091,7 @@ msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
@@ -4091,12 +4101,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4268,7 +4278,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4323,7 +4333,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4331,7 +4341,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4516,7 +4526,7 @@ msgstr "Perfil %s eliminado"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4663,7 +4673,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4718,14 +4728,14 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4796,7 +4806,7 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -4816,11 +4826,11 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -4844,11 +4854,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4942,7 +4952,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -4960,7 +4970,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4969,7 +4979,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4978,7 +4988,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5017,16 +5027,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5119,7 +5129,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5182,7 +5192,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5327,7 +5337,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5343,12 +5353,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5426,7 +5436,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5452,7 +5462,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5700,7 +5710,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5712,7 +5722,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5759,7 +5769,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5903,7 +5913,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5915,7 +5925,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
@@ -5947,7 +5957,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -6096,7 +6106,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6107,11 +6117,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6321,7 +6331,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6367,7 +6377,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6383,12 +6393,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6418,7 +6428,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6433,7 +6443,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6474,12 +6484,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6490,7 +6500,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6523,7 +6533,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6687,7 +6697,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6837,7 +6847,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6867,7 +6877,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6956,7 +6966,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6971,7 +6981,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -6994,37 +7004,37 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7039,12 +7049,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7147,7 +7157,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7612,7 +7622,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7620,7 +7630,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7664,7 +7674,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7737,7 +7747,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7756,7 +7766,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7960,7 +7970,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7976,16 +7986,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8005,10 +8015,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Fingerprint %q not found"
+#~ msgstr "Huella dactilar: %s"
 
 #, fuzzy
 #~ msgid "Failed to get the new instance name"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -248,7 +248,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -268,7 +268,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -679,12 +679,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -790,7 +790,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -804,16 +804,16 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -866,7 +866,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1109,11 +1109,11 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
@@ -1168,7 +1168,7 @@ msgstr "Clé de configuration invalide"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
@@ -1250,7 +1250,7 @@ msgstr "CRÉÉ À"
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
@@ -1264,7 +1264,7 @@ msgstr "Créé : %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonnes"
@@ -1520,7 +1520,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1553,15 +1553,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1613,17 +1613,17 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -1662,7 +1662,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1728,7 +1728,7 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1840,7 +1840,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1865,7 +1865,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1919,7 +1919,7 @@ msgstr "Création du conteneur"
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1927,7 +1927,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
@@ -2014,9 +2014,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -2041,10 +2041,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2197,7 +2197,7 @@ msgstr "Serveur distant : %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2205,7 +2205,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2306,12 +2306,12 @@ msgstr "Création du conteneur"
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2400,7 +2400,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2538,21 +2538,21 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2584,7 +2584,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -2598,7 +2598,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2607,12 +2607,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2627,12 +2627,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2652,7 +2652,17 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2667,7 +2677,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2677,12 +2687,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2722,12 +2732,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2737,7 +2747,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2757,7 +2767,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -2822,10 +2832,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2880,7 +2890,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2901,7 +2911,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -3061,7 +3071,7 @@ msgstr "Profil %s créé"
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3088,22 +3098,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3157,12 +3167,12 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3205,11 +3215,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
@@ -3217,26 +3227,26 @@ msgstr "Image copiée avec succès !"
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3259,14 +3269,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
@@ -3307,12 +3317,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3332,7 +3342,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3384,7 +3394,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3460,7 +3470,7 @@ msgstr "Cible invalide %s"
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
@@ -3505,12 +3515,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -3612,7 +3622,7 @@ msgstr ""
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3627,11 +3637,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3996,7 +4006,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
@@ -4036,7 +4046,7 @@ msgstr "Création du conteneur"
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
@@ -4050,7 +4060,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4325,7 +4335,7 @@ msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4335,12 +4345,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4519,7 +4529,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4586,7 +4596,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4774,7 +4784,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
@@ -4864,7 +4874,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
@@ -4936,7 +4946,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4994,14 +5004,14 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -5073,7 +5083,7 @@ msgstr "Profil %s supprimé de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -5093,12 +5103,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5122,11 +5132,11 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -5220,7 +5230,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5240,7 +5250,7 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5250,7 +5260,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5259,7 +5269,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5301,17 +5311,17 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5407,7 +5417,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5478,7 +5488,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -5646,7 +5656,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5662,12 +5672,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5750,7 +5760,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5777,7 +5787,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -6034,7 +6044,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6046,7 +6056,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6095,7 +6105,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -6254,7 +6264,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6266,7 +6276,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
@@ -6299,7 +6309,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr "Source :"
 
@@ -6458,7 +6468,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6470,11 +6480,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6692,7 +6702,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -6741,7 +6751,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6757,12 +6767,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6792,7 +6802,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6807,7 +6817,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -6849,12 +6859,12 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6865,7 +6875,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6900,7 +6910,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -7073,7 +7083,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -7241,7 +7251,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -7291,7 +7301,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7441,7 +7451,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7470,7 +7480,7 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7505,7 +7515,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7513,7 +7523,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7525,7 +7535,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7533,7 +7543,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7545,7 +7555,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7557,7 +7567,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7565,7 +7575,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7589,7 +7599,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7597,7 +7607,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7797,7 +7807,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8602,7 +8612,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr "désactivé"
 
@@ -8610,7 +8620,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr "activé"
 
@@ -8654,7 +8664,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8727,7 +8737,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8746,7 +8756,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8973,7 +8983,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr "non"
 
@@ -8989,16 +8999,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -9018,10 +9028,14 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy, c-format
+#~ msgid "Fingerprint %q not found"
+#~ msgstr "Empreinte : %s"
 
 #, fuzzy
 #~ msgid "Failed to get the new instance name"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1248,15 +1248,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,16 +1304,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1517,7 +1517,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1650,9 +1650,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1677,10 +1677,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1929,11 +1929,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2128,20 +2128,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2191,12 +2191,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2211,12 +2211,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2261,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2271,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,12 +2315,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2320,7 +2330,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2339,7 +2349,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2400,10 +2410,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2458,7 +2468,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2478,7 +2488,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2617,7 +2627,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2642,22 +2652,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2708,12 +2718,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2752,11 +2762,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2764,25 +2774,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2802,14 +2812,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2847,11 +2857,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2869,7 +2879,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2921,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2994,7 +3004,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3038,12 +3048,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3137,7 +3147,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3152,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3449,7 +3459,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3485,7 +3495,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3497,7 +3507,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,7 +3748,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3746,11 +3756,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3910,7 +3920,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3964,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3972,7 +3982,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4157,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4237,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4304,7 +4314,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4358,14 +4368,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4436,7 +4446,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4453,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4480,11 +4490,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4605,7 +4615,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4614,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4651,16 +4661,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4820,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4948,7 +4958,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4964,12 +4974,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5045,7 +5055,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5071,7 +5081,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5307,7 +5317,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5319,7 +5329,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5364,7 +5374,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5498,7 +5508,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5510,7 +5520,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5690,7 +5700,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5701,11 +5711,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5912,7 +5922,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5974,12 +5984,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6007,7 +6017,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6022,7 +6032,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6063,12 +6073,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6079,7 +6089,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6110,7 +6120,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6257,7 +6267,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6405,7 +6415,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6430,7 +6440,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6503,7 +6513,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6516,7 +6526,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6535,31 +6545,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6571,11 +6581,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6659,7 +6669,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7038,7 +7048,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7046,7 +7056,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7090,7 +7100,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7163,7 +7173,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7182,7 +7192,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7386,7 +7396,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7402,16 +7412,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7431,7 +7441,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -279,7 +279,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -665,7 +665,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -675,12 +675,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -776,7 +776,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -789,15 +789,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -848,7 +848,7 @@ msgstr "Il nome del container è: %s"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1074,11 +1074,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1131,7 +1131,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -1213,7 +1213,7 @@ msgstr "CREATO IL"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colonne"
@@ -1467,7 +1467,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1500,15 +1500,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1556,16 +1556,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1603,7 +1603,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1779,7 +1779,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1830,7 +1830,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1917,9 +1917,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1944,10 +1944,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2098,7 +2098,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -2106,7 +2106,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2203,11 +2203,11 @@ msgstr "Creazione del container in corso"
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2408,20 +2408,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2451,7 +2451,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2473,12 +2473,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2493,12 +2493,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2518,7 +2518,17 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "Il nome del container è: %s"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "Il nome del container è: %s"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2533,7 +2543,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2543,12 +2553,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2587,12 +2597,12 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2602,7 +2612,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2622,7 +2632,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2684,10 +2694,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2742,7 +2752,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2763,7 +2773,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2912,7 +2922,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2938,22 +2948,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3004,12 +3014,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3049,11 +3059,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3061,25 +3071,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3099,14 +3109,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3146,11 +3156,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3169,7 +3179,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3221,7 +3231,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3297,7 +3307,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3341,12 +3351,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3463,11 +3473,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3768,7 +3778,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3807,7 +3817,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
@@ -3821,7 +3831,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4080,7 +4090,7 @@ msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
@@ -4090,12 +4100,12 @@ msgstr "Il nome del container è: %s"
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4266,7 +4276,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4321,7 +4331,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4329,7 +4339,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4514,7 +4524,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4662,7 +4672,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4718,14 +4728,14 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4796,7 +4806,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -4815,11 +4825,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4842,11 +4852,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4940,7 +4950,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4958,7 +4968,7 @@ msgstr "Creazione del container in corso"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4968,7 +4978,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4977,7 +4987,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5016,16 +5026,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5118,7 +5128,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5182,7 +5192,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5327,7 +5337,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5343,12 +5353,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5426,7 +5436,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5452,7 +5462,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,7 +5718,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5755,7 +5765,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5899,7 +5909,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
@@ -5943,7 +5953,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -6094,7 +6104,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6106,11 +6116,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6319,7 +6329,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6365,7 +6375,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6381,12 +6391,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6415,7 +6425,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6430,7 +6440,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6472,12 +6482,12 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6488,7 +6498,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6522,7 +6532,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6680,7 +6690,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6834,7 +6844,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6864,7 +6874,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -6953,7 +6963,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6968,7 +6978,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -6991,37 +7001,37 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
@@ -7036,12 +7046,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -7144,7 +7154,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7609,7 +7619,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7617,7 +7627,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7661,7 +7671,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7734,7 +7744,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7753,7 +7763,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7958,7 +7968,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr "no"
 
@@ -7974,16 +7984,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8003,8 +8013,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -236,7 +236,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -255,7 +255,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -667,12 +667,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -765,7 +765,7 @@ msgstr "<remote> <new-name>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -780,15 +780,15 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -839,7 +839,7 @@ msgstr "クラスタグループからメンバを削除します"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -1007,7 +1007,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1085,11 +1085,11 @@ msgstr "認証タイプ '%s' はサーバではサポートされていません
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
@@ -1144,7 +1144,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -1225,7 +1225,7 @@ msgstr "CREATED AT"
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
@@ -1238,7 +1238,7 @@ msgstr "キャッシュ:"
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1489,7 +1489,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1522,15 +1522,15 @@ msgstr "コントロール: %s (%s)"
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr "サーバ間でイメージをコピーします"
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1593,16 +1593,16 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -1640,7 +1640,7 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
@@ -1703,7 +1703,7 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1788,7 +1788,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1812,7 +1812,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1863,7 +1863,7 @@ msgstr "インスタンス内のファイルを削除します"
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1872,7 +1872,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr "イメージを削除します"
 
@@ -1947,9 +1947,9 @@ msgstr "警告を削除します"
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1974,10 +1974,10 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2132,7 +2132,7 @@ msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -2140,7 +2140,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2236,12 +2236,12 @@ msgstr "インスタンス内のファイルを編集します"
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
@@ -2318,7 +2318,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2459,20 +2459,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -2517,7 +2517,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2526,12 +2526,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2546,12 +2546,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2571,7 +2571,17 @@ msgstr "クライアント %q に対する SFTP インスタンスの接続に�
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2586,7 +2596,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q for device override: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2596,12 +2606,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2640,12 +2650,12 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2655,7 +2665,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2674,7 +2684,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -2751,10 +2761,10 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2809,7 +2819,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2830,7 +2840,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -2978,7 +2988,7 @@ msgstr "プロファイル %s を作成しました"
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3004,22 +3014,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3070,12 +3080,12 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3119,11 +3129,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
@@ -3131,25 +3141,25 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3172,7 +3182,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3183,7 +3193,7 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
@@ -3221,11 +3231,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3244,7 +3254,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3297,7 +3307,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3377,7 +3387,7 @@ msgstr "不正な送り先 %s"
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
@@ -3423,12 +3433,12 @@ msgstr "LXD サーバはクラスタの一部ではありません"
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -3524,7 +3534,7 @@ msgstr "プロファイルを一覧表示します"
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3543,11 +3553,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3976,7 +3986,7 @@ msgstr "MTU"
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr "イメージを public にする"
 
@@ -4012,7 +4022,7 @@ msgstr "デバイスを管理します"
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
@@ -4027,7 +4037,7 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4288,7 +4298,7 @@ msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
@@ -4298,12 +4308,12 @@ msgstr "クラスターグループ名がありません"
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4469,7 +4479,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4536,7 +4546,7 @@ msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -4544,7 +4554,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4731,7 +4741,7 @@ msgstr "ネットワークゾーンレコード %s を削除しました"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
@@ -4812,7 +4822,7 @@ msgstr "\"カスタム\" のボリュームのみがスナップショットを�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
@@ -4879,7 +4889,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4933,14 +4943,14 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -5013,7 +5023,7 @@ msgstr "プロファイル %s が %s から削除されました"
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
@@ -5030,11 +5040,11 @@ msgstr "移動先のインスタンスに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5057,11 +5067,11 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5158,7 +5168,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5176,7 +5186,7 @@ msgstr "インスタンスの出力中: %s"
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
@@ -5185,7 +5195,7 @@ msgstr "ファイル %s を %s から取得します: %%s"
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5194,7 +5204,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5233,16 +5243,16 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5332,7 +5342,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5396,7 +5406,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5543,7 +5553,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5559,12 +5569,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5642,7 +5652,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5676,7 +5686,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -5970,7 +5980,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -5983,7 +5993,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6029,7 +6039,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6164,7 +6174,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6176,7 +6186,7 @@ msgstr "ストレージプールの情報を表示します"
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
@@ -6208,7 +6218,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6356,7 +6366,7 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6367,11 +6377,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6595,7 +6605,7 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -6649,7 +6659,7 @@ msgstr "トランシーバータイプ: %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6665,12 +6675,12 @@ msgstr "転送モード。pull, push, relay のいずれか"
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6700,7 +6710,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6715,7 +6725,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -6756,12 +6766,12 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6772,7 +6782,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -6804,7 +6814,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -6962,7 +6972,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -7120,7 +7130,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -7145,7 +7155,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7218,7 +7228,7 @@ msgstr "[<remote>:]<alias> <new-name>"
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7231,7 +7241,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
@@ -7252,34 +7262,34 @@ msgstr "[<remote>:]<group> <new-name>"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
@@ -7292,11 +7302,11 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -7383,7 +7393,7 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7781,7 +7791,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr "無効"
 
@@ -7789,7 +7799,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr "有効"
 
@@ -7845,7 +7855,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
@@ -7951,7 +7961,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7979,7 +7989,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8281,7 +8291,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr "no"
 
@@ -8297,16 +8307,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"
@@ -8328,10 +8338,14 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy, c-format
+#~ msgid "Fingerprint %q not found"
+#~ msgstr "証明書のフィンガープリント: %s"
 
 #~ msgid "Candid domain to use"
 #~ msgstr "使用する Candid ドメイン"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -820,11 +820,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1244,15 +1244,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1300,16 +1300,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1646,9 +1646,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1673,10 +1673,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2187,12 +2187,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2207,12 +2207,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2232,7 +2232,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2247,7 +2257,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2257,12 +2267,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2301,12 +2311,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2316,7 +2326,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2335,7 +2345,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2396,10 +2406,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2454,7 +2464,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2613,7 +2623,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2638,22 +2648,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2704,12 +2714,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2748,11 +2758,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2760,25 +2770,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2798,14 +2808,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2843,11 +2853,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2865,7 +2875,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2917,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2990,7 +3000,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3034,12 +3044,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3133,7 +3143,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3148,11 +3158,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3445,7 +3455,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3481,7 +3491,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3493,7 +3503,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,7 +3744,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3742,11 +3752,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3906,7 +3916,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3960,7 +3970,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3968,7 +3978,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4153,7 +4163,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4233,7 +4243,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4300,7 +4310,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4354,14 +4364,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4432,7 +4442,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4449,11 +4459,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4476,11 +4486,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4574,7 +4584,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4592,7 +4602,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4601,7 +4611,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4610,7 +4620,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4647,16 +4657,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4816,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4944,7 +4954,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4960,12 +4970,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5041,7 +5051,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5067,7 +5077,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5303,7 +5313,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5315,7 +5325,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5360,7 +5370,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5494,7 +5504,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5506,7 +5516,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5538,7 +5548,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5686,7 +5696,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5697,11 +5707,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5908,7 +5918,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5954,7 +5964,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5970,12 +5980,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6003,7 +6013,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6018,7 +6028,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6059,12 +6069,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6075,7 +6085,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6106,7 +6116,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6253,7 +6263,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6401,7 +6411,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6426,7 +6436,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6499,7 +6509,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6512,7 +6522,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6531,31 +6541,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6567,11 +6577,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6655,7 +6665,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7034,7 +7044,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7042,7 +7052,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7086,7 +7096,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7159,7 +7169,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7178,7 +7188,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7382,7 +7392,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7398,16 +7408,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7427,7 +7437,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-03-06 16:42+0100\n"
+        "POT-Creation-Date: 2024-03-19 13:38+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -166,7 +166,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all identity information is shown but only the projects and groups can be modified"
 msgstr  ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -179,7 +179,7 @@ msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Note that the name is shown but cannot be modified"
 msgstr  ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -391,7 +391,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -401,12 +401,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -498,7 +498,7 @@ msgstr  ""
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -510,15 +510,15 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -568,7 +568,7 @@ msgstr  ""
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -693,7 +693,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid   "Aliases:"
 msgstr  ""
 
@@ -709,7 +709,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -781,11 +781,11 @@ msgstr  ""
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -836,7 +836,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -917,7 +917,7 @@ msgstr  ""
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
@@ -930,7 +930,7 @@ msgstr  ""
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
@@ -1102,7 +1102,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404 lxc/warning.go:92
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404 lxc/warning.go:92
 msgid   "Columns"
 msgstr  ""
 
@@ -1137,7 +1137,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:635 lxc/network_load_balancer.go:637 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:993 lxc/storage_volume.go:1025
+#: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272 lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147 lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686 lxc/network_acl.go:620 lxc/network_forward.go:635 lxc/network_load_balancer.go:637 lxc/network_peer.go:610 lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518 lxc/project.go:315 lxc/storage.go:310 lxc/storage_bucket.go:343 lxc/storage_bucket.go:1092 lxc/storage_volume.go:993 lxc/storage_volume.go:1025
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1164,15 +1164,15 @@ msgstr  ""
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid   "Copy images between servers"
 msgstr  ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid   "Copy images between servers\n"
         "\n"
         "The auto-update flag instructs the server to keep this image up to date.\n"
@@ -1214,15 +1214,15 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252 lxc/storage_volume.go:338
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252 lxc/storage_volume.go:338
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -1260,7 +1260,7 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
@@ -1322,7 +1322,7 @@ msgstr  ""
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1401,7 +1401,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1424,7 +1424,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438 lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985 lxc/network_acl.go:148 lxc/network_forward.go:145 lxc/network_load_balancer.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172 lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646 lxc/storage_bucket.go:507 lxc/storage_bucket.go:827 lxc/storage_volume.go:1511
+#: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438 lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985 lxc/network_acl.go:148 lxc/network_forward.go:145 lxc/network_load_balancer.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172 lxc/profile.go:658 lxc/project.go:505 lxc/storage.go:646 lxc/storage_bucket.go:507 lxc/storage_bucket.go:827 lxc/storage_volume.go:1511
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1468,7 +1468,7 @@ msgstr  ""
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1476,7 +1476,7 @@ msgstr  ""
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid   "Delete images"
 msgstr  ""
 
@@ -1544,7 +1544,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470 lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750 lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37 lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490 lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338 lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255 lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471 lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804 lxc/cluster.go:880 lxc/cluster.go:982 lxc/cluster.go:1061 lxc/cluster.go:1168 lxc/cluster.go:1190 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:99 lxc/config.go:384 lxc/config.go:517 lxc/config.go:734 lxc/config.go:858 lxc/config.go:893 lxc/config.go:933 lxc/config.go:988 lxc/config.go:1079 lxc/config.go:1110 lxc/config.go:1164 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167 lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37 lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500 lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350 lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:135 lxc/network.go:220 lxc/network.go:293 lxc/network.go:372 lxc/network.go:422 lxc/network.go:507 lxc/network.go:592 lxc/network.go:720 lxc/network.go:789 lxc/network.go:912 lxc/network.go:1005 lxc/network.go:1076 lxc/network.go:1128 lxc/network.go:1216 lxc/network.go:1280 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_load_balancer.go:29 lxc/network_load_balancer.go:90 lxc/network_load_balancer.go:169 lxc/network_load_balancer.go:233 lxc/network_load_balancer.go:331 lxc/network_load_balancer.go:399 lxc/network_load_balancer.go:497 lxc/network_load_balancer.go:527 lxc/network_load_balancer.go:670 lxc/network_load_balancer.go:731 lxc/network_load_balancer.go:746 lxc/network_load_balancer.go:810 lxc/network_load_balancer.go:896 lxc/network_load_balancer.go:911 lxc/network_load_balancer.go:972 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:349 lxc/project.go:410 lxc/project.go:523 lxc/project.go:580 lxc/project.go:659 lxc/project.go:690 lxc/project.go:743 lxc/project.go:802 lxc/publish.go:33 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:624 lxc/remote.go:662 lxc/remote.go:748 lxc/remote.go:821 lxc/remote.go:877 lxc/remote.go:917 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:96 lxc/storage.go:170 lxc/storage.go:220 lxc/storage.go:344 lxc/storage.go:414 lxc/storage.go:586 lxc/storage.go:665 lxc/storage.go:761 lxc/storage.go:847 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:183 lxc/storage_bucket.go:244 lxc/storage_bucket.go:377 lxc/storage_bucket.go:453 lxc/storage_bucket.go:530 lxc/storage_bucket.go:624 lxc/storage_bucket.go:693 lxc/storage_bucket.go:727 lxc/storage_bucket.go:768 lxc/storage_bucket.go:847 lxc/storage_bucket.go:925 lxc/storage_bucket.go:989 lxc/storage_bucket.go:1124 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1322 lxc/storage_volume.go:1406 lxc/storage_volume.go:1613 lxc/storage_volume.go:1694 lxc/storage_volume.go:1809 lxc/storage_volume.go:1953 lxc/storage_volume.go:2062 lxc/storage_volume.go:2108 lxc/storage_volume.go:2205 lxc/storage_volume.go:2272 lxc/storage_volume.go:2426 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1618,7 +1618,7 @@ msgstr  ""
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1626,7 +1626,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1716,11 +1716,11 @@ msgstr  ""
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid   "Edit image properties"
 msgstr  ""
 
@@ -1796,7 +1796,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539 lxc/warning.go:235
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539 lxc/warning.go:235
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1897,20 +1897,20 @@ msgstr  ""
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid   "Export and download images"
 msgstr  ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
@@ -1937,7 +1937,7 @@ msgstr  ""
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -1950,7 +1950,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -1958,12 +1958,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1978,12 +1978,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2003,7 +2003,17 @@ msgstr  ""
 msgid   "Failed deleting instance snapshot %q in project %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid   "Failed fetching fingerprint %q for alias %q: %w"
+msgstr  ""
+
+#: lxc/image.go:123
+#, c-format
+msgid   "Failed fetching fingerprint %q: %w"
+msgstr  ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2018,7 +2028,7 @@ msgstr  ""
 msgid   "Failed loading profile %q for device override: %w"
 msgstr  ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2028,12 +2038,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2072,12 +2082,12 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -2087,7 +2097,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2105,7 +2115,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2161,7 +2171,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916 lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_load_balancer.go:93 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:412 lxc/project.go:804 lxc/remote.go:666 lxc/storage.go:588 lxc/storage_bucket.go:454 lxc/storage_bucket.go:769 lxc/storage_volume.go:1422 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2209,7 +2219,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2229,7 +2239,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2368,7 +2378,7 @@ msgstr  ""
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2393,22 +2403,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2459,12 +2469,12 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
@@ -2501,11 +2511,11 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid   "Image copied successfully!"
 msgstr  ""
 
@@ -2513,25 +2523,25 @@ msgstr  ""
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2551,13 +2561,13 @@ msgstr  ""
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root."
 msgstr  ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid   "Import images into the image store"
 msgstr  ""
 
@@ -2595,11 +2605,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2617,7 +2627,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2669,7 +2679,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2739,7 +2749,7 @@ msgstr  ""
 msgid   "IsSM: %s (%s)"
 msgstr  ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
@@ -2780,12 +2790,12 @@ msgstr  ""
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid   "Last used: never"
 msgstr  ""
 
@@ -2879,7 +2889,7 @@ msgstr  ""
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -2893,11 +2903,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3179,7 +3189,7 @@ msgstr  ""
 msgid   "MTU: %d"
 msgstr  ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid   "Make image public"
 msgstr  ""
 
@@ -3215,7 +3225,7 @@ msgstr  ""
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid   "Manage groups"
 msgstr  ""
 
@@ -3227,7 +3237,7 @@ msgstr  ""
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3455,7 +3465,7 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416 lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416 lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid   "Missing group name"
 msgstr  ""
 
@@ -3463,11 +3473,11 @@ msgstr  ""
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
@@ -3571,7 +3581,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3620,7 +3630,7 @@ msgstr  ""
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -3628,7 +3638,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183 lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:498 lxc/remote.go:724 lxc/storage.go:638 lxc/storage_bucket.go:506 lxc/storage_bucket.go:826 lxc/storage_volume.go:1510
 msgid   "NAME"
 msgstr  ""
 
@@ -3803,7 +3813,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid   "New aliases to add to the image"
 msgstr  ""
 
@@ -3883,7 +3893,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
@@ -3950,7 +3960,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4004,11 +4014,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771 lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348 lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206 lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687 lxc/network_acl.go:621 lxc/network_forward.go:636 lxc/network_load_balancer.go:638 lxc/network_peer.go:611 lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519 lxc/project.go:316 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1093 lxc/storage_volume.go:994 lxc/storage_volume.go:1026
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4073,7 +4083,7 @@ msgstr  ""
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
@@ -4090,11 +4100,11 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4117,11 +4127,11 @@ msgstr  ""
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid   "Property not found"
 msgstr  ""
 
@@ -4199,7 +4209,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4217,7 +4227,7 @@ msgstr  ""
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
@@ -4226,7 +4236,7 @@ msgstr  ""
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4235,7 +4245,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4272,16 +4282,16 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4369,7 +4379,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4429,7 +4439,7 @@ msgstr  ""
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -4565,7 +4575,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid   "SIZE"
 msgstr  ""
 
@@ -4581,12 +4591,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4661,7 +4671,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4683,7 +4693,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4895,7 +4905,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4907,7 +4917,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -4948,7 +4958,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5080,7 +5090,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5092,7 +5102,7 @@ msgstr  ""
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
@@ -5124,7 +5134,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid   "Source:"
 msgstr  ""
 
@@ -5272,7 +5282,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1509 lxc/warning.go:215
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074 lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981 lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1509 lxc/warning.go:215
 msgid   "TYPE"
 msgstr  ""
 
@@ -5280,11 +5290,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5483,7 +5493,7 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -5527,7 +5537,7 @@ msgstr  ""
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
@@ -5543,12 +5553,12 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5574,7 +5584,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837 lxc/storage_volume.go:1270
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837 lxc/storage_volume.go:1270
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5588,7 +5598,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5627,12 +5637,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547 lxc/warning.go:243
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547 lxc/warning.go:243
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5642,7 +5652,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5673,7 +5683,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5818,7 +5828,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -5958,7 +5968,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687 lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689 lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82 lxc/operation.go:103 lxc/profile.go:610 lxc/project.go:407 lxc/storage.go:583 lxc/version.go:20 lxc/warning.go:68
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -5978,7 +5988,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6050,7 +6060,7 @@ msgstr  ""
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6062,7 +6072,7 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439 lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155 lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
+#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439 lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155 lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
@@ -6078,31 +6088,31 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
@@ -6114,11 +6124,11 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -6198,7 +6208,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6554,7 +6564,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid   "disabled"
 msgstr  ""
 
@@ -6562,7 +6572,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid   "enabled"
 msgstr  ""
 
@@ -6600,7 +6610,7 @@ msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < i
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
@@ -6657,7 +6667,7 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
@@ -6672,7 +6682,7 @@ msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid   "lxc image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -6843,7 +6853,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid   "no"
 msgstr  ""
 
@@ -6859,16 +6869,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 
@@ -6888,7 +6898,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930 lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942 lxc/image.go:1127
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -249,7 +249,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -270,7 +270,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -657,12 +657,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -755,7 +755,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -768,15 +768,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1047,11 +1047,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1185,7 +1185,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1399,7 +1399,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1438,7 +1438,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1471,15 +1471,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1527,16 +1527,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1740,7 +1740,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1873,9 +1873,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1900,10 +1900,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2152,11 +2152,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2232,7 +2232,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2351,20 +2351,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2392,7 +2392,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2414,12 +2414,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2434,12 +2434,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2459,7 +2459,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2484,12 +2494,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2528,12 +2538,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2543,7 +2553,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2562,7 +2572,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2623,10 +2633,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2681,7 +2691,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2701,7 +2711,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2840,7 +2850,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2865,22 +2875,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2931,12 +2941,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2975,11 +2985,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2987,25 +2997,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3025,14 +3035,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3070,11 +3080,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3092,7 +3102,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3144,7 +3154,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3217,7 +3227,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3261,12 +3271,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3360,7 +3370,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3375,11 +3385,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3672,7 +3682,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3708,7 +3718,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3720,7 +3730,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3961,7 +3971,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3969,11 +3979,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4133,7 +4143,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4187,7 +4197,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4195,7 +4205,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4380,7 +4390,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4460,7 +4470,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4527,7 +4537,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4581,14 +4591,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4659,7 +4669,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4676,11 +4686,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4703,11 +4713,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4801,7 +4811,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4819,7 +4829,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4828,7 +4838,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4837,7 +4847,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4874,16 +4884,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4972,7 +4982,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5033,7 +5043,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5171,7 +5181,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5187,12 +5197,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5268,7 +5278,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5294,7 +5304,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5587,7 +5597,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5721,7 +5731,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5733,7 +5743,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5765,7 +5775,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5913,7 +5923,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5924,11 +5934,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6135,7 +6145,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6181,7 +6191,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6197,12 +6207,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6230,7 +6240,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6245,7 +6255,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6286,12 +6296,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6302,7 +6312,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6333,7 +6343,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6480,7 +6490,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6628,7 +6638,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6653,7 +6663,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6726,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6739,7 +6749,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6758,31 +6768,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6794,11 +6804,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6882,7 +6892,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7261,7 +7271,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7269,7 +7279,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7313,7 +7323,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7386,7 +7396,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7405,7 +7415,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7609,7 +7619,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7625,16 +7635,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7654,8 +7664,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -280,7 +280,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -685,7 +685,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -695,12 +695,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -806,15 +806,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -864,7 +864,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -996,7 +996,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1085,11 +1085,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1142,7 +1142,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1236,7 +1236,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1476,7 +1476,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1509,15 +1509,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1565,16 +1565,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1778,7 +1778,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1911,9 +1911,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1938,10 +1938,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2098,7 +2098,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2190,11 +2190,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2270,7 +2270,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2389,20 +2389,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2430,7 +2430,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2443,7 +2443,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2452,12 +2452,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2472,12 +2472,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2497,7 +2497,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2512,7 +2522,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2522,12 +2532,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2566,12 +2576,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2581,7 +2591,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2600,7 +2610,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2661,10 +2671,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2719,7 +2729,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2739,7 +2749,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2878,7 +2888,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2903,22 +2913,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2969,12 +2979,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3013,11 +3023,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3025,25 +3035,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3063,14 +3073,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3108,11 +3118,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3130,7 +3140,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3182,7 +3192,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3255,7 +3265,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3299,12 +3309,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3398,7 +3408,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3413,11 +3423,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3710,7 +3720,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3746,7 +3756,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3758,7 +3768,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3999,7 +4009,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -4007,11 +4017,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4171,7 +4181,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4225,7 +4235,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4233,7 +4243,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4418,7 +4428,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4498,7 +4508,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4565,7 +4575,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4619,14 +4629,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4697,7 +4707,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4714,11 +4724,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4741,11 +4751,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4839,7 +4849,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4857,7 +4867,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4866,7 +4876,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4875,7 +4885,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4912,16 +4922,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5010,7 +5020,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5071,7 +5081,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5209,7 +5219,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5225,12 +5235,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5332,7 +5342,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5568,7 +5578,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5580,7 +5590,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5625,7 +5635,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5759,7 +5769,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5771,7 +5781,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5803,7 +5813,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5951,7 +5961,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5962,11 +5972,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6173,7 +6183,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6219,7 +6229,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6235,12 +6245,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6268,7 +6278,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6283,7 +6293,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6324,12 +6334,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6340,7 +6350,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6371,7 +6381,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6518,7 +6528,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6666,7 +6676,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6691,7 +6701,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6764,7 +6774,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6777,7 +6787,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6796,31 +6806,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6832,11 +6842,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6920,7 +6930,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7299,7 +7309,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7307,7 +7317,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7351,7 +7361,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7424,7 +7434,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7443,7 +7453,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7647,7 +7657,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7663,16 +7673,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7692,8 +7702,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -820,11 +820,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1244,15 +1244,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1300,16 +1300,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1646,9 +1646,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1673,10 +1673,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2187,12 +2187,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2207,12 +2207,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2232,7 +2232,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2247,7 +2257,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2257,12 +2267,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2301,12 +2311,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2316,7 +2326,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2335,7 +2345,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2396,10 +2406,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2454,7 +2464,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2613,7 +2623,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2638,22 +2648,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2704,12 +2714,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2748,11 +2758,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2760,25 +2770,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2798,14 +2808,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2843,11 +2853,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2865,7 +2875,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2917,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2990,7 +3000,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3034,12 +3044,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3133,7 +3143,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3148,11 +3158,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3445,7 +3455,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3481,7 +3491,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3493,7 +3503,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,7 +3744,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3742,11 +3752,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3906,7 +3916,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3960,7 +3970,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3968,7 +3978,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4153,7 +4163,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4233,7 +4243,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4300,7 +4310,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4354,14 +4364,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4432,7 +4442,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4449,11 +4459,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4476,11 +4486,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4574,7 +4584,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4592,7 +4602,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4601,7 +4611,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4610,7 +4620,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4647,16 +4657,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4816,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4944,7 +4954,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4960,12 +4970,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5041,7 +5051,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5067,7 +5077,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5303,7 +5313,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5315,7 +5325,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5360,7 +5370,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5494,7 +5504,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5506,7 +5516,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5538,7 +5548,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5686,7 +5696,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5697,11 +5707,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5908,7 +5918,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5954,7 +5964,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5970,12 +5980,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6003,7 +6013,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6018,7 +6028,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6059,12 +6069,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6075,7 +6085,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6106,7 +6116,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6253,7 +6263,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6401,7 +6411,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6426,7 +6436,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6499,7 +6509,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6512,7 +6522,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6531,31 +6541,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6567,11 +6577,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6655,7 +6665,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7034,7 +7044,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7042,7 +7052,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7086,7 +7096,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7159,7 +7169,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7178,7 +7188,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7382,7 +7392,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7398,16 +7408,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7427,7 +7437,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -252,7 +252,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -273,7 +273,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -671,7 +671,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -681,12 +681,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -790,7 +790,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,15 +803,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -863,7 +863,7 @@ msgstr "Nome de membro do cluster"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1098,11 +1098,11 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
@@ -1156,7 +1156,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
@@ -1237,7 +1237,7 @@ msgstr "CRIADO EM"
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
@@ -1251,7 +1251,7 @@ msgstr "Em cache: %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Colunas"
@@ -1502,7 +1502,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1535,15 +1535,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1592,17 +1592,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
@@ -1640,7 +1640,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1704,7 +1704,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1798,7 +1798,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1823,7 +1823,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1877,7 +1877,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1969,9 +1969,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1996,10 +1996,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2152,7 +2152,7 @@ msgstr "Em cache: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -2160,7 +2160,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2259,12 +2259,12 @@ msgstr "Editar arquivos no container"
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
@@ -2353,7 +2353,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2473,20 +2473,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2536,12 +2536,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2556,12 +2556,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2581,7 +2581,17 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "Nome de membro do cluster"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "Nome de membro do cluster"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2596,7 +2606,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2606,12 +2616,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2650,12 +2660,12 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2665,7 +2675,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2684,7 +2694,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2746,10 +2756,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2804,7 +2814,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2825,7 +2835,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -2983,7 +2993,7 @@ msgstr "Clustering ativado"
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3008,22 +3018,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3074,12 +3084,12 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3119,11 +3129,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3131,25 +3141,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3170,14 +3180,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3215,11 +3225,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3237,7 +3247,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3289,7 +3299,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3364,7 +3374,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3408,12 +3418,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3512,7 +3522,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3527,11 +3537,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3829,7 +3839,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3868,7 +3878,7 @@ msgstr "Editar arquivos no container"
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
@@ -3882,7 +3892,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4148,7 +4158,7 @@ msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
@@ -4158,12 +4168,12 @@ msgstr "Nome de membro do cluster"
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4332,7 +4342,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4387,7 +4397,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4395,7 +4405,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4580,7 +4590,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4660,7 +4670,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4727,7 +4737,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4782,14 +4792,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4860,7 +4870,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -4880,12 +4890,12 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -4909,11 +4919,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -5007,7 +5017,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5025,7 +5035,7 @@ msgstr "Editar arquivos no container"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5035,7 +5045,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5083,16 +5093,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5187,7 +5197,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5256,7 +5266,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5405,7 +5415,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5421,12 +5431,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5504,7 +5514,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5531,7 +5541,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5784,7 +5794,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5796,7 +5806,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5845,7 +5855,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5996,7 +6006,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6008,7 +6018,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6040,7 +6050,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -6189,7 +6199,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6200,12 +6210,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6416,7 +6426,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6462,7 +6472,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6478,12 +6488,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6512,7 +6522,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6527,7 +6537,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6569,12 +6579,12 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6585,7 +6595,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6620,7 +6630,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -6788,7 +6798,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6938,7 +6948,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6966,7 +6976,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7049,7 +7059,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7063,7 +7073,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7086,36 +7096,36 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7128,11 +7138,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7220,7 +7230,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7643,7 +7653,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7651,7 +7661,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7695,7 +7705,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7768,7 +7778,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7787,7 +7797,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7991,7 +8001,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -8007,16 +8017,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8036,8 +8046,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -256,7 +256,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -680,7 +680,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -690,12 +690,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -806,16 +806,16 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -866,7 +866,7 @@ msgstr "Копирование образа: %s"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1095,11 +1095,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
@@ -1153,7 +1153,7 @@ msgstr "Имя контейнера: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1236,7 +1236,7 @@ msgstr "СОЗДАН"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1249,7 +1249,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr "Столбцы"
@@ -1490,7 +1490,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1523,15 +1523,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1580,17 +1580,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -1628,7 +1628,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1787,7 +1787,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1812,7 +1812,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1864,7 +1864,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1872,7 +1872,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1955,9 +1955,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1982,10 +1982,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -2136,7 +2136,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2240,12 +2240,12 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2452,21 +2452,21 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2498,7 +2498,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2520,12 +2520,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2540,12 +2540,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2565,7 +2565,17 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr "Копирование образа: %s"
+
+#: lxc/image.go:123
+#, fuzzy, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr "Копирование образа: %s"
+
+#: lxc/file.go:1175
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2580,7 +2590,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2590,12 +2600,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2634,12 +2644,12 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2649,7 +2659,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2668,7 +2678,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2730,10 +2740,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2788,7 +2798,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2809,7 +2819,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2963,7 +2973,7 @@ msgstr " Использование сети:"
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2989,22 +2999,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3055,12 +3065,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3100,11 +3110,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3112,25 +3122,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3151,14 +3161,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
@@ -3199,11 +3209,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3223,7 +3233,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3275,7 +3285,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3350,7 +3360,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3394,12 +3404,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3501,7 +3511,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3516,11 +3526,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3824,7 +3834,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3863,7 +3873,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
@@ -3877,7 +3887,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4145,7 +4155,7 @@ msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
@@ -4155,12 +4165,12 @@ msgstr "Копирование образа: %s"
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4332,7 +4342,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4388,7 +4398,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4396,7 +4406,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4583,7 +4593,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4665,7 +4675,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4732,7 +4742,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4787,14 +4797,14 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4865,7 +4875,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4882,11 +4892,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4909,11 +4919,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -5007,7 +5017,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5025,7 +5035,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -5034,7 +5044,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5043,7 +5053,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5083,17 +5093,17 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5186,7 +5196,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5251,7 +5261,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5400,7 +5410,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5416,12 +5426,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5499,7 +5509,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5525,7 +5535,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5775,7 +5785,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5787,7 +5797,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5835,7 +5845,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5983,7 +5993,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5995,7 +6005,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
@@ -6028,7 +6038,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -6180,7 +6190,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -6191,11 +6201,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6402,7 +6412,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6448,7 +6458,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6464,12 +6474,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6498,7 +6508,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6513,7 +6523,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6554,12 +6564,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6570,7 +6580,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6603,7 +6613,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6769,7 +6779,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6926,7 +6936,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6971,7 +6981,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7108,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7129,7 +7139,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7164,7 +7174,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7172,7 +7182,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7180,7 +7190,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7188,7 +7198,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7196,7 +7206,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7204,7 +7214,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7212,7 +7222,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7236,7 +7246,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7244,7 +7254,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7408,7 +7418,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8131,7 +8141,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -8139,7 +8149,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -8183,7 +8193,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8256,7 +8266,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8275,7 +8285,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8479,7 +8489,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -8495,16 +8505,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8524,8 +8534,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1248,15 +1248,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,16 +1304,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1517,7 +1517,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1650,9 +1650,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1677,10 +1677,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1929,11 +1929,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2128,20 +2128,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2191,12 +2191,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2211,12 +2211,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2261,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2271,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,12 +2315,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2320,7 +2330,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2339,7 +2349,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2400,10 +2410,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2458,7 +2468,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2478,7 +2488,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2617,7 +2627,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2642,22 +2652,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2708,12 +2718,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2752,11 +2762,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2764,25 +2774,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2802,14 +2812,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2847,11 +2857,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2869,7 +2879,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2921,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2994,7 +3004,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3038,12 +3048,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3137,7 +3147,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3152,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3449,7 +3459,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3485,7 +3495,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3497,7 +3507,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,7 +3748,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3746,11 +3756,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3910,7 +3920,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3964,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3972,7 +3982,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4157,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4237,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4304,7 +4314,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4358,14 +4368,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4436,7 +4446,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4453,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4480,11 +4490,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4605,7 +4615,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4614,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4651,16 +4661,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4820,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4948,7 +4958,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4964,12 +4974,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5045,7 +5055,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5071,7 +5081,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5307,7 +5317,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5319,7 +5329,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5364,7 +5374,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5498,7 +5508,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5510,7 +5520,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5690,7 +5700,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5701,11 +5711,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5912,7 +5922,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5974,12 +5984,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6007,7 +6017,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6022,7 +6032,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6063,12 +6073,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6079,7 +6089,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6110,7 +6120,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6257,7 +6267,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6405,7 +6415,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6430,7 +6440,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6503,7 +6513,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6516,7 +6526,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6535,31 +6545,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6571,11 +6581,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6659,7 +6669,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7038,7 +7048,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7046,7 +7056,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7090,7 +7100,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7163,7 +7173,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7182,7 +7192,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7386,7 +7396,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7402,16 +7412,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7431,7 +7441,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1248,15 +1248,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,16 +1304,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1517,7 +1517,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1650,9 +1650,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1677,10 +1677,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1929,11 +1929,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2128,20 +2128,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2191,12 +2191,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2211,12 +2211,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2261,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2271,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,12 +2315,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2320,7 +2330,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2339,7 +2349,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2400,10 +2410,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2458,7 +2468,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2478,7 +2488,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2617,7 +2627,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2642,22 +2652,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2708,12 +2718,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2752,11 +2762,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2764,25 +2774,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2802,14 +2812,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2847,11 +2857,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2869,7 +2879,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2921,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2994,7 +3004,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3038,12 +3048,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3137,7 +3147,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3152,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3449,7 +3459,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3485,7 +3495,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3497,7 +3507,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,7 +3748,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3746,11 +3756,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3910,7 +3920,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3964,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3972,7 +3982,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4157,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4237,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4304,7 +4314,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4358,14 +4368,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4436,7 +4446,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4453,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4480,11 +4490,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4605,7 +4615,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4614,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4651,16 +4661,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4820,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4948,7 +4958,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4964,12 +4974,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5045,7 +5055,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5071,7 +5081,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5307,7 +5317,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5319,7 +5329,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5364,7 +5374,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5498,7 +5508,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5510,7 +5520,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5690,7 +5700,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5701,11 +5711,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5912,7 +5922,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5974,12 +5984,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6007,7 +6017,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6022,7 +6032,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6063,12 +6073,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6079,7 +6089,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6110,7 +6120,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6257,7 +6267,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6405,7 +6415,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6430,7 +6440,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6503,7 +6513,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6516,7 +6526,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6535,31 +6545,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6571,11 +6581,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6659,7 +6669,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7038,7 +7048,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7046,7 +7056,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7090,7 +7100,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7163,7 +7173,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7182,7 +7192,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7386,7 +7396,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7402,16 +7412,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7431,7 +7441,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -820,11 +820,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1244,15 +1244,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1300,16 +1300,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1347,7 +1347,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1646,9 +1646,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1673,10 +1673,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1925,11 +1925,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2187,12 +2187,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2207,12 +2207,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2232,7 +2232,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2247,7 +2257,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2257,12 +2267,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2301,12 +2311,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2316,7 +2326,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2335,7 +2345,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2396,10 +2406,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2454,7 +2464,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2474,7 +2484,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2613,7 +2623,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2638,22 +2648,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2704,12 +2714,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2748,11 +2758,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2760,25 +2770,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2798,14 +2808,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2843,11 +2853,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2865,7 +2875,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2917,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2990,7 +3000,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3034,12 +3044,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3133,7 +3143,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3148,11 +3158,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3445,7 +3455,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3481,7 +3491,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3493,7 +3503,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3734,7 +3744,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3742,11 +3752,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3906,7 +3916,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3960,7 +3970,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3968,7 +3978,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4153,7 +4163,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4233,7 +4243,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4300,7 +4310,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4354,14 +4364,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4432,7 +4442,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4449,11 +4459,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4476,11 +4486,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4574,7 +4584,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4592,7 +4602,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4601,7 +4611,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4610,7 +4620,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4647,16 +4657,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4806,7 +4816,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4944,7 +4954,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4960,12 +4970,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5041,7 +5051,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5067,7 +5077,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5303,7 +5313,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5315,7 +5325,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5360,7 +5370,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5494,7 +5504,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5506,7 +5516,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5538,7 +5548,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5686,7 +5696,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5697,11 +5707,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5908,7 +5918,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5954,7 +5964,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5970,12 +5980,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6003,7 +6013,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6018,7 +6028,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6059,12 +6069,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6075,7 +6085,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6106,7 +6116,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6253,7 +6263,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6401,7 +6411,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6426,7 +6436,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6499,7 +6509,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6512,7 +6522,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6531,31 +6541,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6567,11 +6577,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6655,7 +6665,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7034,7 +7044,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7042,7 +7052,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7086,7 +7096,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7159,7 +7169,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7178,7 +7188,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7382,7 +7392,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7398,16 +7408,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7427,7 +7437,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -603,7 +603,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -824,11 +824,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1248,15 +1248,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1304,16 +1304,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1351,7 +1351,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1413,7 +1413,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1517,7 +1517,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1567,7 +1567,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1575,7 +1575,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1650,9 +1650,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1677,10 +1677,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1929,11 +1929,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2009,7 +2009,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2128,20 +2128,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2191,12 +2191,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2211,12 +2211,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2236,7 +2236,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2251,7 +2261,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2261,12 +2271,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2305,12 +2315,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2320,7 +2330,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2339,7 +2349,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2400,10 +2410,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2458,7 +2468,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2478,7 +2488,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2617,7 +2627,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2642,22 +2652,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2708,12 +2718,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2752,11 +2762,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2764,25 +2774,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2802,14 +2812,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2847,11 +2857,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2869,7 +2879,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2921,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2994,7 +3004,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3038,12 +3048,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3137,7 +3147,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3152,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3449,7 +3459,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3485,7 +3495,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3497,7 +3507,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3738,7 +3748,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3746,11 +3756,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3910,7 +3920,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3964,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3972,7 +3982,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4157,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4237,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4304,7 +4314,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4358,14 +4368,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4436,7 +4446,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4453,11 +4463,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4480,11 +4490,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4605,7 +4615,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4614,7 +4624,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4651,16 +4661,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4810,7 +4820,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4948,7 +4958,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4964,12 +4974,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5045,7 +5055,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5071,7 +5081,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5307,7 +5317,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5319,7 +5329,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5364,7 +5374,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5498,7 +5508,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5510,7 +5520,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5690,7 +5700,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5701,11 +5711,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5912,7 +5922,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5974,12 +5984,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6007,7 +6017,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6022,7 +6032,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6063,12 +6073,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6079,7 +6089,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6110,7 +6120,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6257,7 +6267,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6405,7 +6415,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6430,7 +6440,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6503,7 +6513,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6516,7 +6526,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6535,31 +6545,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6571,11 +6581,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6659,7 +6669,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7038,7 +7048,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7046,7 +7056,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7090,7 +7100,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7163,7 +7173,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7182,7 +7192,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7386,7 +7396,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7402,16 +7412,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7431,7 +7441,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -280,7 +280,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -584,7 +584,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -594,12 +594,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -692,7 +692,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -705,15 +705,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -984,11 +984,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1122,7 +1122,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1135,7 +1135,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1336,7 +1336,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1375,7 +1375,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1408,15 +1408,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1464,16 +1464,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1511,7 +1511,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1653,7 +1653,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1677,7 +1677,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1727,7 +1727,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1810,9 +1810,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1837,10 +1837,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1997,7 +1997,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2089,11 +2089,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2169,7 +2169,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2288,20 +2288,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2351,12 +2351,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2371,12 +2371,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2396,7 +2396,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2411,7 +2421,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2421,12 +2431,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2465,12 +2475,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2480,7 +2490,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2499,7 +2509,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2560,10 +2570,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2618,7 +2628,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2638,7 +2648,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2777,7 +2787,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2802,22 +2812,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2868,12 +2878,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2912,11 +2922,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2924,25 +2934,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2962,14 +2972,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3007,11 +3017,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3029,7 +3039,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3081,7 +3091,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3154,7 +3164,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3198,12 +3208,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3297,7 +3307,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3312,11 +3322,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3609,7 +3619,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3645,7 +3655,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3657,7 +3667,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3898,7 +3908,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3906,11 +3916,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4070,7 +4080,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4124,7 +4134,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4132,7 +4142,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4317,7 +4327,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4397,7 +4407,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4464,7 +4474,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4518,14 +4528,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4596,7 +4606,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4613,11 +4623,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4640,11 +4650,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4738,7 +4748,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4756,7 +4766,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4765,7 +4775,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4774,7 +4784,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4811,16 +4821,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4909,7 +4919,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4970,7 +4980,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5108,7 +5118,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -5124,12 +5134,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5205,7 +5215,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5231,7 +5241,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5467,7 +5477,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5479,7 +5489,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5524,7 +5534,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5658,7 +5668,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5670,7 +5680,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5702,7 +5712,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5850,7 +5860,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5861,11 +5871,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6072,7 +6082,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6128,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6134,12 +6144,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6167,7 +6177,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6182,7 +6192,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6223,12 +6233,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6239,7 +6249,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6270,7 +6280,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6417,7 +6427,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6565,7 +6575,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6590,7 +6600,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6663,7 +6673,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6676,7 +6686,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6695,31 +6705,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6731,11 +6741,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6819,7 +6829,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7198,7 +7208,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7206,7 +7216,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7250,7 +7260,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7323,7 +7333,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7342,7 +7352,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7546,7 +7556,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7562,16 +7572,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7591,8 +7601,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-03-06 16:42+0100\n"
+"POT-Creation-Date: 2024-03-19 13:38+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1583
+#: lxc/auth.go:1585
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:378
+#: lxc/image.go:394
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1101
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:916
+#: lxc/file.go:917
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:806
+#: lxc/file.go:807
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:649
+#: lxc/image.go:662
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1053 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1065 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1066
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/image.go:1059 lxc/list.go:554
+#: lxc/cluster.go:186 lxc/image.go:1071 lxc/list.go:554
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -602,7 +602,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1872 lxc/auth.go:1873
+#: lxc/auth.go:1874 lxc/auth.go:1875
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:974
+#: lxc/image.go:986
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:945 lxc/info.go:478
+#: lxc/image.go:957 lxc/info.go:478
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -823,11 +823,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:174
+#: lxc/image.go:187
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:984
+#: lxc/image.go:996
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:756
+#: lxc/image.go:769
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:983
+#: lxc/image.go:995
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:207
+#: lxc/image.go:220
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1044 lxc/list.go:132 lxc/storage_volume.go:1404
+#: lxc/image.go:1056 lxc/list.go:132 lxc/storage_volume.go:1404
 #: lxc/warning.go:92
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 
 #: lxc/cluster.go:770 lxc/cluster_group.go:339 lxc/config.go:272
 #: lxc/config.go:347 lxc/config.go:1277 lxc/config_metadata.go:147
-#: lxc/config_trust.go:314 lxc/image.go:456 lxc/network.go:686
+#: lxc/config_trust.go:314 lxc/image.go:466 lxc/network.go:686
 #: lxc/network_acl.go:620 lxc/network_forward.go:635
 #: lxc/network_load_balancer.go:637 lxc/network_peer.go:610
 #: lxc/network_zone.go:551 lxc/network_zone.go:1143 lxc/profile.go:518
@@ -1247,15 +1247,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:152
+#: lxc/image.go:165
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:144
+#: lxc/image.go:157
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:145
+#: lxc/image.go:158
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1303,16 +1303,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:62 lxc/image.go:157 lxc/move.go:67 lxc/profile.go:252
+#: lxc/copy.go:62 lxc/image.go:170 lxc/move.go:67 lxc/profile.go:252
 #: lxc/storage_volume.go:338
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:155
+#: lxc/image.go:168
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:263
+#: lxc/image.go:275
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1658
+#: lxc/auth.go:300 lxc/auth.go:1660
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1469 lxc/auth.go:1470
+#: lxc/auth.go:1471 lxc/auth.go:1472
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:952 lxc/info.go:489 lxc/storage_volume.go:1290
+#: lxc/image.go:964 lxc/info.go:489 lxc/storage_volume.go:1290
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1516,7 +1516,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:376 lxc/cluster.go:188 lxc/cluster_group.go:438
-#: lxc/image.go:1058 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
+#: lxc/image.go:1070 lxc/image_alias.go:237 lxc/list.go:557 lxc/network.go:985
 #: lxc/network_acl.go:148 lxc/network_forward.go:145
 #: lxc/network_load_balancer.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:742 lxc/operation.go:172
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1522
+#: lxc/auth.go:1523 lxc/auth.go:1524
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1574,7 +1574,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:311 lxc/image.go:312
+#: lxc/image.go:323 lxc/image.go:324
 msgid "Delete images"
 msgstr ""
 
@@ -1649,9 +1649,9 @@ msgstr ""
 #: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
 #: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
 #: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1432 lxc/auth.go:1470
-#: lxc/auth.go:1522 lxc/auth.go:1571 lxc/auth.go:1690 lxc/auth.go:1750
-#: lxc/auth.go:1799 lxc/auth.go:1850 lxc/auth.go:1873 lxc/auth.go:1926
+#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
+#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
+#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
 #: lxc/cluster.go:29 lxc/cluster.go:122 lxc/cluster.go:206 lxc/cluster.go:255
 #: lxc/cluster.go:306 lxc/cluster.go:367 lxc/cluster.go:439 lxc/cluster.go:471
 #: lxc/cluster.go:521 lxc/cluster.go:604 lxc/cluster.go:689 lxc/cluster.go:804
@@ -1676,10 +1676,10 @@ msgstr ""
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:78 lxc/file.go:118 lxc/file.go:167
-#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:967 lxc/image.go:37
-#: lxc/image.go:145 lxc/image.go:312 lxc/image.go:363 lxc/image.go:490
-#: lxc/image.go:651 lxc/image.go:884 lxc/image.go:1019 lxc/image.go:1338
-#: lxc/image.go:1418 lxc/image.go:1477 lxc/image.go:1529 lxc/image.go:1585
+#: lxc/file.go:237 lxc/file.go:459 lxc/file.go:968 lxc/image.go:37
+#: lxc/image.go:158 lxc/image.go:324 lxc/image.go:379 lxc/image.go:500
+#: lxc/image.go:664 lxc/image.go:897 lxc/image.go:1031 lxc/image.go:1350
+#: lxc/image.go:1434 lxc/image.go:1492 lxc/image.go:1543 lxc/image.go:1598
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:42 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82
@@ -1828,7 +1828,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:666
+#: lxc/image.go:679
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:975
+#: lxc/file.go:976
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1928,11 +1928,11 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1570 lxc/auth.go:1571
+#: lxc/auth.go:1572 lxc/auth.go:1573
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:362 lxc/image.go:363
+#: lxc/image.go:378 lxc/image.go:379
 msgid "Edit image properties"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/list.go:614 lxc/storage_volume.go:1539
+#: lxc/image.go:1082 lxc/list.go:614 lxc/storage_volume.go:1539
 #: lxc/warning.go:235
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2127,20 +2127,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:958
+#: lxc/image.go:970
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:960
+#: lxc/image.go:972
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:489
+#: lxc/image.go:499
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:500
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:571
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1055 lxc/image.go:1056
+#: lxc/config_trust.go:411 lxc/image.go:1067 lxc/image.go:1068
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1218
+#: lxc/file.go:1219
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1241
+#: lxc/file.go:1242
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2210,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1268
+#: lxc/file.go:1269
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1053
+#: lxc/file.go:1054
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,17 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/file.go:1174
+#: lxc/image.go:132
+#, c-format
+msgid "Failed fetching fingerprint %q for alias %q: %w"
+msgstr ""
+
+#: lxc/image.go:123
+#, c-format
+msgid "Failed fetching fingerprint %q: %w"
+msgstr ""
+
+#: lxc/file.go:1175
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q for device override: %w"
 msgstr ""
 
-#: lxc/file.go:1179
+#: lxc/file.go:1180
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1079
+#: lxc/file.go:1080
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1207
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,12 +2314,12 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1191
+#: lxc/file.go:1192
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:361
+#: lxc/copy.go:358
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:801
+#: lxc/file.go:802
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2348,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:943
+#: lxc/image.go:955
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2399,10 +2409,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1694
+#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
 #: lxc/cluster.go:124 lxc/cluster.go:881 lxc/cluster_group.go:384
 #: lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1045 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
+#: lxc/image.go:1057 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:916
 #: lxc/network.go:1007 lxc/network_acl.go:97 lxc/network_allocations.go:57
 #: lxc/network_forward.go:89 lxc/network_load_balancer.go:93
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
@@ -2457,7 +2467,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1734
+#: lxc/auth.go:817 lxc/auth.go:1736
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1476 lxc/image.go:1477
+#: lxc/image.go:1491 lxc/image.go:1492
 msgid "Get image properties"
 msgstr ""
 
@@ -2616,7 +2626,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1784
+#: lxc/auth.go:426 lxc/auth.go:1786
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,22 +2651,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1291
+#: lxc/file.go:1292
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1281
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1104
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1113
+#: lxc/file.go:1114
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2707,12 +2717,12 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1506
+#: lxc/auth.go:1508
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1556
+#: lxc/auth.go:1558
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2751,11 +2761,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1399
+#: lxc/image.go:1415
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:280
+#: lxc/image.go:292
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2763,25 +2773,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:634
+#: lxc/image.go:647
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:335 lxc/image.go:1361
+#: lxc/image.go:347 lxc/image.go:1373
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:403 lxc/image.go:1553
+#: lxc/image.go:419 lxc/image.go:1567
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:854
+#: lxc/image.go:867
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1397
+#: lxc/image.go:1413
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2801,14 +2811,14 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:664
 msgid ""
 "Import image into the image store\n"
 "\n"
 "Directory import is only available on Linux and must be performed as root."
 msgstr ""
 
-#: lxc/image.go:650
+#: lxc/image.go:663
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2846,11 +2856,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1105
+#: lxc/file.go:1106
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1282
+#: lxc/file.go:1283
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2878,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1025
+#: lxc/file.go:1026
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2920,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1020
+#: lxc/file.go:1021
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,7 +3003,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:153
+#: lxc/image.go:166
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3037,12 +3047,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:964
+#: lxc/image.go:976
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:978
 msgid "Last used: never"
 msgstr ""
 
@@ -3136,7 +3146,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1689 lxc/auth.go:1690
+#: lxc/auth.go:1691 lxc/auth.go:1692
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3151,11 +3161,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1030
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1031
 msgid ""
 "List images\n"
 "\n"
@@ -3448,7 +3458,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:151 lxc/image.go:656
+#: lxc/image.go:164 lxc/image.go:669
 msgid "Make image public"
 msgstr ""
 
@@ -3484,7 +3494,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1431 lxc/auth.go:1432
+#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
 msgid "Manage groups"
 msgstr ""
 
@@ -3496,7 +3506,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1849 lxc/auth.go:1850
+#: lxc/auth.go:1851 lxc/auth.go:1852
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3737,7 +3747,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1823
+#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
 msgid "Missing group name"
 msgstr ""
 
@@ -3745,11 +3755,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1493 lxc/auth.go:1546 lxc/auth.go:1612 lxc/auth.go:1774
+#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1950
+#: lxc/auth.go:1899 lxc/auth.go:1952
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3909,7 +3919,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:966 lxc/file.go:967
+#: lxc/file.go:967 lxc/file.go:968
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3963,7 +3973,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:668
+#: lxc/image.go:681
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -3971,7 +3981,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1733 lxc/cluster.go:183
+#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:183
 #: lxc/cluster.go:964 lxc/cluster_group.go:437 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:565 lxc/network.go:980
 #: lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138
@@ -4156,7 +4166,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:154 lxc/image.go:657
+#: lxc/image.go:167 lxc/image.go:670
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4236,7 +4246,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:745
+#: lxc/image.go:758
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4303,7 +4313,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1057 lxc/remote.go:728
+#: lxc/image.go:1069 lxc/remote.go:728
 msgid "PUBLIC"
 msgstr ""
 
@@ -4357,14 +4367,14 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1083
+#: lxc/file.go:1084
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1659 lxc/cluster.go:771
+#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:771
 #: lxc/cluster_group.go:340 lxc/config.go:273 lxc/config.go:348
 #: lxc/config.go:1278 lxc/config_metadata.go:148 lxc/config_template.go:206
-#: lxc/config_trust.go:315 lxc/image.go:457 lxc/network.go:687
+#: lxc/config_trust.go:315 lxc/image.go:467 lxc/network.go:687
 #: lxc/network_acl.go:621 lxc/network_forward.go:636
 #: lxc/network_load_balancer.go:638 lxc/network_peer.go:611
 #: lxc/network_zone.go:552 lxc/network_zone.go:1144 lxc/profile.go:519
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:171
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4452,11 +4462,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:996
+#: lxc/image.go:1008
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:994
+#: lxc/image.go:1006
 msgid "Profiles: "
 msgstr ""
 
@@ -4479,11 +4489,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:969
+#: lxc/image.go:981
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1512
+#: lxc/image.go:1526
 msgid "Property not found"
 msgstr ""
 
@@ -4577,7 +4587,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:947
+#: lxc/image.go:959
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4595,7 +4605,7 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:408 lxc/file.go:748
+#: lxc/file.go:408 lxc/file.go:749
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
@@ -4604,7 +4614,7 @@ msgstr ""
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:682 lxc/file.go:848
+#: lxc/file.go:683 lxc/file.go:849
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4613,7 +4623,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:495 lxc/image.go:887 lxc/image.go:1421
+#: lxc/image.go:505 lxc/image.go:900 lxc/image.go:1437
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4650,16 +4660,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1337 lxc/image.go:1338
+#: lxc/image.go:1349 lxc/image.go:1350
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:383
+#: lxc/copy.go:380
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1366
+#: lxc/image.go:1382
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1925 lxc/auth.go:1926
+#: lxc/auth.go:1927 lxc/auth.go:1928
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4809,7 +4819,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1749 lxc/auth.go:1750
+#: lxc/auth.go:1751 lxc/auth.go:1752
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4947,7 +4957,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1060
+#: lxc/image.go:1072
 msgid "SIZE"
 msgstr ""
 
@@ -4963,12 +4973,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1212
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1212
+#: lxc/file.go:1213
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5044,7 +5054,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:976
+#: lxc/file.go:977
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5070,7 +5080,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1528 lxc/image.go:1529
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Set image properties"
 msgstr ""
 
@@ -5306,7 +5316,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:974
+#: lxc/file.go:975
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5318,7 +5328,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1798 lxc/auth.go:1799
+#: lxc/auth.go:1800 lxc/auth.go:1801
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5363,7 +5373,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1417 lxc/image.go:1418
+#: lxc/image.go:1433 lxc/image.go:1434
 msgid "Show image properties"
 msgstr ""
 
@@ -5497,7 +5507,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:883 lxc/image.go:884
+#: lxc/image.go:896 lxc/image.go:897
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5509,7 +5519,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:944
+#: lxc/image.go:956
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5541,7 +5551,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:987
+#: lxc/image.go:999
 msgid "Source:"
 msgstr ""
 
@@ -5689,7 +5699,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1062
+#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1074
 #: lxc/image_alias.go:236 lxc/list.go:571 lxc/network.go:981
 #: lxc/network.go:1055 lxc/network_allocations.go:26 lxc/operation.go:171
 #: lxc/storage_volume.go:1509 lxc/warning.go:215
@@ -5700,11 +5710,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1013
+#: lxc/file.go:1014
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1007
+#: lxc/file.go:1008
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5911,7 +5921,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:948
+#: lxc/image.go:960
 msgid "Timestamps:"
 msgstr ""
 
@@ -5957,7 +5967,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:169
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -5973,12 +5983,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:767
+#: lxc/image.go:780
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:339 lxc/move.go:314
+#: lxc/copy.go:336 lxc/move.go:314
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6006,7 +6016,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:946 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
+#: lxc/image.go:958 lxc/info.go:273 lxc/info.go:475 lxc/network.go:837
 #: lxc/storage_volume.go:1270
 #, c-format
 msgid "Type: %s"
@@ -6021,7 +6031,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1061
+#: lxc/image.go:1073
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6062,12 +6072,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1234
+#: lxc/file.go:1235
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1078 lxc/list.go:629 lxc/storage_volume.go:1547
+#: lxc/image.go:1090 lxc/list.go:629 lxc/storage_volume.go:1547
 #: lxc/warning.go:243
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:788
+#: lxc/file.go:789
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6109,7 +6119,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1584 lxc/image.go:1585
+#: lxc/image.go:1597 lxc/image.go:1598
 msgid "Unset image properties"
 msgstr ""
 
@@ -6256,7 +6266,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:955
+#: lxc/image.go:967
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6404,7 +6414,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1687
+#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
 #: lxc/cluster.go:119 lxc/cluster.go:878 lxc/cluster_group.go:379
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
 #: lxc/network.go:909 lxc/network_acl.go:91 lxc/network_zone.go:82
@@ -6429,7 +6439,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/list.go:46
+#: lxc/image.go:1028 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6502,7 +6512,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1924
+#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6515,7 +6525,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1468 lxc/cluster_group.go:155
+#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:155
 #: lxc/cluster_group.go:211 lxc/cluster_group.go:264 lxc/cluster_group.go:575
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6534,31 +6544,31 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1519 lxc/auth.go:1569 lxc/auth.go:1797
+#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1871
+#: lxc/auth.go:1873
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1747
+#: lxc/auth.go:1749
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:361 lxc/image.go:882 lxc/image.go:1416
+#: lxc/image.go:377 lxc/image.go:895 lxc/image.go:1432
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1475 lxc/image.go:1583
+#: lxc/image.go:1490 lxc/image.go:1596
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1527
+#: lxc/image.go:1541
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:142
+#: lxc/image.go:155
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6570,11 +6580,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:488
+#: lxc/image.go:498
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:309 lxc/image.go:1336
+#: lxc/image.go:321 lxc/image.go:1348
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6658,7 +6668,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:965
+#: lxc/file.go:966
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7037,7 +7047,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:933
+#: lxc/image.go:945
 msgid "disabled"
 msgstr ""
 
@@ -7045,7 +7055,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:935
+#: lxc/image.go:947
 msgid "enabled"
 msgstr ""
 
@@ -7089,7 +7099,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1573
+#: lxc/auth.go:1575
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7162,7 +7172,7 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:969
+#: lxc/file.go:970
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7181,7 +7191,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:365
+#: lxc/image.go:381
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7385,7 +7395,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:923 lxc/image.go:928 lxc/image.go:1118
+#: lxc/image.go:935 lxc/image.go:940 lxc/image.go:1130
 msgid "no"
 msgstr ""
 
@@ -7401,16 +7411,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1124
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1082
+#: lxc/file.go:1083
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1035
+#: lxc/file.go:1036
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -7430,7 +7440,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:925 lxc/image.go:930
-#: lxc/image.go:1115
+#: lxc/cluster.go:551 lxc/delete.go:47 lxc/image.go:937 lxc/image.go:942
+#: lxc/image.go:1127
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
closes https://github.com/canonical/lxd/issues/12725

When doing a `lxc image export ..`, dereferencing the provided image name either returns a fingerprint or a human readable alias. Both forms can be fine. However, since this `dereferenceAlias` operation is not really checking if the image associated with this alias exists on the remote, we were creating a local target based on the same string that a user entered. Most of the time, this `targetMeta` string was resolved to a fingerprint (e.g, `/var/lib/snapd/hostfs/home/gab/d2a43fade9d0055e454a091b2e9bd819f7eb715a3d4d46667644a5784d40172`) and this was fine because there is only the fingerprint file created and no intermediate directories.

Anyway, I think it is safer to systematically check for the image existence prior to creating any file resources. This way we avoid changing the filesystem write logic that could annoy exsting users and break their export image pipeline:

```
target := "."
targetMeta := fingerprint
if len(args) > 1 {
	target = args[1]
	if shared.IsDir(shared.HostPathFollow(args[1])) {
		targetMeta = filepath.Join(args[1], targetMeta)
	} else {
		targetMeta = args[1]
	}
}
targetMeta = shared.HostPathFollow(targetMeta)
```