### PR TITLE
VM: Use auto-converge for all live migrations (from Incus)

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -129,7 +129,6 @@ func (d *disk) CanHotPlug() bool {
 	return true
 }
 
-// validateConfig checks the supplied config for correctness.
 // isRequired indicates whether the supplied device config requires this device to start OK.
 func (d *disk) isRequired(devConfig deviceConfig.Device) bool {
 	// Defaults to required.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6845,6 +6845,17 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 		defer revert.Fail() // Run the revert fail before the earlier defers.
 
 		d.logger.Debug("Setup temporary migration storage snapshot")
+	} else {
+		// Still set some options for shared storage.
+		capabilities := map[string]bool{
+			// Automatically throttle down the guest to speed up convergence of RAM migration.
+			"auto-converge": true,
+		}
+
+		err = monitor.MigrateSetCapabilities(capabilities)
+		if err != nil {
+			return fmt.Errorf("Failed setting migration capabilities: %w", err)
+		}
 	}
 
 	// Perform storage transfer while instance is still running.


### PR DESCRIPTION
The auto-converge feature in QEMU throttles down the guest to speed up convergence of RAM migration.
Previously this was only being used for shared storage VM live migrations, but this PR ensure its also used for local storage live VM migrations.