### PR TITLE
Refactor file header parsing

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -809,12 +809,16 @@ func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.Re
 	}
 
 	// Parse the headers
-	uid, gid, mode, fileType, _ := shared.ParseLXDFileHeaders(resp.Header)
+	headers, err := shared.ParseLXDFileHeaders(resp.Header)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed to parse response headers: %w", err)
+	}
+
 	fileResp := ContainerFileResponse{
-		UID:  uid,
-		GID:  gid,
-		Mode: mode,
-		Type: fileType,
+		UID:  headers.UID,
+		GID:  headers.GID,
+		Mode: headers.Mode,
+		Type: headers.Type,
 	}
 
 	if fileResp.Type == "directory" {

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1492,12 +1492,16 @@ func (r *ProtocolLXD) GetInstanceFile(instanceName string, filePath string) (io.
 	}
 
 	// Parse the headers
-	uid, gid, mode, fileType, _ := shared.ParseLXDFileHeaders(resp.Header)
+	headers, err := shared.ParseLXDFileHeaders(resp.Header)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	fileResp := InstanceFileResponse{
-		UID:  uid,
-		GID:  gid,
-		Mode: mode,
-		Type: fileType,
+		UID:  headers.UID,
+		GID:  headers.GID,
+		Mode: headers.Mode,
+		Type: headers.Type,
 	}
 
 	if fileResp.Type == "directory" {

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -439,20 +439,19 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 	defer func() { _ = client.Close() }()
 
 	// Extract file ownership and mode from headers
-	uid, gid, mode, type_, write := shared.ParseLXDFileHeaders(r.Header)
-
-	if !shared.ValueInSlice(write, []string{"overwrite", "append"}) {
-		return response.BadRequest(fmt.Errorf("Bad file write mode: %s", write))
+	headers, err := shared.ParseLXDFileHeaders(r.Header)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	// Check if the file already exists.
 	_, err = client.Stat(path)
 	exists := err == nil
 
-	if type_ == "file" {
+	if headers.Type == "file" {
 		fileMode := os.O_RDWR
 
-		if write == "overwrite" {
+		if headers.Write == "overwrite" {
 			fileMode |= os.O_CREATE | os.O_TRUNC
 		}
 
@@ -478,16 +477,17 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 
 		if !exists {
 			// Set file permissions.
-			if mode >= 0 {
-				err = file.Chmod(fs.FileMode(mode))
+			if headers.Mode >= 0 {
+				err = file.Chmod(fs.FileMode(headers.Mode))
 				if err != nil {
 					return response.SmartError(err)
 				}
 			}
 
 			// Set file ownership.
-			if uid >= 0 || gid >= 0 {
-				err = file.Chown(int(uid), int(gid))
+			if headers.UID >= 0 || headers.GID >= 0 {
+				// -1 leaves the id unchanged
+				err = file.Chown(int(headers.UID), int(headers.GID))
 				if err != nil {
 					return response.SmartError(err)
 				}
@@ -496,7 +496,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
-	} else if type_ == "symlink" {
+	} else if headers.Type == "symlink" {
 		// Figure out target.
 		target, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -517,7 +517,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
-	} else if type_ == "directory" {
+	} else if headers.Type == "directory" {
 		// Check if it already exists.
 		if exists {
 			return response.EmptySyncResponse
@@ -530,19 +530,19 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 		}
 
 		// Set file permissions.
-		if mode < 0 {
+		if headers.Mode < 0 {
 			// Default mode for directories (sftp doesn't know about umask).
-			mode = 0750
+			headers.Mode = 0750
 		}
 
-		err = client.Chmod(path, fs.FileMode(mode))
+		err = client.Chmod(path, fs.FileMode(headers.Mode))
 		if err != nil {
 			return response.SmartError(err)
 		}
 
 		// Set file ownership.
-		if uid >= 0 || gid >= 0 {
-			err = client.Chown(path, int(uid), int(gid))
+		if headers.UID >= 0 || headers.GID >= 0 {
+			err = client.Chown(path, int(headers.UID), int(headers.GID))
 			if err != nil {
 				return response.SmartError(err)
 			}
@@ -551,7 +551,7 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 		s.Events.SendLifecycle(inst.Project().Name, lifecycle.InstanceFilePushed.Event(inst, logger.Ctx{"path": path}))
 		return response.EmptySyncResponse
 	} else {
-		return response.BadRequest(fmt.Errorf("Bad file type: %s", type_))
+		return response.BadRequest(fmt.Errorf("Bad file type: %s", headers.Type))
 	}
 }
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -257,6 +257,17 @@ func LogPath(path ...string) string {
 	return filepath.Join(items...)
 }
 
+// LXDFileHeaders is extracted from the `X-LXD-*` family of file permissions
+// headers.
+type LXDFileHeaders struct {
+	UID  int64
+	GID  int64
+	Mode int
+
+	Type  string
+	Write string
+}
+
 // ParseLXDFileHeaders parses and validates the `X-LXD-*` family of file
 // permissions headers.
 //   - `X-LXD-uid`, `X-LXD-gid`
@@ -268,41 +279,50 @@ func LogPath(path ...string) string {
 //     One of `file`, `symlink`, `directory`
 //   - `X-LXD-write`
 //     One of `overwrite`, `append`
-func ParseLXDFileHeaders(headers http.Header) (uid int64, gid int64, mode int, type_ string, write string) {
-	uid, err := strconv.ParseInt(headers.Get("X-LXD-uid"), 10, 32)
-	if err != nil {
-		uid = -1
-	}
+func ParseLXDFileHeaders(headers http.Header) (*LXDFileHeaders, error) {
+	var uid, gid int64 = -1, -1
+	var mode = -1
+	var err error
 
-	gid, err = strconv.ParseInt(headers.Get("X-LXD-gid"), 10, 32)
-	if err != nil {
-		gid = -1
-	}
-
-	mode64, err := strconv.ParseInt(headers.Get("X-LXD-mode"), 10, 0)
-	if err != nil {
-		mode64 = -1
-	} else {
-		rawMode, err := strconv.ParseInt(headers.Get("X-LXD-mode"), 0, 0)
-		if err == nil {
-			mode64 = rawMode
+	rawUID := headers.Get("X-LXD-uid")
+	if rawUID != "" {
+		uid, err = strconv.ParseInt(rawUID, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid UID: %w", err)
 		}
 	}
 
-	mode = -1
-	if mode64 >= 0 {
+	rawGID := headers.Get("X-LXD-gid")
+	if rawGID != "" {
+		gid, err = strconv.ParseInt(rawGID, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid GID: %w", err)
+		}
+	}
+
+	rawMode := headers.Get("X-LXD-mode")
+	if rawMode != "" {
+		mode64, err := strconv.ParseInt(rawMode, 0, 0)
+		if err != nil || mode64 < 0 {
+			return nil, fmt.Errorf("Invalid Mode: %w", err)
+		}
+
 		mode = int(mode64 & int64(os.ModePerm))
 	}
 
-	type_ = headers.Get("X-LXD-type")
+	filetype := headers.Get("X-LXD-type")
 	/* backwards compat: before "type" was introduced, we could only
 	 * manipulate files
 	 */
-	if type_ == "" {
-		type_ = "file"
+	if filetype == "" {
+		filetype = "file"
 	}
 
-	write = headers.Get("X-LXD-write")
+	if !ValueInSlice(filetype, []string{"file", "symlink", "directory"}) {
+		return nil, fmt.Errorf("Invalid file type: %q", filetype)
+	}
+
+	write := headers.Get("X-LXD-write")
 	/* backwards compat: before "write" was introduced, we could only
 	 * overwrite files
 	 */
@@ -310,7 +330,18 @@ func ParseLXDFileHeaders(headers http.Header) (uid int64, gid int64, mode int, t
 		write = "overwrite"
 	}
 
-	return uid, gid, mode, type_, write
+	if !ValueInSlice(write, []string{"overwrite", "append"}) {
+		return nil, fmt.Errorf("Invalid file write mode: %q", write)
+	}
+
+	return &LXDFileHeaders{
+		UID:  uid,
+		GID:  gid,
+		Mode: mode,
+
+		Type:  filetype,
+		Write: write,
+	}, nil
 }
 
 func ReaderToChannel(r io.Reader, bufferSize int) <-chan []byte {

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -40,6 +40,67 @@ func TestUrlsJoin(t *testing.T) {
 	}
 }
 
+func TestParseLXDFileHeader(t *testing.T) {
+	header := map[string][]string{
+		"X-Lxd-Uid":  {"1000"},
+		"X-Lxd-Gid":  {"1001"},
+		"X-Lxd-Mode": {"0700"},
+	}
+
+	headers, err := ParseLXDFileHeaders(header)
+	if err != nil {
+		t.Fatalf("Failed to parse headers %q: %s", header, err)
+	}
+
+	if headers.UID != 1000 || headers.GID != 1001 || headers.Mode != 0o700 {
+		t.Fatalf("Mismatched UID (%d), GID (%d), or Mode (%d)", headers.UID, headers.GID, headers.Mode)
+	}
+
+	header = map[string][]string{
+		"X-Lxd-Uid":  {"0"},
+		"X-Lxd-Gid":  {"99"},
+		"X-Lxd-Mode": {"420"},
+	}
+
+	headers, err = ParseLXDFileHeaders(header)
+	if err != nil {
+		t.Fatalf("Failed to parse headers %q: %s", header, err)
+	}
+
+	if headers.UID != 0 || headers.GID != 99 || headers.Mode != 0o644 {
+		t.Fatalf("Mismatched UID (%d), GID (%d), or Mode (%d)", headers.UID, headers.GID, headers.Mode)
+	}
+
+	header = map[string][]string{
+		"X-Lxd-Type":  {"file"},
+		"X-Lxd-Write": {"append"},
+	}
+
+	headers, err = ParseLXDFileHeaders(header)
+	if err != nil {
+		t.Fatalf("Failed to parse headers %q: %s", header, err)
+	}
+
+	if headers.Type != "file" || headers.Write != "append" {
+		t.Fatalf("Mismatched Type (%s) or Write (%s)", headers.Type, headers.Write)
+	}
+
+	invalidHeaderTests := []map[string][]string{
+		{"X-Lxd-Uid": {"0xF4"}},
+		{"X-Lxd-Gid": {"0b1101"}},
+		{"X-Lxd-Mode": {"write"}},
+		{"X-Lxd-Type": {"dir"}},
+		{"X-Lxd-Write": {"Append"}},
+	}
+
+	for _, header := range invalidHeaderTests {
+		_, err = ParseLXDFileHeaders(header)
+		if err == nil {
+			t.Fatalf("Parsed invalid headers %q", header)
+		}
+	}
+}
+
 func TestFileCopy(t *testing.T) {
 	helloWorld := []byte("hello world\n")
 	source, err := os.CreateTemp("", "")


### PR DESCRIPTION
Depends on #13230 (didn't rebase, figured it would be easier to have these merged in order)

In preparation for https://github.com/canonical/lxd/pull/13193, we will need to return additional fields from `ParseLXDFileHeaders`. This makes that less gross.