### PR TITLE
Storage: Fix redundant settings of zfs properties

### DIFF
--- a/lxd/storage/drivers/driver_zfs_utils.go
+++ b/lxd/storage/drivers/driver_zfs_utils.go
@@ -194,6 +194,44 @@ func (d *zfs) getDatasets(dataset string, types string) ([]string, error) {
 	return children, nil
 }
 
+// filterRedundantOptions filters out options for setting dataset properties that match with the values already set.
+func (d *zfs) filterRedundantOptions(dataset string, options ...string) ([]string, error) {
+	var keys, values []string
+
+	// Extract keys and values from options.
+	for _, option := range options {
+		property := strings.Split(option, "=")
+
+		if len(property) != 2 {
+			return nil, fmt.Errorf("Wrongly formatted option %q", option)
+		}
+
+		keys = append(keys, property[0])
+		values = append(values, property[1])
+	}
+
+	// Get current values for the keys.
+	currentProperties, err := d.getDatasetProperties(dataset, keys...)
+	if err != nil {
+		return nil, err
+	}
+
+	var resultantOptions []string
+
+	// Change property values that are different from the current value.
+	for propertyIndex := range keys {
+		if currentProperties[keys[propertyIndex]] == "posix" && values[propertyIndex] == "posixacl" { // "posixacl" is an alias for "posix"
+			continue
+		}
+
+		if currentProperties[keys[propertyIndex]] != values[propertyIndex] {
+			resultantOptions = append(resultantOptions, options[propertyIndex])
+		}
+	}
+
+	return resultantOptions, nil
+}
+
 func (d *zfs) setDatasetProperties(dataset string, options ...string) error {
 	args := []string{"set"}
 	args = append(args, options...)

--- a/test/suites/storage_driver_zfs.sh
+++ b/test/suites/storage_driver_zfs.sh
@@ -268,9 +268,9 @@ do_storage_driver_zfs() {
   # Turn off block mode
   lxc storage unset lxdtest-"$(basename "${LXD_DIR}")" volume.zfs.block_mode
 
-  # Regular (no block mode) custom storage block volumes shouldn't be allowed to set block.*.
-  ! lxc storage create lxdtest-"$(basename "${LXD_DIR}")" block.filesystem=ext4 || false
-  ! lxc storage create lxdtest-"$(basename "${LXD_DIR}")" block.mount_options=rw || false
+  # Regular (no block mode) storage pool shouldn't be allowed to set block.*.
+  ! lxc storage set lxdtest-"$(basename "${LXD_DIR}")" block.filesystem=ext4 || false
+  ! lxc storage set lxdtest-"$(basename "${LXD_DIR}")" block.mount_options=rw || false
 
   # shellcheck disable=SC2031
   kill_lxd "${LXD_STORAGE_DIR}"


### PR DESCRIPTION
Fixes #12278 by making It possible for LXD to get ZFS dataset properties before setting them and avoid resetting those that already have the desired value. Performs this operation on `ensureInitialDatasets`.