### PR TITLE
Metrics: Expose clean metrics for a stopped or running instance 

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8244,6 +8244,16 @@ func (d *lxc) Info() instance.Info {
 	}
 }
 
+// Helper function to adapt metric value based on instance state.
+func adaptMetricValueWithState(value float64, isInstanceRunning bool) float64 {
+	// Set value to 0 if instance is not running.
+	if !isInstanceRunning {
+		return 0
+	}
+
+	return value
+}
+
 // Metrics returns the metric set for the LXC driver. It collects various metrics related to memory, CPU, disk, filesystem, and network usage.
 func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
 	state := instance.PowerStateStopped

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8334,6 +8334,12 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 		d.logger.Warn("Failed to get oom kills", logger.Ctx{"err": err})
 	}
 
+	// If we failed to get OOM kills, because of a couple of reasons (instance stopped, cgroup controller not available, etc),
+	// we default to 0 instead of -1 for the MemoryOOMKillsTotal metric (a total of `-1` would be misleading).
+	if oomKills < 0 {
+		oomKills = 0
+	}
+
 	out.AddSamples(metrics.MemoryOOMKillsTotal, metrics.Sample{Value: float64(oomKills)})
 
 	// Handle swap.
@@ -8342,6 +8348,12 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 		if err != nil && isRunning {
 			d.logger.Warn("Failed to get swap usage", logger.Ctx{"err": err})
 		} else {
+			// If we failed to get swap memory usage, because of a couple of reasons (instance stopped, cgroup controller not available, etc),
+			// we default to 0 instead of -1 for the MemorySwapBytes metric (`-1` bytes would be misleading).
+			if swapUsage < 0 {
+				swapUsage = 0
+			}
+
 			out.AddSamples(metrics.MemorySwapBytes, metrics.Sample{Value: float64(swapUsage)})
 		}
 	}
@@ -8364,6 +8376,12 @@ func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error
 	if err != nil && isRunning {
 		d.logger.Warn("Failed to get CPUs", logger.Ctx{"err": err})
 	} else {
+		// If we failed to get the number of total effective CPUs, because of a couple of reasons (instance stopped, cgroup controller not available, etc),
+		// we default to 0 instead of -1 for the CPUs metric (a total of `-1` would be misleading).
+		if CPUs < 0 {
+			CPUs = 0
+		}
+
 		out.AddSamples(metrics.CPUs, metrics.Sample{Value: float64(CPUs)})
 	}
 


### PR DESCRIPTION
closes https://github.com/canonical/lxd/issues/13136
closes https://github.com/canonical/lxd/issues/13178

* [x] Fixing `-1` metric values 
Some CGroup related metrics like `MemorySwapUsage`, `OOMKills`, and `CPUs` (effective CPUs) for stopped instances returned -1 (because the CGroup controller is not available in such a case). This value help the application logic but in regards to the metrics, we should expose them as `0` instead of a numerical total being negative which is misleading.

* [x] When a container is stopped, set its gauge metric values to a sentinel value of `0`.
* [x] Allow the VM's metrics to always be exposed whether the VM is running or stopped. Also, apply the same gauge metric rules as for the container.   