### PR TITLE
doc: workaround for undefined references

### DIFF
--- a/doc/external_resources.md
+++ b/doc/external_resources.md
@@ -1,4 +1,17 @@
 (troubleshoot)=
+(howtos-getstarted)=
+(howtos-work)=
+(howtos-production)=
+(reference-general)=
+(reference-config)=
+(reference-production)=
+(reference-api)=
+(reference-manpages)=
+(reference-internal)=
+(explanation-concepts)=
+(explanation-entities)=
+(explanation-iam)=
+(explanation-production)=
 # External resources
 
 ```{toctree}


### PR DESCRIPTION
Needed to prevent the build for the topical navigation from failing.