### PR TITLE
Storage: Recover BTRFS pools `source` to block device UUID to align with creation process

### DIFF
--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -189,6 +189,8 @@ func (d *btrfs) Create() error {
 		}
 
 		// Confirm that the symlink is appearing (give it 10s).
+		// In case of timeout it falls back to using the volume's path
+		// instead of its UUID.
 		if tryExists(fmt.Sprintf("/dev/disk/by-uuid/%s", devUUID)) {
 			// Override the config to use the UUID.
 			d.config["source"] = devUUID

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -125,15 +125,27 @@ func (d *btrfs) FillConfig() error {
 		d.config["size"] = ""
 	}
 
+	// Store the provided source as we are likely to be mangling it.
+	d.config["volatile.initial_source"] = d.config["source"]
+
+	// Set the block device's UUID in case it already has one.
+	// This allows to recover the pools configuration without actually
+	// creating the storage pool.
+	// Downstream functions should use `volatile.initial_source` to ensure
+	// they are using the path instead of the volume's UUID.
+	if shared.IsBlockdevPath(d.config["source"]) {
+		devUUID, err := fsUUID(d.config["source"])
+		if err == nil {
+			d.config["source"] = devUUID
+		}
+	}
+
 	return nil
 }
 
 // Create is called during pool creation and is effectively using an empty driver struct.
 // WARNING: The Create() function cannot rely on any of the struct attributes being set.
 func (d *btrfs) Create() error {
-	// Store the provided source as we are likely to be mangling it.
-	d.config["volatile.initial_source"] = d.config["source"]
-
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -165,25 +177,29 @@ func (d *btrfs) Create() error {
 		if err != nil {
 			return fmt.Errorf("Failed to format sparse file: %w", err)
 		}
-	} else if shared.IsBlockdevPath(d.config["source"]) {
+	} else if shared.IsBlockdevPath(d.config["volatile.initial_source"]) {
+		// Make sure to use the block volumes `volatile.initial_source` here
+		// as an earlier call to the drivers FillConfig() might have set
+		// the `source` property to the block volumes UUID in case it's not empty.
+
 		// Wipe if requested.
 		if shared.IsTrue(d.config["source.wipe"]) {
-			err := wipeBlockHeaders(d.config["source"])
+			err := wipeBlockHeaders(d.config["volatile.initial_source"])
 			if err != nil {
-				return fmt.Errorf("Failed to wipe headers from disk %q: %w", d.config["source"], err)
+				return fmt.Errorf("Failed to wipe headers from disk %q: %w", d.config["volatile.initial_source"], err)
 			}
 
 			d.config["source.wipe"] = ""
 		}
 
 		// Format the block device.
-		_, err := makeFSType(d.config["source"], "btrfs", &mkfsOptions{Label: d.name})
+		_, err := makeFSType(d.config["volatile.initial_source"], "btrfs", &mkfsOptions{Label: d.name})
 		if err != nil {
 			return fmt.Errorf("Failed to format block device: %w", err)
 		}
 
 		// Record the UUID as the source.
-		devUUID, err := fsUUID(d.config["source"])
+		devUUID, err := fsUUID(d.config["volatile.initial_source"])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/12605.

This moves the replacement of the pools `source` property from path to its block UUID into `FillConfig()`. The recovery procedure can now reconstruct all of the pools config without actually creating the pool using the drivers function.

Additionally this addresses an unhandled timeout in https://github.com/canonical/lxd/pull/13184/commits/79c17806506cef4a8c4a72cadc13fbe5050c5b2f.