### PR TITLE
gitignore: Ignore all __pycache__ under doc/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ doc/.sphinx/warnings.txt
 doc/.sphinx/.wordlist.dic
 doc/.sphinx/_static/swagger-ui
 doc/.sphinx/_static/download
-doc/__pycache__
+doc/**/__pycache__
 
 # For Atom ctags
 .tags


### PR DESCRIPTION
I somehow ended up with a `doc/.sphinx/__pycache__`; seems like a safe bet that nobody will ever want to check in one of those...