### PR TITLE
Storage: Use progress tracker for Btrfs migration

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -3,7 +3,6 @@ package drivers
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -458,7 +457,7 @@ func (d *btrfs) getSubvolumesMetaData(vol Volume) ([]BTRFSSubVolume, error) {
 
 	if !d.state.OS.RunningInUserNS {
 		// List all subvolumes in the given filesystem with their UUIDs and received UUIDs.
-		err = shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", "-u", "-R", poolMountPath)
+		err = shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", "-u", "-R", poolMountPath)
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +495,7 @@ func (d *btrfs) getSubVolumeReceivedUUID(vol Volume) (string, error) {
 	poolMountPath := GetPoolMountPath(vol.pool)
 
 	// List all subvolumes in the given filesystem with their UUIDs.
-	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", "-R", poolMountPath)
+	err := shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", "-R", poolMountPath)
 	if err != nil {
 		return "", err
 	}
@@ -618,7 +617,7 @@ func (d *btrfs) receiveSubVolume(r io.Reader, receivePath string, tracker *iopro
 		}
 	}
 
-	err = shared.RunCommandWithFds(context.TODO(), stdin, nil, "btrfs", "receive", "-e", receivePath)
+	err = shared.RunCommandWithFds(d.state.ShutdownCtx, stdin, nil, "btrfs", "receive", "-e", receivePath)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -252,7 +252,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, sr
 			}
 
 			if hdr.Name == srcFile {
-				subVolRecvPath, err := d.receiveSubVolume(tr, targetPath)
+				subVolRecvPath, err := d.receiveSubVolume(tr, targetPath, nil)
 				if err != nil {
 					return "", err
 				}
@@ -661,6 +661,12 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 	receiveVolume := func(v Volume, receivePath string) error {
 		_, snapName, _ := api.GetParentAndSnapshotName(v.name)
 
+		// Setup progress tracking.
+		var wrapper *ioprogress.ProgressTracker
+		if volTargetArgs.TrackProgress {
+			wrapper = migration.ProgressTracker(op, "fs_progress", v.name)
+		}
+
 		for _, subVol := range subvolumes {
 			if subVol.Snapshot != snapName {
 				continue // Skip any subvolumes that dont belong to our volume (empty for main).
@@ -676,7 +682,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 			subVolTargetPath := filepath.Join(v.MountPath(), subVol.Path)
 			d.logger.Debug("Receiving volume", logger.Ctx{"name": v.name, "receivePath": receivePath, "path": subVolTargetPath})
 
-			subVolRecvPath, err := d.receiveSubVolume(conn, receivePath)
+			subVolRecvPath, err := d.receiveSubVolume(conn, receivePath, wrapper)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1479,7 +1479,7 @@ func (d *btrfs) BackupVolume(vol VolumeCopy, tarWriter *instancewriter.InstanceT
 
 		// Write the subvolume to the file.
 		d.logger.Debug("Generating optimized volume file", logger.Ctx{"sourcePath": path, "parent": parent, "file": tmpFile.Name(), "name": fileName})
-		err = shared.RunCommandWithFds(context.TODO(), nil, tmpFile, "btrfs", args...)
+		err = shared.RunCommandWithFds(d.state.ShutdownCtx, nil, tmpFile, "btrfs", args...)
 		if err != nil {
 			return err
 		}
@@ -1780,7 +1780,7 @@ func (d *btrfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string,
 func (d *btrfs) volumeSnapshotsSorted(vol Volume, op *operations.Operation) ([]string, error) {
 	stdout := bytes.Buffer{}
 
-	err := shared.RunCommandWithFds(context.TODO(), nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))
+	err := shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))
 	if err != nil {
 		return nil, err
 	}

--- a/shared/ioprogress/reader.go
+++ b/shared/ioprogress/reader.go
@@ -1,19 +1,30 @@
 package ioprogress
 
 import (
+	"fmt"
 	"io"
 )
 
 // ProgressReader is a wrapper around ReadCloser which allows for progress tracking.
 type ProgressReader struct {
+	io.Reader
 	io.ReadCloser
 	Tracker *ProgressTracker
 }
 
 // Read in ProgressReader is the same as io.Read.
 func (pt *ProgressReader) Read(p []byte) (int, error) {
+	var reader io.Reader
+	if pt.ReadCloser != nil {
+		reader = pt.ReadCloser
+	} else if pt.Reader != nil {
+		reader = pt.Reader
+	} else {
+		return -1, fmt.Errorf("ProgressReader is missing a reader")
+	}
+
 	// Do normal reader tasks
-	n, err := pt.ReadCloser.Read(p)
+	n, err := reader.Read(p)
 
 	// Do the actual progress tracking
 	if pt.Tracker != nil {


### PR DESCRIPTION
From https://github.com/lxc/incus/pull/683.

Additionally this PR ensures that the Btrfs driver is consistently using the daemons shutdown context instead of the `context.TODO()` for all the command executions.