### PR TITLE
Metrics: Do not expose the stopped instance metrics anymore

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8246,14 +8246,12 @@ func (d *lxc) Info() instance.Info {
 
 // Metrics returns the metric set for the LXC driver. It collects various metrics related to memory, CPU, disk, filesystem, and network usage.
 func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
-	state := instance.PowerStateStopped
 	isRunning := d.IsRunning()
-
-	if isRunning {
-		state = instance.PowerStateRunning
+	if !isRunning {
+		return nil, ErrInstanceIsStopped
 	}
 
-	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.Container.String(), "state": state})
+	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.Container.String()})
 
 	cc, err := d.initLXC(false)
 	if err != nil {

--- a/lxd/metrics/metrics.go
+++ b/lxd/metrics/metrics.go
@@ -94,8 +94,7 @@ func (m *MetricSet) String() string {
 		CPUs,
 		GoGoroutines,
 		GoHeapObjects,
-		Containers,
-		VMs,
+		Instances,
 	}
 
 	for _, metricType := range metricTypes {

--- a/lxd/metrics/types.go
+++ b/lxd/metrics/types.go
@@ -144,10 +144,8 @@ const (
 	GoOtherSysBytes
 	// GoNextGCBytes represents the number of heap bytes when next garbage collection will take place.
 	GoNextGCBytes
-	// Containers represents the container count.
-	Containers
-	// VMs represents the VM count.
-	VMs
+	// Instances represents the instance count.
+	Instances
 )
 
 // MetricNames associates a metric type to its name.
@@ -216,8 +214,7 @@ var MetricNames = map[MetricType]string{
 	ProcsTotal:                  "lxd_procs_total",
 	UptimeSeconds:               "lxd_uptime_seconds",
 	WarningsTotal:               "lxd_warnings_total",
-	Containers:                  "lxd_containers",
-	VMs:                         "lxd_vms",
+	Instances:                   "lxd_instances",
 }
 
 // MetricHeaders represents the metric headers which contain help messages as specified by OpenMetrics.
@@ -286,6 +283,5 @@ var MetricHeaders = map[MetricType]string{
 	ProcsTotal:                  "# HELP lxd_procs_total The number of running processes.",
 	UptimeSeconds:               "# HELP lxd_uptime_seconds The daemon uptime in seconds.",
 	WarningsTotal:               "# HELP lxd_warnings_total The number of active warnings.",
-	Containers:                  "# HELP lxd_containers The number of containers.",
-	VMs:                         "# HELP lxd_vms The number of virtual machines.",
+	Instances:                   "# HELP lxd_instances The number of instances.",
 }

--- a/test/suites/metrics.sh
+++ b/test/suites/metrics.sh
@@ -9,17 +9,22 @@ test_metrics() {
 
   # create another container in the non default project
   lxc project create foo -c features.images=false -c features.profiles=false
-  lxc init testimage c3 --project foo
+  lxc launch testimage c3 --project foo
 
   # c1 metrics should show as the container is running
   lxc query "/1.0/metrics" | grep "name=\"c1\""
   lxc query "/1.0/metrics?project=default" | grep "name=\"c1\""
 
-  # c2 metrics should show the container as stopped
-  lxc query "/1.0/metrics" | grep "name=\"c2\""
-  lxc query "/1.0/metrics?project=default" | grep "name=\"c2\""
-  lxc query "/1.0/metrics" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
-  lxc query "/1.0/metrics?project=default" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
+  # c2 metrics should not be shown as the container is stopped
+  ! lxc query "/1.0/metrics" | grep "name=\"c2\"" || false
+  ! lxc query "/1.0/metrics?project=default" | grep "name=\"c2\"" || false
+
+  # Check that we can get the count of existing instances.
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="default",type="container"} 2'
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo",type="container"} 1'
+  # Ensure lxd_instances reports VM count properly (0)
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="default",type="virtual-machine"} 0'
+  lxc query /1.0/metrics | grep -xF 'lxd_instances{project="foo",type="virtual-machine"} 0'
 
   # c3 metrics from another project also show up for non metrics unrestricted certificate
   lxc query "/1.0/metrics" | grep "name=\"c3\""
@@ -39,13 +44,13 @@ test_metrics() {
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c1\""
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=default" | grep "name=\"c1\""
 
-  # c2 metrics should show the container as stopped
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=default" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
+  # c2 metrics should not be shown as the container is stopped
+  ! curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c2\"" || false
+  ! curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=default" | grep "name=\"c2\"" || false
 
-  # c3 metrics from another project should show the container as stopped for unrestricted certificate
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c3\"" | grep "state=\"STOPPED\""
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\"" | grep "state=\"STOPPED\""
+  # c3 metrics from another project should be shown for unrestricted certificate
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c3\""
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\""
 
   # internal server metrics should be shown as the certificate is not restricted
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep -E "^lxd_warnings_total [0-9]+$"
@@ -58,17 +63,17 @@ test_metrics() {
 
   lxc config set core.metrics_address "${metrics_addr}"
 
-  # c1 metrics should show as the container is running
+  # c1 metrics should be shown as the container is running
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep "name=\"c1\""
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics?project=default" | grep "name=\"c1\""
 
-  # c2 metrics should show the container as stopped
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics?project=default" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
+  # c2 metrics should not be shown as the container is stopped
+  ! curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep "name=\"c2\"" || false
+  ! curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics?project=default" | grep "name=\"c2\"" || false
 
-  # c3 metrics from another project should show the container as stopped for unrestricted metrics certificate
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c3\"" | grep "state=\"STOPPED\""
-  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\"" | grep "state=\"STOPPED\""
+  # c3 metrics from another project should  be shown for unrestricted metrics certificate
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics" | grep "name=\"c3\""
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\""
 
   # internal server metrics should be shown as the certificate is not restricted
   curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep -E "^lxd_warnings_total [0-9]+$"
@@ -84,10 +89,10 @@ test_metrics() {
   lxc config trust add "${TEST_DIR}/metrics-restricted.crt" --type=metrics --restricted --projects foo
   lxc config trust show "$(openssl x509 -in "${TEST_DIR}/metrics-restricted.crt" -outform der | sha256sum | head -c12)" | grep -xF "restricted: true"
 
-  # c3 metrics should show the container as stopped for restricted metrics certificate
-  curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\"" | grep "state=\"STOPPED\""
+  # c3 metrics should be showned
+  curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${LXD_ADDR}/1.0/metrics?project=foo" | grep "name=\"c3\""
 
-  # c3 metrics for the stopped container cannot be viewed via the generic metrics endpoint if the certificate is restricted
+  # c3 metrics cannot be viewed via the generic metrics endpoint if the certificate is restricted
   ! curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${LXD_ADDR}/1.0/metrics"
 
   # other projects metrics aren't visible as they aren't allowed for the restricted certificate
@@ -95,7 +100,13 @@ test_metrics() {
 
   # c1 and c2 metrics are not visible as they are in another project
   ! curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${metrics_addr}/1.0/metrics?project=foo" | grep "name=\"c1\""
-  ! curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${metrics_addr}/1.0/metrics?project=foo" | grep "name=\"c2\"" | grep "state=\"STOPPED\""
+  ! curl -k -s --cert "${TEST_DIR}/metrics-restricted.crt" --key "${TEST_DIR}/metrics-restricted.key" -X GET "https://${metrics_addr}/1.0/metrics?project=foo" | grep "name=\"c2\""
+
+  # Check that we can get the count of existing containers. There should be two in the default project: c1 (RUNNING) and c2 (STOPPED).
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep -xF 'lxd_instances{project="default",type="container"} 2'
+  sleep 10
+  # Try again after the metric cache has expired. We should still see two containers.
+  curl -k -s --cert "${TEST_DIR}/metrics.crt" --key "${TEST_DIR}/metrics.key" -X GET "https://${metrics_addr}/1.0/metrics" | grep -xF 'lxd_instances{project="default",type="container"} 2'
 
   # test unauthenticated connections
   ! curl -k -s -X GET "https://${metrics_addr}/1.0/metrics" | grep "name=\"c1\"" || false


### PR DESCRIPTION
closes https://github.com/canonical/lxd/issues/13217

This partially reverts https://github.com/canonical/lxd/pull/12639 , while keeping the ability to track the instances counts (containers count, live or stopped + vms count, live or stoppped). This also fix a negative metric issue (in case of CGroup Controller issue, we  want to expose `0` values and not negative ones) 

* [x] Revert exposing offline instance metrics
* [x] Address the absence of `lxd_containers` and `lxd_vms` metrics
* [x] Filter out `lxd_containers` and `lxd_vms` metrics  metrics according to their project certificate
     * This will be taken care of by https://github.com/canonical/lxd/pull/13214