### PR TITLE
lxd/device/nic: fix default IP for routed NIC (`ipv4.host_address`)

### DIFF
--- a/doc/config_options.txt
+++ b/doc/config_options.txt
@@ -1097,7 +1097,7 @@ Possible values are `auto` and `none`.
 ```
 
 ```{config:option} ipv4.host_address device-nic-routed-device-conf
-:defaultdesc: "`192.254.0.1`"
+:defaultdesc: "`169.254.0.1`"
 :shortdesc: "IPv4 address to add to the host-side `veth` interface"
 :type: "string"
 

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -481,7 +481,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		//
 		// ---
 		//  type: string
-		//  defaultdesc: `192.254.0.1`
+		//  defaultdesc: `169.254.0.1`
 		//  shortdesc: IPv4 address to add to the host-side `veth` interface
 		"ipv4.host_address": validate.Optional(validate.IsNetworkAddressV4),
 		// lxdmeta:generate(entities=device-nic-routed; group=device-conf; key=ipv6.host_address)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1260,7 +1260,7 @@
 					},
 					{
 						"ipv4.host_address": {
-							"defaultdesc": "`192.254.0.1`",
+							"defaultdesc": "`169.254.0.1`",
 							"longdesc": "",
 							"shortdesc": "IPv4 address to add to the host-side `veth` interface",
 							"type": "string"


### PR DESCRIPTION
This was apparently a typo as a link-local address should be used for both IPv4 and IPv6.