### PR TITLE
drivers/driver_lxc: do not set "soft" limit when hard limit is set

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1167,10 +1167,12 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 					}
 				}
 
-				// Set soft limit to value 10% less than hard limit
-				err = cg.SetMemorySoftLimit(int64(float64(valueInt) * 0.9))
-				if err != nil {
-					return nil, err
+				if d.state.OS.CGInfo.Layout != cgroup.CgroupsUnified {
+					// Set soft limit to value 10% less than hard limit
+					err = cg.SetMemorySoftLimit(int64(float64(valueInt) * 0.9))
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}
@@ -4603,11 +4605,13 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 						}
 					}
 
-					// Set soft limit to value 10% less than hard limit
-					err = cg.SetMemorySoftLimit(int64(float64(memoryInt) * 0.9))
-					if err != nil {
-						revertMemory()
-						return err
+					if d.state.OS.CGInfo.Layout != cgroup.CgroupsUnified {
+						// Set soft limit to value 10% less than hard limit
+						err = cg.SetMemorySoftLimit(int64(float64(memoryInt) * 0.9))
+						if err != nil {
+							revertMemory()
+							return err
+						}
 					}
 				}
 


### PR DESCRIPTION

In cgroup-v1 memcg implementation we have a concept of "soft" memory limit (`memory.soft_limit_in_bytes`). In cgroup-v2 memcg we don't have an explicit analog of it. Originally, when hard memory limit is set, we set it value to `memory.limit_in_bytes` and set 90% of its value to `memory.soft_limit_in_bytes`. And it was working quite well. But in cgroup-v2 we tried to treat `memory.high` as analogy to `memory.soft_limit_in_bytes` which is not fully correct. Yes, reaching `memory.high` limit does not invoke OOM-killer, at the same time it forces process to go into memory reclaim on each page fault that want's to charge pages in memcg which makes its execution terribly slow. Let's stop doing that. If hard limit is set, let's set only `memory.max` value and do nothing with `memory.high`. But if soft limit is set, then we have not so many options and let's stick with setting `memory.high` value.

Fixes: #13147