### PR TITLE
gitignore: Ignore all `.bak`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ lxd-*.tar.gz
 .vagrant
 *~
 tags
+**/*.bak
 
 # Potential binaries
 fuidshift/fuidshift


### PR DESCRIPTION
See #13232; `.bak` are generated by a few make targets.