### PR TITLE
API: Enable gzip compression

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -100,7 +100,21 @@ func restServer(d *Daemon) *http.Server {
 	docEnabled := documentationPath != "" && shared.PathExists(documentationPath)
 	if docEnabled {
 		documentationHTTPDir := documentationHTTPDir{http.Dir(documentationPath)}
-		mux.PathPrefix("/documentation/").Handler(http.StripPrefix("/documentation/", http.FileServer(documentationHTTPDir)))
+
+		// Serve the LXD documentation.
+		documentationHandler := http.StripPrefix("/documentation/", http.FileServer(documentationHTTPDir))
+
+		// Set security headers
+		documentationHandlerWithSecurity := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Permissions-Policy", "interest-cohort=()")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+			w.Header().Set("X-Xss-Protection", "1; mode=block")
+
+			documentationHandler.ServeHTTP(w, r)
+		})
+
+		mux.PathPrefix("/documentation/").Handler(documentationHandlerWithSecurity)
 		mux.HandleFunc("/documentation", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/documentation/", http.StatusMovedPermanently)
 		})


### PR DESCRIPTION
And add security response headers to documentation endpoint.

Fixes https://github.com/canonical/lxd/issues/13150