### PR TITLE
Migration: Always clone the device config

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1101,7 +1101,9 @@ func (d *common) canMigrate(inst instance.Instance) (migrate bool, live bool) {
 	volatileGet := func() map[string]string { return map[string]string{} }
 	volatileSet := func(_ map[string]string) error { return nil }
 	for deviceName, rawConfig := range d.ExpandedDevices() {
-		dev, err := device.New(inst, d.state, deviceName, rawConfig, volatileGet, volatileSet)
+		// Make sure to clone the devices config for new devices.
+		// Some device drivers might modify the configuration and populate additional settings.
+		dev, err := device.New(inst, d.state, deviceName, rawConfig.Clone(), volatileGet, volatileSet)
 		if err != nil {
 			logger.Warn("Instance will not be migrated due to a device error", logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "device": dev.Name(), "err": err})
 			return false, false


### PR DESCRIPTION
When instantiating a new device make sure to clone it's config. This ensures that the downstream drivers don't modify the original config map.

This fixes https://github.com/canonical/lxd/issues/13082 since the call to `dev.CanMigrate()` will populate the devices `mtu` field through `dev.validateConfig()` which will modify the outer config map passed down to the driver.