### PR TITLE
Allow setting file permissions via API and `lxd file push --mode`

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -703,6 +703,12 @@ type InstanceFileArgs struct {
 	// File permissions
 	Mode int
 
+	// Whether to modify the permissions of existing files (see the
+	// instances_files_modify_permissions api extension)
+	GIDModifyExisting  bool
+	UIDModifyExisting  bool
+	ModeModifyExisting bool
+
 	// File type (file or directory)
 	Type string
 

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1597,6 +1597,24 @@ func (r *ProtocolLXD) CreateInstanceFile(instanceName string, filePath string, a
 		req.Header.Set("X-LXD-write", args.WriteMode)
 	}
 
+	var modifyPerm []string
+
+	if args.UIDModifyExisting {
+		modifyPerm = append(modifyPerm, "uid")
+	}
+
+	if args.GIDModifyExisting {
+		modifyPerm = append(modifyPerm, "gid")
+	}
+
+	if args.ModeModifyExisting {
+		modifyPerm = append(modifyPerm, "mode")
+	}
+
+	if len(modifyPerm) != 0 && r.CheckExtension("instance_files_modify_permissions") == nil {
+		req.Header.Set("X-LXD-modify-perm", strings.Join(modifyPerm, ","))
+	}
+
 	// Send the request
 	resp, err := r.DoHTTP(req)
 	if err != nil {

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2392,3 +2392,9 @@ Adds the ability to limit disk I/O for virtual machines.
 ## `storage_volumes_all`
 
 This API extension adds support for listing storage volumes from all storage pools via `/1.0/storage-volumes` or `/1.0/storage-volumes/{type}` to filter by volume type. Also adds a `pool` field to storage volumes.
+
+## `instances_files_modify_permissions`
+
+Adds the ability for `POST /1.0/instances/{name}/files` to modify the permissions of files that already exist via the `X-LXD-modify-perm` header.
+
+`X-LXD-modify-perm` should be a comma-separated list of 0 or more of `mode`, `uid`, and `gid`.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -10247,6 +10247,12 @@ paths:
                   name: X-LXD-mode
                   schema:
                     type: integer
+                - description: Comma-separated list of permissions to set for pre-existing files (0 or more of `uid`, `gid`, `mode`)
+                  example: uid,gid,mode
+                  in: header
+                  name: X-LXD-modify-perm
+                  schema:
+                    type: integer
                 - description: Type of file (file, symlink or directory)
                   example: file
                   in: header

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -570,11 +570,15 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	modifyExistingUID := c.file.flagUID != -1
+
 	// Determine the target uid
 	uid := 0
 	if c.file.flagUID >= 0 {
 		uid = c.file.flagUID
 	}
+
+	modifyExistingGID := c.file.flagGID != -1
 
 	// Determine the target gid
 	gid := 0
@@ -637,9 +641,12 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 
 		// Transfer the files
 		args := lxd.InstanceFileArgs{
-			UID:  -1,
-			GID:  -1,
-			Mode: -1,
+			UID:                -1,
+			UIDModifyExisting:  modifyExistingUID,
+			GID:                -1,
+			GIDModifyExisting:  modifyExistingGID,
+			Mode:               -1,
+			ModeModifyExisting: c.file.flagMode != "",
 		}
 
 		if !c.noModeChange {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -402,6 +402,7 @@ var APIExtensions = []string{
 	"access_management",
 	"vm_disk_io_limits",
 	"storage_volumes_all",
+	"instances_files_modify_permissions",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Add an API extension `instances_files_modify_permissions` which allows setting the permissions of existing files using the file API. Also updates `lxc` to send the `X-LXD-modify-perm` header when `--mode`, `--uid`, or `--gid` are passed.

I elected to go with a new header rather than adding complexity to the existing headers as discussed in https://github.com/canonical/lxd/issues/12724; maintaining the client's backwards compatibility with older servers would have been non-trivial. This way the new header is simply ignored by older servers.

I'm happy to add integration tests if needed.

Closes https://github.com/canonical/lxd/issues/12724