### PR TITLE
lxd/api: Revert gzip compression on API

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 
-	gorillaHandlers "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
@@ -67,11 +66,6 @@ func restServer(d *Daemon) *http.Server {
 	mux.StrictSlash(false) // Don't redirect to URL with trailing slash.
 	mux.SkipClean(true)
 	mux.UseEncodedPath() // Allow encoded values in path segments.
-
-	// Enable gzip compression globally.
-	mux.Use(func(next http.Handler) http.Handler {
-		return gorillaHandlers.CompressHandler(next)
-	})
 
 	uiPath := os.Getenv("LXD_UI")
 	uiEnabled := uiPath != "" && shared.PathExists(uiPath)


### PR DESCRIPTION
Partially reverts c9ffbb29e01b0c0198ec93e8d17ac4c71061174d and 26e61c005f634d999fa490a170e2109181cb7de4

Because its applying gzip compression even if Accept-Encoding header isn't set.

This was breaking Go SDK clients using the LXD API, this was causing microcloud setup errors:

```
microcloud init
Waiting for LXD to start...
Error: Failed to check LXD initialization: invalid character '\x1f' looking for beginning of value
```

Furthermore we should more carefully evaluate if there are security implications to gzipping TLS traffic before potentially re-enabling correctly.

See https://en.wikipedia.org/wiki/BREACH